### PR TITLE
Fix allowing airbrake_env/TO being different from rails_env/RAILS_ENV in deployment notifications

### DIFF
--- a/lib/airbrake/capistrano.rb
+++ b/lib/airbrake/capistrano.rb
@@ -14,11 +14,12 @@ module Airbrake
               - Run remotely so we use remote API keys, environment, etc.
           DESC
           task :deploy, :except => { :no_release => true } do
-            rails_env = fetch(:airbrake_env, fetch(:rails_env, "production"))
+            rails_env = fetch(:rails_env, "production")
+            airbrake_env = fetch(:airbrake_env, fetch(:rails_env, "production"))
             local_user = ENV['USER'] || ENV['USERNAME']
             executable = RUBY_PLATFORM.downcase.include?('mswin') ? fetch(:rake, 'rake.bat') : fetch(:rake, 'rake')
             directory = configuration.current_release
-            notify_command = "cd #{directory}; #{executable} RAILS_ENV=#{rails_env} airbrake:deploy TO=#{rails_env} REVISION=#{current_revision} REPO=#{repository} USER=#{local_user}"
+            notify_command = "cd #{directory}; #{executable} RAILS_ENV=#{rails_env} airbrake:deploy TO=#{airbrake_env} REVISION=#{current_revision} REPO=#{repository} USER=#{local_user}"
             notify_command << " DRY_RUN=true" if dry_run
             notify_command << " API_KEY=#{ENV['API_KEY']}" if ENV['API_KEY']
             logger.info "Notifying Airbrake of Deploy (#{notify_command})"


### PR DESCRIPTION
Deployment notifications were regressed In commit f12aa5355292a3ac8efbba2673c800e5aff067b3 

By reusing the airbrake_env Capistrano variable for the RAILS_ENV environment variable, this has broken the whole reason the TO environment variable exists. For example, we have more named deployment environments (staging1, staging2, staging3) than we have Rails environment modes (staging) so they are not a 1 for 1 match. My deployments now fail because it's trying to load a Rails environment that doesn't exist.
