### PR TITLE
Fix an error if not using ActionController::Base

### DIFF
--- a/lib/airbrake/railtie.rb
+++ b/lib/airbrake/railtie.rb
@@ -24,11 +24,15 @@ module Airbrake
       ActiveSupport.on_load(:action_controller) do
         # Lazily load action_controller methods
         #
-        require 'airbrake/rails/javascript_notifier'
         require 'airbrake/rails/controller_methods'
 
-        include Airbrake::Rails::JavascriptNotifier
         include Airbrake::Rails::ControllerMethods
+      end
+
+      if defined?(::ActionController::Base)
+        require 'airbrake/rails/javascript_notifier'
+
+        ::ActionController::Base.send(:include, Airbrake::Rails::JavascriptNotifier)
       end
 
       if defined?(::ActionDispatch::DebugExceptions)


### PR DESCRIPTION
Commit 3167c3eeb426f3b76feb095c657c0f1b8606d1b3 changed the logic for loading
javascript_notifier.rb. The javascript notifier has a dependency on the "helper_method" method on ActionController::Base. When using an alternate controller such as ActionController::API provided by https://github.com/rails-api/rails-api this causes an "undefined method `helper_method'" error. This change reverts the logic to the previous approach.
