### PR TITLE
Remove activesupport runtime dependency

### DIFF
--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.test_files    = Dir.glob("{test,spec,features}/**/*")
 
   s.add_runtime_dependency("builder")
-  s.add_runtime_dependency("activesupport")
   s.add_runtime_dependency("girl_friday")
 
   s.add_development_dependency("actionpack",    "~> 2.3.8")

--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -2,13 +2,6 @@ require "girl_friday"
 require 'net/http'
 require 'net/https'
 require 'rubygems'
-begin
-  require 'active_support'
-  require 'active_support/core_ext'
-rescue LoadError
-  require 'activesupport'
-  require 'activesupport/core_ext'
-end
 require 'airbrake/version'
 require 'airbrake/configuration'
 require 'airbrake/notice'


### PR DESCRIPTION
The tests still pass, I doubt this is used, and pulling in all of core_ext can be a problem for non-rails apps.
