### PR TITLE
Fix the inform user feature - use id to lookup error instead of error-id.

### DIFF
--- a/lib/airbrake/sender.rb
+++ b/lib/airbrake/sender.rb
@@ -50,7 +50,7 @@ module Airbrake
       end
 
       if response && response.respond_to?(:body)
-        error_id = response.body.match(%r{<error-id[^>]*>(.*?)</error-id>})
+        error_id = response.body.match(%r{<id[^>]*>(.*?)</id>})
         error_id[1] if error_id
       end
     rescue => e


### PR DESCRIPTION
Because error-id is no more in the returned xml.

I've also created discussion on airbrake support - http://help.airbrake.io/discussions/hoptoad-notifier-patches-and-discussion/94-airbrake-notifier-does-not-inform-user-about-error-id
