### PR TITLE
Refactor config.async to provide custom asynchronous delivery way

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,24 @@ configuration.
 *Ruby 1.9+. It does not support Ruby 1.8 because of its poor threading*
 *support.*
 
+For implementing custom asynchronous send, pass any callable object instead of
+`true`. This callable receives `job` and `notice` params. `job.call` does
+actual notification delivery. `notice` is useful in case of some remote
+worker(e.g. Resque or Sidekiq), when execution of `job.call` isn't possible.
+
+    # configuration for Threads or Actors
+    Airbrake.configure do |config|
+      ...
+      config.async = lambda {|job, _notice| Thread.new {job.call}}
+    end
+
+    # Resque-like configuration
+    Airbrake.configure do |config|
+      ...
+      config.async = lambda do |_job, notice|
+        Resque.enqueue(AirbrakeDeliveryWorker, notice)
+      end
+    end
 
 Tracking deployments in Airbrake
 --------------------------------

--- a/lib/airbrake/configuration.rb
+++ b/lib/airbrake/configuration.rb
@@ -102,7 +102,7 @@ module Airbrake
 
     # Should Airbrake send notifications asynchronously
     # (boolean or nil; default is nil)
-    attr_accessor :async
+    attr_reader :async
 
     DEFAULT_PARAMS_FILTERS = %w(password password_confirmation).freeze
 
@@ -244,6 +244,11 @@ module Airbrake
       end
     end
 
+    def async=(value)
+      # use default GirlFriday-async for 'true' value
+      @async = value == true ? girl_friday_async_processor : value
+    end
+
     def js_api_key
       @js_api_key || self.api_key
     end
@@ -279,6 +284,11 @@ module Airbrake
       else
         80
       end
+    end
+
+    def girl_friday_async_processor
+      queue = GirlFriday::WorkQueue.new(nil, :size => 3) {|job| job.call}
+      lambda {|job, _notice| queue << job}
     end
 
   end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -32,6 +32,12 @@ class ConfigurationTest < Test::Unit::TestCase
     assert_config_default :async, nil
   end
 
+  should "set GirlFriday-callable for async=true" do
+    config = Airbrake::Configuration.new
+    config.async = true
+    assert config.async.respond_to?(:call)
+  end
+
   should "provide default values for secure connections" do
     config = Airbrake::Configuration.new
     config.secure = true


### PR DESCRIPTION
Hi @shime,

as I promised, here is configurable async with ability to be used in any async-environment, even with Resque.
Added tests, Readme and implementation.

BTW, you can move GirlFriday solution out of default and provide it as a sample in async-section. But it's up to you.
