### PR TITLE
Rails 3.2.3 deprecation warning removed

### DIFF
--- a/lib/airbrake/rails/javascript_notifier.rb
+++ b/lib/airbrake/rails/javascript_notifier.rb
@@ -10,7 +10,7 @@ module Airbrake
       def airbrake_javascript_notifier
         return unless Airbrake.configuration.public?
 
-        path = File.join File.dirname(__FILE__), '..', '..', 'templates', 'javascript_notifier.erb'
+        path = File.join File.dirname(__FILE__), '..', '..', 'templates', 'javascript_notifier'
         host = Airbrake.configuration.host.dup
         port = Airbrake.configuration.port
         host << ":#{port}" unless [80, 443].include?(port)


### PR DESCRIPTION
DEPRECATION WARNING: Passing a template handler in the template name is deprecated. You can simply remove the handler name or pass render :handlers => [:erb] instead.
