### PR TITLE
Partial thread-safety fix (lib/airbrake/rails/middleware.rb is still bro...

### DIFF
--- a/lib/airbrake/rack.rb
+++ b/lib/airbrake/rack.rb
@@ -40,23 +40,22 @@ module Airbrake
     end
 
     def call(env)
-      @env = env
       begin
-        response = @app.call(@env)
+        response = @app.call(env)
       rescue Exception => raised
-        @env['airbrake.error_id'] = notify_airbrake(raised, @env)
+        env['airbrake.error_id'] = notify_airbrake(raised, env)
         raise raised
       end
 
-      if framework_exception
-        @env['airbrake.error_id'] = notify_airbrake(framework_exception, @env)
+      if framework_exception(env)
+        env['airbrake.error_id'] = notify_airbrake(framework_exception(env), env)
       end
 
       response
     end
 
-    def framework_exception
-      @env['rack.exception']
+    def framework_exception(env)
+      env['rack.exception']
     end
 
   end

--- a/lib/airbrake/sinatra.rb
+++ b/lib/airbrake/sinatra.rb
@@ -26,8 +26,8 @@ module Airbrake
       Airbrake.configuration.framework = "Sinatra: #{::Sinatra::VERSION}"
     end 
 
-    def framework_exception
-      @env['sinatra.error']
+    def framework_exception(env)
+      env['sinatra.error']
     end
 
   end


### PR DESCRIPTION
...ken)

The current version of the airbrake gem is no longer thread-safe (since dec07d249eeaec8384fbf0c4d39e6642e8592fa1). This change partially fixes the issue.

Airbrake::Rack, Airbrake::Sinatra and Airbrake::Rails::Middleware are singletons, so storing state in `@env` will cause different threads to overwrite each other's state (in JRuby, which supports real threads).

lib/airbrake/rails/middleware.rb is, however, still broken as I am not exactly sure from which context the methods accessing `@env` are called (and thus how to alternatively supply `env` without using a virtually global attribute).
