### PR TITLE
Fix for issue #58

### DIFF
--- a/lib/airbrake/rails/controller_methods.rb
+++ b/lib/airbrake/rails/controller_methods.rb
@@ -13,11 +13,9 @@ module Airbrake
       
       def airbrake_local_request?
         if defined?(::Rails.application.config)
-          is_local = request.local? && (!request.env["HTTP_X_FORWARDED_FOR"])
-          ::Rails.application.config.consider_all_requests_local || is_local
+          ::Rails.application.config.consider_all_requests_local || (request.local? && (!request.env["HTTP_X_FORWARDED_FOR"]))
         else
-          is_local = local_request? && (!request.env["HTTP_X_FORWARDED_FOR"])
-          consider_all_requests_local || is_local
+          consider_all_requests_local || (local_request? && (!request.env["HTTP_X_FORWARDED_FOR"]))
         end
       end
 


### PR DESCRIPTION
https://github.com/airbrake/airbrake/issues/58#issuecomment-4146159

When on a a cluster environment on EngineYard, the Application Master instance hosts both HAProxy that handles all requests as well as the application itself (NGINX+Unicorn)
When HAproxt directs the request to unicorn, request.local? is True and AirBrake fails to report exception when it should...
