### PR TITLE
Fix notifier API URL as per Airbrake docs

### DIFF
--- a/lib/airbrake/sender.rb
+++ b/lib/airbrake/sender.rb
@@ -2,7 +2,7 @@ module Airbrake
   # Sends out the notice to Airbrake
   class Sender
 
-    NOTICES_URI = '/notifier_api/v2/notices/'.freeze
+    NOTICES_URI = '/notifier_api/v2/notices'.freeze
     HEADERS = {
       :xml => {
       'Content-type' => 'text/xml',


### PR DESCRIPTION
Docs say that URL has no trailing slash.

See
http://help.airbrake.io/kb/api-2/notifier-api-version-23
http://help.airbrake.io/kb/api-2/notifier-api-v3
