### PR TITLE
Setting config.user_attributes doesn't seem to pick up other attributes

### DIFF
--- a/features/rails.feature
+++ b/features/rails.feature
@@ -225,6 +225,24 @@ Feature: Install the Gem in a Rails application
     Then I should receive a Airbrake notification
     And the Airbrake notification should contain user details
 
+  Scenario: It should also send custom user attributes
+    When I configure the Airbrake shim
+    And I configure the notifier to use the following configuration lines:
+      """
+         config.api_key = "myapikey"
+         config.logger = Logger.new STDOUT
+         config.user_attributes = [:id, :name, :email, :username, :class_name]
+      """
+    And I define a response for "TestController#index":
+      """
+      raise RuntimeError, "some message"
+      """
+    And I route "/test/index" to "test#index"
+    And I have set up authentication system in my app that uses "current_user"
+    And I perform a request to "http://example.com:123/test/index" in the "production" environment
+    Then I should receive a Airbrake notification
+    And the Airbrake notification should contain the custom user details
+
   Scenario: It should log the notice when failure happens
     When Airbrake server is not responding
     And I configure the notifier to use the following configuration lines:

--- a/features/step_definitions/rails_application_steps.rb
+++ b/features/step_definitions/rails_application_steps.rb
@@ -227,11 +227,18 @@ When /^I have set up authentication system in my app that uses "([^\"]*)"$/ do |
 
     # this is the ultimate authentication system, devise is history
     def #{current_user}
-      Struct.new(:id, :name, :email, :username).new(1, 'Bender', 'bender@beer.com', 'b3nd0r')
+      Struct.new(:id, :name, :email, :username, :class_name).new(1, 'Bender', 'bender@beer.com', 'b3nd0r', 'User')
     end
   end
   """
   File.open(application_controller, "w") {|file| file.puts definition }
+end
+
+Then /^the Airbrake notification should contain the custom user details$/ do
+  step %{I should see "<name>Bender</name>"}
+  step %{I should see "<email>bender@beer.com</email>"}
+  step %{I should see "<username>b3nd0r</username>"}
+  step %{I should see "<class_name>User</class_name>"}
 end
 
 Then /^the Airbrake notification should contain user details$/ do

--- a/lib/airbrake/notice.rb
+++ b/lib/airbrake/notice.rb
@@ -198,10 +198,9 @@ module Airbrake
         end
         unless user.blank?
           notice.tag!("current-user") do |u|
-            u.tag!("id",user[:id])
-            u.tag!("name",user[:name])
-            u.tag!("email",user[:email])
-            u.tag!("username",user[:username])
+            user.each do |attr, value|
+              u.tag!(attr.to_s, value)
+            end
           end
         end
         unless framework.blank?


### PR DESCRIPTION
Setting custom user attributes to send to Airbrake about our current user do not seem to work.

``` ruby
# in config/initializers/airbrake.rb
Airbrake.configure do |config|
  config.api_key = 'API_KEY'
  config.user_attributes = [:class_name, :id, :email]
end
```

``` ruby
class ApplicationController < ActionController::Base
  def current_user
    current_agent || current_customer
  end
  helper_method :current_user
end
```

``` ruby
# app/models/customer.rb
class Customer < ActiveRecord::Base
  def class_name; self.class.name; end
end

# app/models/agent.rb
class Agent < ActiveRecord::Base
  def class_name; self.class.name; end
end
```

Resulting exception displayed in Airbrake UI:

![Screen Shot 2013-03-20 at 10 36 20 AM](https://f.cloud.github.com/assets/26285/281978/bdeb9b52-9184-11e2-88c0-14f0ef398a40.png)
