### PR TITLE
Coerce user attributes to strings before checking that they are valid.

### DIFF
--- a/features/rails.feature
+++ b/features/rails.feature
@@ -251,6 +251,7 @@ Feature: Install the Gem in a Rails application
       """
     And I run `rails runner config/boot.rb`
     Then I should see "Unsupported user attribute: 'shoe_size'"
+    And I should not see "Unsupported user attribute: 'id'"
 
   Scenario: It should log the notice when failure happens
     When Airbrake server is not responding

--- a/lib/airbrake/configuration.rb
+++ b/lib/airbrake/configuration.rb
@@ -329,7 +329,7 @@ module Airbrake
 
     def validate_user_attributes(user_attributes)
       user_attributes.each do |attribute|
-        next if VALID_USER_ATTRIBUTES.include? attribute
+        next if VALID_USER_ATTRIBUTES.include? attribute.to_s
         warn "[AIRBRAKE] Unsupported user attribute: '#{attribute}'. "\
           "This attribute will not be shown in the Airbrake UI. "\
           "Check http://git.io/h6YRpA for more info."


### PR DESCRIPTION
If the user attributes were defined as symbols, the validation would fail as it was expecting strings.
