### PR TITLE
Stop overriding Ruby's Object#method in Airbrake::Backtrace::Line

### DIFF
--- a/lib/airbrake/backtrace.rb
+++ b/lib/airbrake/backtrace.rb
@@ -14,26 +14,26 @@ module Airbrake
       # The line number portion of the line
       attr_reader :number
 
-      # The method of the line (such as index)
-      attr_reader :method
+      # The method_name of the line (such as index)
+      attr_reader :method_name
 
       # Parses a single line of a given backtrace
       # @param [String] unparsed_line The raw line from +caller+ or some backtrace
       # @return [Line] The parsed backtrace line
       def self.parse(unparsed_line)
-        _, file, number, method = unparsed_line.match(INPUT_FORMAT).to_a
-        new(file, number, method)
+        _, file, number, method_name = unparsed_line.match(INPUT_FORMAT).to_a
+        new(file, number, method_name)
       end
 
-      def initialize(file, number, method)
+      def initialize(file, number, method_name)
         self.file   = file
         self.number = number
-        self.method = method
+        self.method_name = method_name
       end
 
       # Reconstructs the line in a readable fashion
       def to_s
-        "#{file}:#{number}:in `#{method}'"
+        "#{file}:#{number}:in `#{method_name}'"
       end
 
       def ==(other)
@@ -46,7 +46,7 @@ module Airbrake
 
       private
 
-      attr_writer :file, :number, :method
+      attr_writer :file, :number, :method_name
     end
 
     # holder for an Array of Backtrace::Line instances

--- a/lib/airbrake/notice.rb
+++ b/lib/airbrake/notice.rb
@@ -156,9 +156,11 @@ module Airbrake
           error.message(error_message)
           error.backtrace do |backtrace|
             self.backtrace.lines.each do |line|
-              backtrace.line(:number => line.number,
-                             :file   => line.file,
-                             :method => line.method)
+              backtrace.line(
+                :number      => line.number,
+                :file        => line.file,
+                :method_name => line.method_name
+              )
             end
           end
         end
@@ -223,7 +225,7 @@ module Airbrake
                 {
                   'file'     => line.file,
                   'line'     => line.number.to_i,
-                  'function' => line.method
+                  'function' => line.method_name
                 }
             end
           }],

--- a/resources/airbrake_2_4.xsd
+++ b/resources/airbrake_2_4.xsd
@@ -38,7 +38,7 @@
         <xs:complexType>
           <xs:attribute name="file" type="xs:string" use="required"/>
           <xs:attribute name="number" type="xs:string" use="required"/>
-          <xs:attribute name="method" type="xs:string" use="optional"/>
+          <xs:attribute name="method_name" type="xs:string" use="optional"/>
         </xs:complexType>
       </xs:element>
     </xs:sequence>

--- a/test/backtrace_test.rb
+++ b/test/backtrace_test.rb
@@ -13,12 +13,12 @@ class BacktraceTest < Test::Unit::TestCase
     line = backtrace.lines.first
     assert_equal '13', line.number
     assert_equal 'app/models/user.rb', line.file
-    assert_equal 'magic', line.method
+    assert_equal 'magic', line.method_name
 
     line = backtrace.lines.last
     assert_equal '8', line.number
     assert_equal 'app/controllers/users_controller.rb', line.file
-    assert_equal 'index', line.method
+    assert_equal 'index', line.method_name
   end
 
   should "parse a windows backtrace into lines" do
@@ -32,12 +32,12 @@ class BacktraceTest < Test::Unit::TestCase
     line = backtrace.lines.first
     assert_equal '13', line.number
     assert_equal 'C:/Program Files/Server/app/models/user.rb', line.file
-    assert_equal 'magic', line.method
+    assert_equal 'magic', line.method_name
 
     line = backtrace.lines.last
     assert_equal '8', line.number
     assert_equal 'C:/Program Files/Server/app/controllers/users_controller.rb', line.file
-    assert_equal 'index', line.method
+    assert_equal 'index', line.method_name
   end
 
   should "be equal with equal lines" do

--- a/test/notice_test.rb
+++ b/test/notice_test.rb
@@ -351,7 +351,7 @@ class NoticeTest < Test::Unit::TestCase
 
       assert_valid_node(@document, "//error/backtrace/line/@number", @notice.backtrace.lines.first.number)
       assert_valid_node(@document, "//error/backtrace/line/@file", @notice.backtrace.lines.first.file)
-      assert_valid_node(@document, "//error/backtrace/line/@method", @notice.backtrace.lines.first.method)
+      assert_valid_node(@document, "//error/backtrace/line/@method_name", @notice.backtrace.lines.first.method_name)
 
       assert_valid_node(@document, "//request/url",        @notice.url)
       assert_valid_node(@document, "//request/component", @notice.controller)


### PR DESCRIPTION
The use of the `:method` attribute for the Line class overrides Object#method, causing unexpected errors.

This will likely require a minor version bump.

Note, I can't get the cucumber tests to pass either before or after this change.
