### PR TITLE
Ignore ActionController::UnknownHttpMethod by default

### DIFF
--- a/lib/airbrake/configuration.rb
+++ b/lib/airbrake/configuration.rb
@@ -138,6 +138,7 @@ module Airbrake
                       'ActionController::RoutingError',
                       'ActionController::InvalidAuthenticityToken',
                       'CGI::Session::CookieStore::TamperedWithCookie',
+                      'ActionController::UnknownHttpMethod',
                       'ActionController::UnknownAction',
                       'AbstractController::ActionNotFound',
                       'Mongoid::Errors::DocumentNotFound']


### PR DESCRIPTION
Happens when a bogus HTTP request method is given. Doesn't seem worthy of a notification.
