### PR TITLE
Unix style params

### DIFF
--- a/lib/airbrake/shared_tasks.rb
+++ b/lib/airbrake/shared_tasks.rb
@@ -23,7 +23,7 @@ namespace :airbrake do
       heroku_api_key = `heroku #{run} console 'puts ENV[%{HOPTOAD_API_KEY}]' | head -n 1`.strip
       heroku_rails_env = `heroku #{run} console 'puts RAILS_ENV' | head -n 1`.strip
 
-      command = %Q(heroku addons:add deployhooks:http url="http://airbrake.io/deploys.txt?deploy[rails_env]=#{heroku_rails_env}&api_key=#{heroku_api_key}")
+      command = %Q(heroku addons:add deployhooks:http --url="http://airbrake.io/deploys.txt?deploy[rails_env]=#{heroku_rails_env}&api_key=#{heroku_api_key}")
 
       puts "\nRunning:\n#{command}\n"
       puts `#{command}`


### PR DESCRIPTION
The following rake task produced a deprecation warning from the heroku gem:

```
$ rake airbrake:heroku:add_deploy_notification

heroku addons:add deployhooks:http url="http://airbrake.io/deploys.txt?deploy[rails_env]=NameError: uninitialized constant RAILS_ENV&api_key="
Warning: non-unix style params have been deprecated, use --url=http://airbrake.io/deploys.txt?deploy[rails_env]=NameError: uninitialized constant RAILS_ENV&api_key= instead
```

This is the commit in the heroku gem which added this warning:
https://github.com/heroku/heroku/commit/eefdc898b5e19f9e6bfd5ad152e63069434378a3
