### PR TITLE
Use Airbrake.notify_or_ignore instead of just Airbrake.notify

### DIFF
--- a/lib/airbrake/rails/controller_methods.rb
+++ b/lib/airbrake/rails/controller_methods.rb
@@ -20,7 +20,7 @@ module Airbrake
       # inside the controller. Otherwise it works like Airbrake.notify.
       def notify_airbrake(hash_or_exception)
         unless airbrake_local_request?
-          Airbrake.notify(hash_or_exception, airbrake_request_data)
+          Airbrake.notify_or_ignore(hash_or_exception, airbrake_request_data)
         end
       end
 


### PR DESCRIPTION
Shouldn't `notify_or_ignore` be used instead of just `notify` in the `notify_airbrake` controller method? It seems like everywhere else this is the case.
If not, how can I use `notify_airbrake` in my controller while still respecting ignored exceptions?
