### PR TITLE
Improved error logging

### DIFF
--- a/lib/airbrake/sender.rb
+++ b/lib/airbrake/sender.rb
@@ -38,7 +38,7 @@ module Airbrake
       response = begin
                    http.post(url.path, data, HEADERS)
                  rescue *HTTP_ERRORS => e
-                   log :error, "Timeout while contacting the Airbrake server."
+                   log :error, "Unable to contact the Airbrake server. HTTP Error=#{e}"
                    nil
                  end
 


### PR DESCRIPTION
I just added the http error to the log message, since not every error code is a timeout. Furthermore I deleted logging that would always be the same in case of an error.
