### PR TITLE
Add the ability to pass XML directly to send_to_airbrake

### DIFF
--- a/lib/airbrake/sender.rb
+++ b/lib/airbrake/sender.rb
@@ -31,9 +31,9 @@ module Airbrake
 
     # Sends the notice data off to Airbrake for processing.
     #
-    # @param [Notice] notice The notice to be sent off
+    # @param [Notice or String] notice The notice to be sent off
     def send_to_airbrake(notice)
-      data = notice.to_xml
+      data = notice.respond_to?(:to_xml) ? notice.to_xml : notice
       http = setup_http_connection
 
       response = begin

--- a/test/sender_test.rb
+++ b/test/sender_test.rb
@@ -31,6 +31,32 @@ class SenderTest < Test::Unit::TestCase
     http
   end
 
+  should "post to Airbrake with XML passed" do
+    xml_notice = Airbrake::Notice.new(:error_class => "FooBar", :error_message => "Foo Bar").to_xml
+
+    http = stub_http
+
+    sender = build_sender
+    sender.send_to_airbrake(xml_notice)
+
+    assert_received(http, :post) do |expect|
+      expect.with(anything, xml_notice, Airbrake::HEADERS)
+    end
+  end
+
+  should "post to Airbrake with a Notice instance passed" do
+    notice = Airbrake::Notice.new(:error_class => "FooBar", :error_message => "Foo Bar")
+
+    http = stub_http
+
+    sender = build_sender
+    sender.send_to_airbrake(notice)
+
+    assert_received(http, :post) do |expect|
+      expect.with(anything, notice.to_xml, Airbrake::HEADERS)
+    end
+  end
+
   should "post to Airbrake when using an HTTP proxy" do
     response = stub(:body => 'body')
     http     = stub(:post          => response,


### PR DESCRIPTION
Currently you have to serialize the data, pass it to Resque, unserialize it, pass it to send_to_airbrake, which then immediately serializes it again as XML.

Letting people serialize it to XML ahead of time simplifies setting up async reporting and reduces the chance that another error will occur when trying to send a report about the original error.

The only real difference is that if you pass XML, it will now dump XML if Airbrake gets an HTTP error from sending the request, it will dump the XML rather than pretty printed.
