### PR TITLE
Use https for rake airbrake:test if force_ssl set to true (fixes #145)

### DIFF
--- a/lib/airbrake/rails3_tasks.rb
+++ b/lib/airbrake/rails3_tasks.rb
@@ -80,7 +80,10 @@ namespace :airbrake do
     end
 
     puts 'Processing request.'
-    env = Rack::MockRequest.env_for("/verify")
+
+    protocol = Rails.application.config.force_ssl ? 'https' : 'http'
+
+    env = Rack::MockRequest.env_for("#{protocol}://www.example.com/verify")
 
     Rails.application.call(env)
 


### PR DESCRIPTION
When an application has config.force_ssl set to true, the airbrake:test rake task tries to call /verify and ends up getting redirected to https://www.example.com/verify. The code isn't set up to handle this, so it just silently fails without actually triggering an exception.

The simplest approach is to detect whether force_ssl is set to true, and use https if necessary. That is what this pull request does.

I am very open to discussion about better approaches.
