### PR TITLE
no longer auto-initialize for rails

### DIFF
--- a/lib/airbrake/rails.rb
+++ b/lib/airbrake/rails.rb
@@ -36,5 +36,3 @@ module Airbrake
     end
   end
 end
-
-Airbrake::Rails.initialize


### PR DESCRIPTION
Authors should be free to include airbrake without airbrake automatically including itself into ActiveRecord::Base or injecting itself into Rack middleware.
