### PR TITLE
Do not log session secret

### DIFF
--- a/lib/airbrake/notice.rb
+++ b/lib/airbrake/notice.rb
@@ -344,6 +344,7 @@ module Airbrake
     def clean_rack_request_data
       if cgi_data
         cgi_data.delete("rack.request.form_vars")
+        cgi_data.delete("action_dispatch.secret_token")
       end
     end
 

--- a/test/notice_test.rb
+++ b/test/notice_test.rb
@@ -257,6 +257,15 @@ class NoticeTest < Test::Unit::TestCase
   should "filter session" do
     assert_filters_hash(:session_data)
   end
+  
+  should "should always remove a Rails application's secret token" do
+    original = {
+      "action_dispatch.secret_token" => "abc123xyz456",
+      "abc" => "123"
+    }
+    notice = build_notice(:cgi_data => original)
+    assert_equal({"abc" => "123"}, notice.cgi_data)
+  end
 
   should "remove rack.request.form_vars" do
     original = {


### PR DESCRIPTION
Airbrake should (by default) NOT log the Rails session secret key.

I think this is very, very bad behavior and needs to be immediately fixed.  There is no good reason for Airbrake to have this and it creates a very real security risk to any applications sharing this information
