### PR TITLE
Use debug log level for verbose log messages.

### DIFF
--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -60,7 +60,7 @@ module Airbrake
 
     # Writes out the given message to the #logger
     def write_verbose_log(message)
-      logger.info LOG_PREFIX + message if logger
+      logger.debug LOG_PREFIX + message if logger
     end
 
     # Look for the Rails logger currently defined


### PR DESCRIPTION
The full XML response from the airbrake notification gets logged with the info log level.  This level of detail wouldn't only be needed for debugging, not at the info log level, so I propose using the debug log level for `write_verbose_log`.
