### PR TITLE
Added Mongoid::Errors::DocumentNotFound to default IGNORED exceptions

### DIFF
--- a/lib/airbrake/configuration.rb
+++ b/lib/airbrake/configuration.rb
@@ -117,7 +117,8 @@ module Airbrake
                       'ActionController::InvalidAuthenticityToken',
                       'CGI::Session::CookieStore::TamperedWithCookie',
                       'ActionController::UnknownAction',
-                      'AbstractController::ActionNotFound']
+                      'AbstractController::ActionNotFound',
+                      'Mongoid::Errors::DocumentNotFound']
 
     alias_method :secure?, :secure
 


### PR DESCRIPTION
Ignore `Mongoid::Errors::DocumentNotFound`, which is equivalent to `ActiveRecord::RecordNotFound` for Mongoid.
