### PR TITLE
Only send notices if configured with an api_key

### DIFF
--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -147,7 +147,7 @@ module Airbrake
     private
 
     def send_notice(notice)
-      if configuration.public?
+      if configuration.configured? && configuration.public?
         if configuration.async?
           configuration.async.call(notice)
           nil # make sure we never set env["airbrake.error_id"] for async notices

--- a/lib/airbrake/configuration.rb
+++ b/lib/airbrake/configuration.rb
@@ -256,6 +256,10 @@ module Airbrake
       to_hash.merge(hash)
     end
 
+    def configured?
+      !api_key.nil? && !api_key.empty?
+    end
+
     # Determines if the notifier will send notices.
     # @return [Boolean] Returns +false+ if in a development environment, +true+ otherwise.
     def public?

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -183,6 +183,27 @@ class ConfigurationTest < Test::Unit::TestCase
     assert_same_elements %w(development test cucumber), config.development_environments
   end
 
+  context "configured?" do
+    setup do
+      @config = Airbrake::Configuration.new
+    end
+
+    should "be true if given an api_key" do
+      @config.api_key = "1234"
+      assert @config.configured?
+    end
+
+    should "be false with a nil api_key" do
+      @config.api_key = nil
+      assert !@config.configured?
+    end
+
+    should "be false with a blank api_key" do
+      @config.api_key = ''
+      assert !@config.configured?
+    end
+  end
+
   should "be public in a public environment" do
     config = Airbrake::Configuration.new
     config.development_environments = %w(development)

--- a/test/integration/catcher_test.rb
+++ b/test/integration/catcher_test.rb
@@ -269,6 +269,13 @@ class ActionControllerCatcherTest < ActionDispatch::IntegrationTest
     assert_caught_and_not_sent
   end
 
+  def test_not_deliver_notices_from_exceptions_with_no_api_key
+    Airbrake.configuration.api_key = nil
+    @app = AirbrakeTestController.action(:boom)
+    get '/'
+    assert_caught_and_not_sent
+  end
+
   def test_not_deliver_notices_from_actions_that_dont_raise
     @app = AirbrakeTestController.action(:hello)
     get '/'

--- a/test/notifier_test.rb
+++ b/test/notifier_test.rb
@@ -187,7 +187,7 @@ class NotifierTest < Test::Unit::TestCase
     config_opts = { 'one' => 'two', 'three' => 'four' }
     stub_notice!
     stub_sender!
-    Airbrake.configuration = stub('config', :merge => config_opts, :public? => true,:async? => nil)
+    Airbrake.configuration = stub('config', :merge => config_opts, :configured? => true, :public? => true,:async? => nil)
 
     Airbrake.notify(exception)
 


### PR DESCRIPTION
Currently if the gem is included, but not configured, it will intercept exceptions and attempt to send them to `api.airbrake.io` without an API key.

This changes the behaviour of send_notice to only send a notice if airbrake is configured.  This defines configured mean it has a non-blank API key.

This is desirable because we want to be able to add airbrake to our application, and have the initializer added to the app at deploy time in some deploy targets (but not others).
