### PR TITLE
Use env rather than @env when constructing fallback request data.

### DIFF
--- a/lib/airbrake/rails/middleware.rb
+++ b/lib/airbrake/rails/middleware.rb
@@ -44,7 +44,7 @@ module Airbrake
 
       def request_data(env)
         env["action_controller.instance"].try(:airbrake_request_data) ||
-          {:rack_env => @env}
+          {:rack_env => env}
       end
 
       def ignored_user_agent?(env)


### PR DESCRIPTION
This PR fixes one remaining reference to `@env` where it should be `env` in the Rails middleware.
