### PR TITLE
Updating test names to be correct. Updated cucumber feature to look for correct task name.

### DIFF
--- a/features/rails.feature
+++ b/features/rails.feature
@@ -67,7 +67,7 @@ Feature: Install the Gem in a Rails application
     And I configure my application to require the "airbrake" gem
     And I run the airbrake generator with "-k myapikey"
     And I run "cap -T"
-    Then I should see "airbrake:notify"
+    Then I should see "airbrake:deploy"
 
   Scenario: Configure and deploy using only vendored gem
     When I generate a new Rails application
@@ -79,7 +79,7 @@ Feature: Install the Gem in a Rails application
     And I uninstall the "airbrake" gem
     And I install cached gems
     And I run "cap -T"
-    Then I should see "airbrake:notify"
+    Then I should see "airbrake:deploy"
 
   Scenario: Try to install when the airbrake plugin still exists
     When I generate a new Rails application

--- a/lib/airbrake/capistrano.rb
+++ b/lib/airbrake/capistrano.rb
@@ -5,12 +5,12 @@ module Airbrake
   module Capistrano
     def self.load_into(configuration)
       configuration.load do
-        after "deploy",            "airbrake:notify"
-        after "deploy:migrations", "airbrake:notify"
+        after "deploy",            "airbrake:deploy"
+        after "deploy:migrations", "airbrake:deploy"
 
         namespace :airbrake do
           desc "Notify Airbrake of the deployment"
-          task :notify, :except => { :no_release => true } do
+          task :deploy, :except => { :no_release => true } do
             rails_env = fetch(:airbrake_env, fetch(:rails_env, "production"))
             local_user = ENV['USER'] || ENV['USERNAME']
             executable = RUBY_PLATFORM.downcase.include?('mswin') ? fetch(:rake, 'rake.bat') : fetch(:rake, 'rake')

--- a/test/capistrano_test.rb
+++ b/test/capistrano_test.rb
@@ -13,11 +13,11 @@ class CapistranoTest < Test::Unit::TestCase
     @configuration.dry_run = true
   end
   
-  should "define airbrake:notify task" do
-    assert_not_nil @configuration.find_task('airbrake:notify')
+  should "define airbrake:deploy task" do
+    assert_not_nil @configuration.find_task('airbrake:deploy')
   end
   
-  should "log when calling airbrake:notify task" do
+  should "log when calling airbrake:deploy task" do
     @configuration.set(:current_revision, '084505b1c0e0bcf1526e673bb6ac99fbcb18aecc')
     @configuration.set(:repository, 'repository')
     io = StringIO.new
@@ -25,7 +25,7 @@ class CapistranoTest < Test::Unit::TestCase
     logger.level = Capistrano::Logger::MAX_LEVEL
     
     @configuration.logger = logger
-    @configuration.find_and_execute_task('airbrake:notify')
+    @configuration.find_and_execute_task('airbrake:deploy')
     
     assert io.string.include?('** Notifying Airbrake of Deploy')
     assert io.string.include?('** Airbrake Notification Complete')


### PR DESCRIPTION
Fixed the name of the capistrano task in the test to be correct. 
Updated the cucumber feature to look for the right task name.
Changed Capistrano task from airbrake:notify to airbrake:deploy.
