### PR TITLE
return environment_info unless environment_name

### DIFF
--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -66,6 +66,7 @@ module Airbrake
       info = "[Ruby: #{RUBY_VERSION}]"
       info << " [#{configuration.framework}]" if configuration.framework
       info << " [Env: #{configuration.environment_name}]" if configuration.environment_name
+      info
     end
 
     # Writes out the given message to the #logger


### PR DESCRIPTION
return environment_info if configuration.environment_name dose not exists. (plain ruby script)

```
def foo
  info = 'first'
  info << ' second' if false
end

foo
=> nil

def foo
  info = 'first'
  info << ' second' if false
  info
end

foo
=> 'first'
```
