### PR TITLE
Support sucker_punch for async processor

### DIFF
--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("appraisal")
   s.add_development_dependency("rspec-rails")
   s.add_development_dependency("girl_friday")
+  s.add_development_dependency("sucker_punch")
   s.add_development_dependency("shoulda-matchers")
   s.add_development_dependency("shoulda-context")
   s.add_development_dependency("pry")

--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -3,12 +3,18 @@ begin
 rescue LoadError
 end
 
+begin
+  require "sucker_punch"
+rescue LoadError
+end
+
 require 'net/http'
 require 'net/https'
 require 'rubygems'
 require 'logger'
 
 require 'airbrake/version'
+require 'airbrake/jobs/send_job'
 require 'airbrake/utils/rack_filters'
 require 'airbrake/utils/params_cleaner'
 require 'airbrake/configuration'

--- a/lib/airbrake/jobs/send_job.rb
+++ b/lib/airbrake/jobs/send_job.rb
@@ -1,0 +1,7 @@
+class SendJob
+  include SuckerPunch::Job if defined?(SuckerPunch)
+
+  def perform(notice)
+    Airbrake.sender.send_to_airbrake(notice)
+  end
+end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -34,7 +34,7 @@ class ConfigurationTest < Test::Unit::TestCase
     assert_config_default :project_id, nil
   end
 
-  should "set GirlFriday-callable for async=true" do
+  should "set GirlFriday/SuckerPunch-callable for async=true" do
     config = Airbrake::Configuration.new
     config.async = true
     assert config.async.respond_to?(:call)


### PR DESCRIPTION
girl_friday recommends using the sucker_punch library in preference to girl_friday now.

Since Version 1 sucker_punch also does not require any special code to be executed after forking occurs on forking servers (Unicorn, Passenger, etc.).

This fixes #219, #122 and #230 

Note: It remains backwards compatible for those still wanting to use girl_friday.
