### PR TITLE
Fixed: rake handler failing when exception happens before Airbrake has been configured

### DIFF
--- a/features/rake.feature
+++ b/features/rake.feature
@@ -6,6 +6,10 @@ Feature: Use the Gem to catch errors in a Rake application
     When I run rake with airbrake
     Then Airbrake should catch the exception
 
+  Scenario: Falling back to default handler before Airbrake is configured
+    When I run rake with airbrake not yet configured
+    Then Airbrake should not catch the exception
+
   Scenario: Disabling Rake exception catcher
     When I run rake with airbrake disabled
     Then Airbrake should not catch the exception

--- a/features/support/rake/Rakefile
+++ b/features/support/rake/Rakefile
@@ -36,11 +36,22 @@ task :airbrake_autodetect_not_from_terminal do
   raise_exception 
 end
 
+task :airbrake_not_yet_configured do
+  Airbrake.configuration.rescue_rake_exceptions = true
+  stub_tty_output(true)
+  stub_empty_sender
+  raise_exception
+end
+
 module Airbrake
   def self.notify(*args)
     # TODO if you need to check more params, you'll have to use json.dump or something
     $stderr.puts "airbrake #{args[1][:component]}"
   end
+end
+
+def stub_empty_sender
+  Airbrake.sender = nil
 end
 
 def stub_tty_output(value)

--- a/lib/airbrake/rake_handler.rb
+++ b/lib/airbrake/rake_handler.rb
@@ -9,8 +9,8 @@ module Airbrake::RakeHandler
   end
 
   def display_error_message_with_airbrake(ex)
-    if Airbrake.configuration.rescue_rake_exceptions || 
-        (Airbrake.configuration.rescue_rake_exceptions===nil && !self.tty_output?)
+    if Airbrake.sender && (Airbrake.configuration.rescue_rake_exceptions || 
+        (Airbrake.configuration.rescue_rake_exceptions===nil && !self.tty_output?))
 
       Airbrake.notify(ex, :component => reconstruct_command_line, :cgi_data => ENV)
     end


### PR DESCRIPTION
Hi,

the rake handler did not check if Airbrake is already configured, so it tried to send the exception anyway, failing with an exception (undefined method send_to_airbrake for nil)

This happened, for example, when running an undefined Rake task.

I fixed this by checking the availability of `Airbrake.sender` before calling `notify`

Relevant Cuke scenario included.
