### PR TITLE
Use "get" instead of "match" for verify route

### DIFF
--- a/lib/airbrake/rails3_tasks.rb
+++ b/lib/airbrake/rails3_tasks.rb
@@ -76,7 +76,7 @@ namespace :airbrake do
     end
 
     Rails.application.routes.draw do
-      match 'verify' => 'application#verify', :as => 'verify'
+      get 'verify' => 'application#verify', :as => 'verify'
     end
 
     puts 'Processing request.'


### PR DESCRIPTION
Using match makes Rails 4 angry. This is the only issue I've encountered thus far for setting up Airbrake with a Rails 4 application.

Details of Rails 4 anger:

➜  card-game git:(master) ✗ script/rails generate airbrake --api-key xxxxx

      create  config/initializers/airbrake.rb
         run  rake airbrake:test --trace from "."
*\* Invoke airbrake:test (first_time)
*\* Invoke environment (first_time)
*\* Execute environment
*\* Execute airbrake:test
Configuration:
                  api_key: "xxxxx"
               js_api_key: "xxxxx"
        backtrace_filters: [#<Proc:0x007fd5cb554ad0@/Users/jle/.rvm/gems/ruby-1.9.
 development_environments: []
       development_lookup: true
         environment_name: "development"
                     host: "api.airbrake.io"
        http_open_timeout: 2
        http_read_timeout: 5
                   ignore: ["ActiveRecord::RecordNotFound", "ActionController::Rou
        ignore_by_filters: []
        ignore_user_agent: []
            notifier_name: "Airbrake Notifier"
             notifier_url: "https://github.com/airbrake/airbrake"
         notifier_version: "3.1.6"
           params_filters: ["password", "password_confirmation"]
             project_root: #<Pathname:/Users/jle/personal/card-game>
                     port: 80
                 protocol: "http"
               proxy_host: nil
               proxy_pass: nil
               proxy_port: nil
               proxy_user: nil
                   secure: false
use_system_ssl_cert_chain: false
                framework: "Rails: 4.0.0.beta"
         user_information: "Airbrake Error {{error_id}}"
   rescue_rake_exceptions: nil
 rake_environment_filters: []
Setting up the Controller.
rake aborted!
You should not use the `match` method in your router without specifying an HTTP method.
If you want to expose your action to GET, use `get` in the router:

  Instead of: match "controller#action"
  Do: get "controller#action"
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/bundler/gems/rails-2283a1d62e36/actionpack/lib/action_dispatch/routing/mapper.rb:72:in `initialize'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/bundler/gems/rails-2283a1d62e36/actionpack/lib/action_dispatch/routing/mapper.rb:1371:in`new'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/bundler/gems/rails-2283a1d62e36/actionpack/lib/action_dispatch/routing/mapper.rb:1371:in `add_route'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/bundler/gems/rails-2283a1d62e36/actionpack/lib/action_dispatch/routing/mapper.rb:1351:in`decomposed_match'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/bundler/gems/rails-2283a1d62e36/actionpack/lib/action_dispatch/routing/mapper.rb:1337:in `block in match'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/bundler/gems/rails-2283a1d62e36/actionpack/lib/action_dispatch/routing/mapper.rb:1337:in`each'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/bundler/gems/rails-2283a1d62e36/actionpack/lib/action_dispatch/routing/mapper.rb:1337:in `match'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/gems/airbrake-3.1.6/lib/airbrake/rails3_tasks.rb:88:in`block (3 levels) in <top (required)>'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/bundler/gems/rails-2283a1d62e36/actionpack/lib/action_dispatch/routing/route_set.rb:281:in `instance_exec'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/bundler/gems/rails-2283a1d62e36/actionpack/lib/action_dispatch/routing/route_set.rb:281:in`eval_block'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/bundler/gems/rails-2283a1d62e36/actionpack/lib/action_dispatch/routing/route_set.rb:259:in `draw'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/gems/airbrake-3.1.6/lib/airbrake/rails3_tasks.rb:87:in`block (2 levels) in <top (required)>'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/gems/rake-10.0.3/lib/rake/task.rb:228:in `call'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/gems/rake-10.0.3/lib/rake/task.rb:228:in`block in execute'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/gems/rake-10.0.3/lib/rake/task.rb:223:in `each'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/gems/rake-10.0.3/lib/rake/task.rb:223:in`execute'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/gems/rake-10.0.3/lib/rake/task.rb:166:in `block in invoke_with_call_chain'
/Users/jle/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/1.9.1/monitor.rb:211:in`mon_synchronize'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/gems/rake-10.0.3/lib/rake/task.rb:159:in `invoke_with_call_chain'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/gems/rake-10.0.3/lib/rake/task.rb:152:in`invoke'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/gems/rake-10.0.3/lib/rake/application.rb:143:in `invoke_task'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/gems/rake-10.0.3/lib/rake/application.rb:101:in`block (2 levels) in top_level'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/gems/rake-10.0.3/lib/rake/application.rb:101:in `each'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/gems/rake-10.0.3/lib/rake/application.rb:101:in`block in top_level'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/gems/rake-10.0.3/lib/rake/application.rb:110:in `run_with_threads'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/gems/rake-10.0.3/lib/rake/application.rb:95:in`top_level'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/gems/rake-10.0.3/lib/rake/application.rb:73:in `block in run'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/gems/rake-10.0.3/lib/rake/application.rb:160:in`standard_exception_handling'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/gems/rake-10.0.3/lib/rake/application.rb:70:in `run'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/gems/rake-10.0.3/bin/rake:33:in`<top (required)>'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/bin/rake:19:in `load'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/bin/rake:19:in`<main>'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/bin/ruby_noexec_wrapper:14:in `eval'
/Users/jle/.rvm/gems/ruby-1.9.3-p327@card-game/bin/ruby_noexec_wrapper:14:in`<main>'
Tasks: TOP => airbrake:test
false
➜  card-game git:(master) ✗ 
