### PR TITLE
Cherry-pick Object#blank? extension

### DIFF
--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -2,13 +2,7 @@ require "girl_friday"
 require 'net/http'
 require 'net/https'
 require 'rubygems'
-begin
-  require 'active_support'
-  require 'active_support/core_ext'
-rescue LoadError
-  require 'activesupport'
-  require 'activesupport/core_ext'
-end
+require 'active_support/core_ext/object/blank'
 require 'airbrake/version'
 require 'airbrake/configuration'
 require 'airbrake/notice'
@@ -27,7 +21,6 @@ module Airbrake
     'Content-type'             => 'text/xml',
     'Accept'                   => 'text/xml, application/xml'
   }
-
 
   # Queue used to send async notices. Used only if configuration.async is
   # set to true.


### PR DESCRIPTION
Since ActiveSupport is modular just include the #blank? inflection extension rather than including all of the core extensions and active_support itself.

It seems heavy-handed to require all of ActiveSupport's core extensions as a side effect of including an exception reporting API. According to 2ba25e8 this include was required for `#blank?` and `#to_xml`. I found references to the former but didn't find any to the latter. This pull does two things:
- Localizes the required code to `active_support/core_ext/object/blank`
- Removes the begin/rescue/end block around the require as if this is in fact a requirement a LoadError should be raised if its missing

My motivation for this change is a problem I'm having with using Airbrake in a jruby application that makes use of threads. Due to the way `autoload` works, I'm seeing threads blocking each other when dealing with JSON coercion with `active_support` required.
