### PR TITLE
Send deploy notification on deploy:cold

### DIFF
--- a/lib/airbrake/capistrano.rb
+++ b/lib/airbrake/capistrano.rb
@@ -7,6 +7,7 @@ module Airbrake
       configuration.load do
         after "deploy",            "airbrake:deploy"
         after "deploy:migrations", "airbrake:deploy"
+        after "deploy:cold",       "airbrake:deploy"
 
         namespace :airbrake do
           desc <<-DESC


### PR DESCRIPTION
In addition to sending deploy notification on deploy and deploy:migrations, send one after the initial deploy:cold.
