### PR TITLE
Reject invalid user attributes on assignment

### DIFF
--- a/lib/airbrake/configuration.rb
+++ b/lib/airbrake/configuration.rb
@@ -328,11 +328,13 @@ module Airbrake
     end
 
     def validate_user_attributes(user_attributes)
-      user_attributes.each do |attribute|
-        next if VALID_USER_ATTRIBUTES.include? attribute.to_s
-        warn "[AIRBRAKE] Unsupported user attribute: '#{attribute}'. "\
-          "This attribute will not be shown in the Airbrake UI. "\
-          "Check http://git.io/h6YRpA for more info."
+      user_attributes.reject do |attribute|
+        unless VALID_USER_ATTRIBUTES.include? attribute.to_s
+          warn "[AIRBRAKE] Unsupported user attribute: '#{attribute}'. "\
+            "This attribute will not be shown in the Airbrake UI. "\
+            "Check http://git.io/h6YRpA for more info."
+          true
+        end
       end
     end
   end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -200,6 +200,12 @@ class ConfigurationTest < Test::Unit::TestCase
     assert_kind_of Airbrake::Configuration, Airbrake.configuration
   end
 
+  should 'reject invalid user attributes' do
+    config = Airbrake::Configuration.new
+    config.user_attributes = %w(id foo)
+    assert_equal %w(id), config.user_attributes
+  end
+
   def assert_config_default(option, default_value, config = nil)
     config ||= Airbrake::Configuration.new
     assert_equal default_value, config.send(option)


### PR DESCRIPTION
Invalid user attributes cause XML that the server cannot process, so they should be rejected on assignment, in addition to the warning that is already provided.

I'd need some verification from Airbrake itself first to verify that invalid user attributes do actually cause malformed XML. I had a project where I was passing an invalid user attribute (full_name) and it caused the errors to just hang in the UI waiting to be processed. Once I removed that attribute, the errors processed and appeared fine.
