### PR TITLE
Allow XML to be passed to send_to_airbrake

### DIFF
--- a/lib/airbrake/sender.rb
+++ b/lib/airbrake/sender.rb
@@ -33,7 +33,7 @@ module Airbrake
     #
     # @param [Notice] notice The notice to be sent off
     def send_to_airbrake(notice)
-      data = notice.to_xml
+      data = notice.respond_to?(:to_xml) : notice.to_xml : notice
       http = setup_http_connection
 
       response = begin


### PR DESCRIPTION
This makes it so you can just pass XML to `send_to_airbrake` for Resque and other non-marshaling background workers.

Currently you have to serialize the data, pass it to Resque, unserialize it, pass it to `send_to_airbrake`, which then immediately serializes it again as XML.

Letting people serialize it to XML ahead of time simplifies setting up async reporting and reduces the chance that another error will occur when trying to send a report about the original error.

The only real difference is that if you pass XML, it will now dump XML if Airbrake gets an HTTP error from sending the request, it will dump the XML rather than the pretty printed notice format.
