### PR TITLE
tagged logging raising exception in Rails v3.2.1

### DIFF
--- a/lib/airbrake/rails3_tasks.rb
+++ b/lib/airbrake/rails3_tasks.rb
@@ -4,7 +4,10 @@ require File.join(File.dirname(__FILE__), 'shared_tasks')
 namespace :airbrake do
   desc "Verify your gem installation by sending a test exception to the airbrake service"
   task :test => [:environment] do
-    Rails.logger = Logger.new(STDOUT)
+    Rails.logger = defined?(ActiveSupport::TaggedLogging) ?
+      ActiveSupport::TaggedLogging.new(Logger.new(STDOUT)) :
+      Logger.new(STDOUT)
+      
     Rails.logger.level = Logger::DEBUG
     Airbrake.configure(true) do |config|
       config.logger = Rails.logger


### PR DESCRIPTION
The Rails test exception task raises an exception because a tagged logger is expected in Rails 3.2.1 and Airbrake instantiates only a normal logger.
