### PR TITLE
Prettier rake exception actions

### DIFF
--- a/lib/airbrake/rake_handler.rb
+++ b/lib/airbrake/rake_handler.rb
@@ -13,14 +13,14 @@ module Airbrake::RakeHandler
         (Airbrake.configuration.rescue_rake_exceptions ||
           (Airbrake.configuration.rescue_rake_exceptions===nil && !self.tty_output?))
 
-      Airbrake.notify_or_ignore(ex, :component => reconstruct_command_line, :cgi_data => environment_info)
+      Airbrake.notify_or_ignore(ex, :component => 'rake', :action => reconstruct_command_line, :cgi_data => environment_info)
     end
 
     display_error_message_without_airbrake(ex)
   end
 
   def reconstruct_command_line
-    "rake #{ARGV.join( ' ' )}"
+    ARGV.join( ' ' )
   end
 
   def environment_info


### PR DESCRIPTION
Display rake exceptions as "rake#the_commandline_args" instead of "rake the_commandline_args#"
