### PR TITLE
Lazily-load actioncontroller

### DIFF
--- a/lib/airbrake/railtie.rb
+++ b/lib/airbrake/railtie.rb
@@ -21,12 +21,11 @@ module Airbrake
         config.framework        = "Rails: #{::Rails::VERSION::STRING}"
       end
 
-      if defined?(::ActionController::Base)
+      ActiveSupport.on_load(:action_controller) do
         require 'airbrake/rails/javascript_notifier'
         require 'airbrake/rails/controller_methods'
-
-        ::ActionController::Base.send(:include, Airbrake::Rails::ControllerMethods)
-        ::ActionController::Base.send(:include, Airbrake::Rails::JavascriptNotifier)
+        include Airbrake::Rails::ControllerMethods
+        include Airbrake::Rails::JavascriptNotifier
       end
     end
   end


### PR DESCRIPTION
Hi,
I've spent the past week or two trying to cut down on my Rails app's launch time, and have managed to improve 'rails runner 0' from 22s to 15s.  Still not ideal, but it's an improvement...

A big part of the reason for the slowness is due to plugins referencing parts of Rails that don't necessarily need to be loaded, so, eg, ActiveRecord::Base gets pulled in even though I'm just trying to run 'rake routes'.  As of Rails 3.0, this can be avoided using on_load hooks.

What do you think to the attached commit, which delays injecting methods into ActionController until ActionController::Base is first referenced?

(I should probably point out that I haven't yet succeeded in running Airbrake's tests against this - what ruby version do you run your tests on?  I'm getting a variety of interesting errors...)
