### PR TITLE
Wrap the JS notifier configuration in a try..catch block

### DIFF
--- a/lib/templates/javascript_notifier.erb
+++ b/lib/templates/javascript_notifier.erb
@@ -13,6 +13,8 @@
     Airbrake.setEnvironment('#{environment}');
     Airbrake.setErrorDefaults({ url: "#{escape_javascript url}", component: "#{controller_name}", action: "#{action_name}" });
   }
-  catch (e) {}
+  catch (e) {
+    window.onerror = null;
+  }
   }
 %>


### PR DESCRIPTION
...since the notifier JS might have failed to load.

Today again we're seeing epic wait times and timeouts for api.airbrake.io. It is naive to assume the JS will in fact load and we'll have _Airbrake_ defined.

5f46c6a does the most basic, but I'm tempted to actually add a noop error handler in the catch block. Any objections to doing that as well?
