### PR TITLE
Fix Airbrake::Sender#log to log messages when logger is not passed to options.

### DIFF
--- a/lib/airbrake/sender.rb
+++ b/lib/airbrake/sender.rb
@@ -137,7 +137,7 @@ module Airbrake
     end
 
     def log(opts = {})
-      opts[:logger].send opts[:level], LOG_PREFIX + opts[:message] if opts[:logger]
+      (opts[:logger] || logger).send(opts[:level], LOG_PREFIX + opts[:message])
       Airbrake.report_environment_info
       Airbrake.report_response_body(opts[:response].body) if opts[:response] && opts[:response].respond_to?(:body)
       Airbrake.report_notice(opts[:notice]) if opts[:notice]


### PR DESCRIPTION
`Airbrake::Sender#log` is broken since https://github.com/airbrake/airbrake/commit/8e55c1f8ac81982b5bd34027ecb3c44a9382f82a. which required `options[:logger]`  to be passed - otherwise messages are not being logged. E.g. `Airbrake::Sender#send_to_airbrake` calls `log` few time with _no_ `:logger` passed and none of these messages/errors are being logged. 
