### PR TITLE
Use hash argument when filtering

### DIFF
--- a/lib/airbrake/rails/controller_methods.rb
+++ b/lib/airbrake/rails/controller_methods.rb
@@ -37,8 +37,10 @@ module Airbrake
       def airbrake_filter_if_filtering(hash)
         return hash if ! hash.is_a?(Hash)
 
+        # Rails 2
         if respond_to?(:filter_parameters)
           filter_parameters(hash)
+        # Rails 3
         elsif defined?(ActionDispatch::Http::ParameterFilter)
           ActionDispatch::Http::ParameterFilter.new(::Rails.application.config.filter_parameters).filter(hash)
         else


### PR DESCRIPTION
/cc @benarent @shime

After looking at the diff from [my previous pull request](https://github.com/airbrake/airbrake/pull/59) with fresh eyes today, I noticed a subtle problem:  I was unintentionally using `params` rather than the `hash` argument.

Technically, the `params` vs `hash` difference won't make a difference in most cases, but it should be consistent with the rest of the method.  I've tested this on a staging instance and it behaved as expected.

Thanks for merging the other pull request so quickly; my apologies for not noticing this problem earlier and including it in the previous request.
