### PR TITLE
Use either Airbrake or Hoptoad js object

### DIFF
--- a/lib/templates/javascript_notifier.erb
+++ b/lib/templates/javascript_notifier.erb
@@ -1,13 +1,15 @@
 <%= javascript_tag %Q{
+  (function(){
     var notifierJsScheme = (("https:" == document.location.protocol) ? "https://" : "http://");
     document.write(unescape("%3Cscript src='" + notifierJsScheme + "#{host}/javascripts/notifier.js' type='text/javascript'%3E%3C/script%3E"));
-  }
-%>
+  })();
+}%>
 
 <%= javascript_tag %Q{
+    window.Airbrake = Airbrake || Hoptoad;
     Airbrake.setKey('#{api_key}');
     Airbrake.setHost('#{host}');
     Airbrake.setEnvironment('#{environment}');
     Airbrake.setErrorDefaults({ url: "#{escape_javascript url}", component: "#{controller_name}", action: "#{action_name}" });
-  } 
+  }
 %>


### PR DESCRIPTION
The current http://airbrakeapp.com/javascripts/notifier.js (v0.1.0)
defines a Hoptoad object, while Airbrake 3.0 expects an Airbrake object.
Add Hoptoad as a fall-back. Also wrap the first javascript with a
closure so it won't pollute the global namespace.
