### PR TITLE
Fixes issue with airbrake:deploy when secure=true.

### DIFF
--- a/lib/airbrake/security.rb
+++ b/lib/airbrake/security.rb
@@ -1,0 +1,18 @@
+module Airbrake
+  module Security
+
+    def self.ca_bundle_path
+      if File.exist?(OpenSSL::X509::DEFAULT_CERT_FILE)
+        path = OpenSSL::X509::DEFAULT_CERT_FILE
+      else
+        path = local_cert_path
+      end
+      return path
+    end
+
+    def self.local_cert_path
+      File.expand_path(File.join("..", "..", "..", "resources", "ca-bundle.crt"), __FILE__)
+    end
+
+  end
+end

--- a/lib/airbrake_tasks.rb
+++ b/lib/airbrake_tasks.rb
@@ -1,6 +1,7 @@
 require 'net/http'
 require 'uri'
 require 'active_support'
+require 'airbrake/security'
 
 # Capistrano tasks for notifying Airbrake of deploys
 module AirbrakeTasks
@@ -37,11 +38,14 @@ module AirbrakeTasks
                             Airbrake.configuration.proxy_user,
                             Airbrake.configuration.proxy_pass)
     http = proxy.new(host, port)
+
+    # Handle Security
     http.use_ssl = Airbrake.configuration.secure
+    http.ca_file = Airbrake::Security.ca_bundle_path if Airbrake.configuration.secure
 
     post = Net::HTTP::Post.new("/deploys.txt")
     post.set_form_data(params)
-  
+
     if dry_run
       puts http.inspect, params.inspect
       return true


### PR DESCRIPTION
The rake task airbrake:deploy doesn't set the ca_file for OpenSSL when secure=true. I have refactored the send_to_airbrake method and the deploy task to use a common method in a new module Airbrake:Security for setting the ca_file. The method uses the default ca bundle path if the file exists, otherwise it uses the ca bundle that is shipped with the gem.

NOTE: This in NOT the same issue as https://github.com/airbrake/airbrake/issues/17 That issue deals with the notify method not working, this issue is with the airbrake:deploy task not working.

NOTE: I did not fix the tests. I'm sorry I didn't have time to get the suites running correctly and I had to move on. I'm assuming this will be trivial for you guys to update.

The support ticket related to this: 
http://help.airbrake.io/discussions/problems/2164-airbrakedeploy-fails-certificate-validation-when-securetrue
