### PR TITLE
Airbrake rakefile is not compatible with Capistrano v3

### DIFF
--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rspec",         "~> 2.6.0")
   s.add_development_dependency("sham_rack",     "~> 1.3.0")
   s.add_development_dependency("json-schema",   "~> 1.0.12")
-  s.add_development_dependency("capistrano")
+  s.add_development_dependency("capistrano",    "~> 2.0")
   s.add_development_dependency("aruba")
   s.add_development_dependency("appraisal")
   s.add_development_dependency("rspec-rails")


### PR DESCRIPTION
On my system, running `bundle exec rake test:unit` as per the README fails, because the Capistrano dependency is not version locked and I have v3 installed:

```
➜  ~/dev/airbrake git:(16944m|master) bundle exec rake test:unit

/Users/marten/.rvm/rubies/ruby-2.0.0-p247/bin/ruby -I"lib:lib" -I"/Users/marten/.rvm/gems/ruby-2.0.0-p247@global/gems/rake-10.1.0/lib" "/Users/marten/.rvm/gems/ruby-2.0.0-p247@global/gems/rake-10.1.0/lib/rake/rake_test_loader.rb" "test/*_test.rb"
/Users/marten/.rvm/gems/ruby-2.0.0-p247/gems/capistrano-3.0.1/lib/capistrano/configuration/server.rb:4:in `<class:Configuration>': uninitialized constant Capistrano::Configuration::SSHKit (NameError)
```

Adding a twiddlewakka to ensure Capistrano 2.0 is used fixes this, and gets me to a green test suite.
