### PR TITLE
Fix reporting of middleware errors under Rails 3

### DIFF
--- a/lib/airbrake/railtie.rb
+++ b/lib/airbrake/railtie.rb
@@ -9,7 +9,7 @@ module Airbrake
     end
 
     initializer "airbrake.use_rack_middleware" do |app|
-      app.config.middleware.use "Airbrake::Rack"
+      app.config.middleware.insert_after "ActionDispatch::ShowExceptions", "Airbrake::Rack"
       app.config.middleware.insert 0, "Airbrake::UserInformer"
     end
 


### PR DESCRIPTION
This fixes the issue (https://github.com/airbrake/airbrake/issues/76) where
errors occurring in the middleware stack (e.g. in the ActiveRecord session
store) do not get reported.

In Rails 3, the Airbrake::Rack middleware was being inserted near the end of
the middleware stack, just before Application.routes.  This change places the
middleware much earlier in the stack: just after
ActionDispatch::ShowExceptions.

This makes airbrake's behaviour similar to how it functioned in Rails 2, with
Airbrake::Rack inserted just after ActionController::Failsafe.

Example middleware stack before:

  use Airbrake::UserInformer
  use ActionDispatch::Static
  use Rack::Lock
  use #ActiveSupport::Cache::Strategy::LocalCache::Middleware:0x1020eb728
  use Rack::Runtime
  use Rack::MethodOverride
  use ActionDispatch::RequestId
  use Rails::Rack::Logger
  use ActionDispatch::ShowExceptions
  use ActionDispatch::DebugExceptions
  use ActionDispatch::RemoteIp
  use ActionDispatch::Reloader
  use ActionDispatch::Callbacks
  use ActiveRecord::ConnectionAdapters::ConnectionManagement
  use ActiveRecord::QueryCache
  use ActionDispatch::Cookies
  use ActionDispatch::Session::CookieStore
  use ActionDispatch::Flash
  use ActionDispatch::ParamsParser
  use ActionDispatch::Head
  use Rack::ConditionalGet
  use Rack::ETag
  use ActionDispatch::BestStandardsSupport
  use Airbrake::Rack
  run SampleApp::Application.routes

Example middleware stack after:

  use Airbrake::UserInformer
  use ActionDispatch::Static
  use Rack::Lock
  use #ActiveSupport::Cache::Strategy::LocalCache::Middleware:0x10224a3f8
  use Rack::Runtime
  use Rack::MethodOverride
  use ActionDispatch::RequestId
  use Rails::Rack::Logger
  use ActionDispatch::ShowExceptions
  use Airbrake::Rack
  use ActionDispatch::DebugExceptions
  use ActionDispatch::RemoteIp
  use ActionDispatch::Reloader
  use ActionDispatch::Callbacks
  use ActiveRecord::ConnectionAdapters::ConnectionManagement
  use ActiveRecord::QueryCache
  use ActionDispatch::Cookies
  use ActiveRecord::SessionStore
  use ActionDispatch::Flash
  use ActionDispatch::ParamsParser
  use ActionDispatch::Head
  use Rack::ConditionalGet
  use Rack::ETag
  use ActionDispatch::BestStandardsSupport
  run SampleApp::Application.routes
