### PR TITLE
Fix encoding issue

### DIFF
--- a/lib/airbrake/user_informer.rb
+++ b/lib/airbrake/user_informer.rb
@@ -17,7 +17,7 @@ module Airbrake
           new_body << chunk.gsub("<!-- AIRBRAKE ERROR -->", replace)
         end
         body.close if body.respond_to?(:close)
-        headers['Content-Length'] = new_body.sum(&:length).to_s
+        headers['Content-Length'] = new_body.sum(&:bytesize).to_s
         body = new_body
       end
       [status, headers, body]


### PR DESCRIPTION
You have to use `String#bytesize` method to get correct length in bytes. Rack and Rails already uses this method to set Content-Length when needed, but airbrake uses `String#length`.

There is an easy case to see the problem, given rails application replace text in public/500.html with symbols outside standard ASCII. Then trigger exception in your rails application and you'll get truncated 500 page because `String#length` reports number of symbols instead of bytes.
