### PR TITLE
Use a separate (blank) array of ignored exceptions for Rake tasks

### DIFF
--- a/lib/airbrake/configuration.rb
+++ b/lib/airbrake/configuration.rb
@@ -65,8 +65,11 @@ module Airbrake
     # Empty by default and used only in rake handler
     attr_reader :rake_environment_filters
 
-    # A list of exception classes to ignore. The array can be appended to.
+    # A list of exception classes to ignore during server requests. The array can be appended to.
     attr_reader :ignore
+
+    # A list of exception classes to ignore during Rake tasks. The array can be appended to.
+    attr_reader :ignore_rake
 
     # A list of user agents that are being ignored. The array can be appended to.
     attr_reader :ignore_user_agent
@@ -162,8 +165,9 @@ module Airbrake
       @http_read_timeout        = 5
       @params_filters           = DEFAULT_PARAMS_FILTERS.dup
       @backtrace_filters        = DEFAULT_BACKTRACE_FILTERS.dup
-      @ignore_by_filters        = []
+      @ignore_by_filters        = []  # These filters are applied to both server requests and Rake tasks
       @ignore                   = IGNORE_DEFAULT.dup
+      @ignore_rake              = []  # Rake tasks don't ignore any exception classes by default
       @ignore_user_agent        = []
       @development_environments = %w(development test cucumber)
       @development_lookup       = true
@@ -211,6 +215,13 @@ module Airbrake
     # @param [Array<Exception>] names A list of exceptions to ignore.
     def ignore_only=(names)
       @ignore = [names].flatten
+    end
+
+    # Overrides the list of default ignored errors during Rake tasks.
+    #
+    # @param [Array<Exception>] names A list of rake exceptions to ignore.
+    def ignore_rake_only=(names)
+      @ignore_rake = [names].flatten
     end
 
     # Overrides the list of default ignored user agents

--- a/lib/airbrake/rake_handler.rb
+++ b/lib/airbrake/rake_handler.rb
@@ -15,8 +15,9 @@ module Airbrake::RakeHandler
 
       Airbrake.notify_or_ignore(exception,
                                 :component => 'rake',
-                                :action => reconstruct_command_line,
-                                :cgi_data => environment_info)
+                                :action    => reconstruct_command_line,
+                                :cgi_data  => environment_info,
+                                :ignore    => Airbrake.configuration.ignore_rake)
     end
 
     display_error_message_without_airbrake(exception)

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -161,6 +161,18 @@ class ConfigurationTest < Test::Unit::TestCase
     assert_replaces(:ignore, :ignore_only=)
   end
 
+  should "allow ignored rake exceptions to be appended" do
+    config = Airbrake::Configuration.new
+    original_filters = config.ignore_rake.dup
+    new_filter = 'hello'
+    config.ignore_rake << new_filter
+    assert_same_elements original_filters + [new_filter], config.ignore_rake
+  end
+
+  should "allow ignored rake exceptions to be replaced" do
+    assert_replaces(:ignore_rake, :ignore_rake_only=)
+  end
+
   should "allow ignored user agents to be replaced" do
     assert_replaces(:ignore_user_agent, :ignore_user_agent_only=)
   end


### PR DESCRIPTION
From #220:

> We've just had a cron task failing silently for over a week with an `ActiveRecord::RecordNotFound` error, because the rake exception handler calls `notify_or_ignore`, and `ActiveRecord::RecordNotFound` is ignored by default.
> 
> I propose a `@ignore_rake` configuration option, which defaults to an empty array. This could be used by changing `lib/airbrake/rake_handler.rb:16` to `Airbrake.notify_or_ignore(..., :ignore => Airbrake.configuration.ignore_rake`.
