### PR TITLE
Handle sinatra errors

### DIFF
--- a/lib/airbrake/rack.rb
+++ b/lib/airbrake/rack.rb
@@ -55,7 +55,7 @@ module Airbrake
     end
 
     def framework_exception(env)
-      env['rack.exception']
+      env['rack.exception'] || env['sinatra.error']
     end
 
   end


### PR DESCRIPTION
When using sinatra airbrake is not cathing errors.

I tried this, but no success: https://github.com/airbrake/airbrake/wiki/Using-Airbrake-in-Sinatra-apps

So I added the variable sinatra.error to Rack middleware
