### PR TITLE
config.use_local_notifier_js

### DIFF
--- a/lib/airbrake/configuration.rb
+++ b/lib/airbrake/configuration.rb
@@ -22,6 +22,9 @@ module Airbrake
 
     # +true+ for https connections, +false+ for http connections.
     attr_accessor :secure
+    
+    # Use a local copy of notifier.js? (defaults to false)
+    attr_accessor :use_local_notifier_js
 
     # The HTTP open timeout in seconds (defaults to 2).
     attr_accessor :http_open_timeout
@@ -124,6 +127,7 @@ module Airbrake
     def initialize
       @secure                   = false
       @host                     = 'airbrakeapp.com'
+      @use_local_notifier_js    = false
       @http_open_timeout        = 2
       @http_read_timeout        = 5
       @params_filters           = DEFAULT_PARAMS_FILTERS.dup

--- a/lib/airbrake/rails/javascript_notifier.rb
+++ b/lib/airbrake/rails/javascript_notifier.rb
@@ -25,7 +25,8 @@ module Airbrake
             :environment     => Airbrake.configuration.environment_name,
             :action_name     => action_name,
             :controller_name => controller_name,
-            :url             => request.url
+            :url             => request.url,
+            :use_local_notifier_js => Airbrake.configuration.use_local_notifier_js,
           }
         }
 

--- a/lib/templates/javascript_notifier.erb
+++ b/lib/templates/javascript_notifier.erb
@@ -1,9 +1,16 @@
-<%= javascript_tag %Q{
+<% js = %Q[
   (function(){
     var notifierJsScheme = (("https:" == document.location.protocol) ? "https://" : "http://");
-    document.write(unescape("%3Cscript src='" + notifierJsScheme + "#{host}/javascripts/notifier.js' type='text/javascript'%3E%3C/script%3E"));
+    document.write(unescape("%3Cscript src='" + notifierJsScheme + ]
+    if use_local_notifier_js
+			js += %Q[document.location.host + ]
+		else
+			js += %Q["#{host}" + ]
+		end
+			js+= %Q["/javascripts/notifier.js' type='text/javascript'%3E%3C/script%3E"));
   })();
-}%>
+]%>
+<%= javascript_tag js %>
 
 <%= javascript_tag %Q{
     window.Airbrake = (typeof(Airbrake) == 'undefined' && typeof(Hoptoad) != 'undefined') ? Hoptoad : Airbrake


### PR DESCRIPTION
added config.use_local_notifier_js to enable use of locally hosted JS notifier script file
