### PR TITLE
log failed certicate verifications

### DIFF
--- a/lib/airbrake/sender.rb
+++ b/lib/airbrake/sender.rb
@@ -20,7 +20,8 @@ module Airbrake
                    Net::HTTPBadResponse,
                    Net::HTTPHeaderSyntaxError,
                    Net::ProtocolError,
-                   Errno::ECONNREFUSED].freeze
+                   Errno::ECONNREFUSED,
+                   OpenSSL::SSL::SSLError].freeze
 
     def initialize(options = {})
       [ :proxy_host,


### PR DESCRIPTION
before this change, eventual certicate verification errors got globbed
by only rescuing preconfigured http_errors without the appropriate ssl
exception.
