### PR TITLE
Simple README edit explaining how to manually test the airbrake_javascript_notifier in "development" env

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,13 @@ It's important to insert this very high in the markup, above all other javascrip
 
 This helper will automatically use the API key, host, and port specified in the configuration.
 
+To test the Javascript notifier in development environment, overwrite (temporarily) the development_environments option:
+
+    Airbrake.configure do |config|
+      # ...
+      config.development_environments = []
+    end
+
 Development
 -----------
 


### PR DESCRIPTION
It took me half a pomodoro to find out ... So I thought it could be useful if it is documented in the README ;)
