### PR TITLE
Call `close` on the old body in UserInformer middleware

### DIFF
--- a/lib/airbrake/user_informer.rb
+++ b/lib/airbrake/user_informer.rb
@@ -15,6 +15,7 @@ module Airbrake
         body.each do |chunk|
           new_body << chunk.gsub("<!-- AIRBRAKE ERROR -->", replacement(env['airbrake.error_id']))
         end
+        body.close if body.respond_to?(:close)
         headers['Content-Length'] = new_body.sum(&:length).to_s
         body = new_body
       end


### PR DESCRIPTION
The UserInformer middleware collects the chunked body and uses it to create a new body. But it does not call `close` on the original body.

This causes the following error for me on rails 3.1:

```
[ pid=6271 thr=70080591090100 file=utils.rb:176 time=2011-10-04 04:32:38.589 ]: *** Exception ThreadError in application (thread 0x7f79d179a368 tried to join itself) (process 6271, thread #<Thread:0x7f79d179a368>):
    from /u/apps/vlphp/shared/ruby/bundle/ruby/1.8/gems/rack-1.3.3/lib/rack/lock.rb:14:in `lock'
    from /u/apps/vlphp/shared/ruby/bundle/ruby/1.8/gems/rack-1.3.3/lib/rack/lock.rb:14:in `call'
```

See similar issue on the rack project - https://github.com/rack/rack/issues/204
