### PR TITLE
Fallback to loading whole environment if initializer does not exist

### DIFF
--- a/lib/airbrake/shared_tasks.rb
+++ b/lib/airbrake/shared_tasks.rb
@@ -2,7 +2,17 @@ namespace :airbrake do
   desc "Notify Airbrake of a new deploy."
   task :deploy do
     require 'airbrake_tasks'
-    load File.join(Rails.root, 'config', 'initializers','airbrake.rb') if defined?(Rails.root)
+
+    if defined?(Rails.root)
+      initializer_file = Rails.root.join('config', 'initializers','airbrake.rb')
+
+      if initializer_file.exist?
+        load initializer_file
+      else
+        Rake::Task[:environment].invoke
+      end
+    end
+
     AirbrakeTasks.deploy(:rails_env      => ENV['TO'],
                         :scm_revision   => ENV['REVISION'],
                         :scm_repository => ENV['REPO'],


### PR DESCRIPTION
This should fix a bug introduced in c926886 which assumed a hardcoded path of the initializer.
