### PR TITLE
make all tests runnable via ruby test_file.rb by loading the helper absolutely

### DIFF
--- a/test/airbrake_tasks_test.rb
+++ b/test/airbrake_tasks_test.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/helper'
+require File.expand_path '../helper', __FILE__
 require 'rubygems'
 
 require File.dirname(__FILE__) + '/../lib/airbrake_tasks'

--- a/test/backtrace_test.rb
+++ b/test/backtrace_test.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/helper'
+require File.expand_path '../helper', __FILE__
 
 class BacktraceTest < Test::Unit::TestCase
 

--- a/test/capistrano_test.rb
+++ b/test/capistrano_test.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/helper'
+require File.expand_path '../helper', __FILE__
 
 require 'capistrano/configuration'
 require 'airbrake/capistrano'

--- a/test/catcher_test.rb
+++ b/test/catcher_test.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/helper'
+require File.expand_path '../helper', __FILE__
 
 class ActionControllerCatcherTest < Test::Unit::TestCase
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/helper'
+require File.expand_path '../helper', __FILE__
 
 class ConfigurationTest < Test::Unit::TestCase
 

--- a/test/javascript_notifier_test.rb
+++ b/test/javascript_notifier_test.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/helper'
+require File.expand_path '../helper', __FILE__
 require 'airbrake/rails/javascript_notifier'
 require 'ostruct'
 

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/helper'
+require File.expand_path '../helper', __FILE__
 
 class LoggerTest < Test::Unit::TestCase
   def stub_http(response, body = nil)

--- a/test/notice_test.rb
+++ b/test/notice_test.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/helper'
+require File.expand_path '../helper', __FILE__
 
 class NoticeTest < Test::Unit::TestCase
 

--- a/test/notifier_test.rb
+++ b/test/notifier_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path( File.join(File.dirname(__FILE__), 'helper') )
+require File.expand_path '../helper', __FILE__
 
 class NotifierTest < Test::Unit::TestCase
 

--- a/test/rack_test.rb
+++ b/test/rack_test.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/helper'
+require File.expand_path '../helper', __FILE__
 
 class RackTest < Test::Unit::TestCase
 

--- a/test/rails_initializer_test.rb
+++ b/test/rails_initializer_test.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/helper'
+require File.expand_path '../helper', __FILE__
 
 require 'airbrake/rails'
 

--- a/test/recursion_test.rb
+++ b/test/recursion_test.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/helper'
+require File.expand_path '../helper', __FILE__
 
 class RecursionTest < Test::Unit::TestCase
   should "not allow infinite recursion" do

--- a/test/sender_test.rb
+++ b/test/sender_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path( File.join(File.dirname(__FILE__), 'helper') )
+require File.expand_path '../helper', __FILE__
 
 class SenderTest < Test::Unit::TestCase
 

--- a/test/user_informer_test.rb
+++ b/test/user_informer_test.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/helper'
+require File.expand_path '../helper', __FILE__
 
 class UserInformerTest < Test::Unit::TestCase
   should "modify output if there is an airbrake id" do


### PR DESCRIPTION
otherwise:

```
ruby test/notice_test.rb
test/notice_test.rb:1:in `require': cannot load such file -- test/helper (LoadError)
```
