### PR TITLE
Add support for SSL in the command line tool

### DIFF
--- a/lib/airbrake/cli/runner.rb
+++ b/lib/airbrake/cli/runner.rb
@@ -22,6 +22,7 @@ module Runner
         c.api_key = options.api_key
         c.host    = options.host if options.host
         c.port    = options.port if options.port
+        c.secure  = options.port.to_i == 443
       end
       exception_id = Airbrake.notify(:error_class   => options.error,
                                      :error_message => "#{options.error}: #{options.message}",


### PR DESCRIPTION
The command line tool currently breaks if the connection to the Airbrake server is an SSL connection. This patch fixes the problem.
