### PR TITLE
Use Capistrano's current_path.

### DIFF
--- a/lib/airbrake/capistrano.rb
+++ b/lib/airbrake/capistrano.rb
@@ -75,7 +75,7 @@ module Airbrake
             airbrake_env = fetch(:airbrake_env, fetch(:rails_env, "production"))
             local_user = ENV['USER'] || ENV['USERNAME']
             executable = RUBY_PLATFORM.downcase.include?('mswin') ? fetch(:rake, 'rake.bat') : fetch(:rake, 'bundle exec rake ')
-            directory = configuration.release_path
+            directory = configuration.current_path
             notify_command = "cd #{directory}; #{executable} RAILS_ENV=#{rails_env} airbrake:deploy TO=#{airbrake_env} REVISION=#{current_revision} REPO=#{repository} USER=#{Airbrake::Capistrano::shellescape(local_user)}"
             notify_command << " DRY_RUN=true" if dry_run
             notify_command << " API_KEY=#{ENV['API_KEY']}" if ENV['API_KEY']

--- a/test/capistrano_test.rb
+++ b/test/capistrano_test.rb
@@ -24,7 +24,7 @@ class CapistranoTest < Test::Unit::TestCase
   should "log when calling airbrake:deploy task" do
     @configuration.set(:current_revision, '084505b1c0e0bcf1526e673bb6ac99fbcb18aecc')
     @configuration.set(:repository, 'repository')
-    @configuration.set(:release_path, '/home/deploy/rails_app/hoptoad')
+    @configuration.set(:current_path, '/home/deploy/rails_app/hoptoad')
     io = StringIO.new
     logger = Capistrano::Logger.new(:output => io)
     logger.level = Capistrano::Logger::MAX_LEVEL


### PR DESCRIPTION
Use Capistrano's current_path instead of release_path to allow the Cap
task to be run independent of when the release directory is created.
The release directory name is determined at Cap load time via Time.now;
however, if the release directory is not being created during this
Cap run the Airbrake Cap task tries to cd into a non-existent directory
and errors out.  Better to use current_path, which is always
correct.