### PR TITLE
remove git dependency from generating gemspec file.  causes errors when ...

### DIFF
--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |s|
   s.summary     = %q{Send your application errors to our hosted service and reclaim your inbox.}
 
   s.require_paths = ["lib"]
-  s.files         = Dir.glob("**/*")
-  s.test_files    = Dir.glob("{test,spec,features}/*")
+  s.files         = Dir.glob("{features,generators,lib,rails,resources,script,test}/*") + Dir.glob("*.md") + %w(CHANGELOG Gemfile Guardfile INSTALL MIT-LICENSE Rakefile SUPPORT_RAILS_VERSION install.rb)
+  s.test_files    = Dir.glob("{test,spec,features}/**/*")
   
   s.add_runtime_dependency("builder")
   s.add_runtime_dependency("activesupport")


### PR DESCRIPTION
...vendoring this gem in other projects
