### PR TITLE
Keep passed exception if original_exception is nil

### DIFF
--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -169,9 +169,7 @@ module Airbrake
         exception.original_exception
       elsif exception.respond_to?(:continued_exception)
         exception.continued_exception
-      else
-        exception
-      end
+      end || exception
     end
   end
 end

--- a/test/notifier_test.rb
+++ b/test/notifier_test.rb
@@ -256,6 +256,12 @@ class NotifierTest < Test::Unit::TestCase
         @hash = Airbrake.build_lookup_hash_for(@exception)
         assert_equal "NotifierTest::OriginalException", @hash[:error_class]
       end
+
+      should "keep exception if #original_exception is nil" do
+        @exception.stubs(:original_exception).returns(nil)
+        @hash = Airbrake.build_lookup_hash_for(@exception)
+        assert_equal "BacktracedException", @hash[:error_class]
+      end
     end
 
     context "when an exception that provides #continued_exception is raised" do
@@ -270,6 +276,12 @@ class NotifierTest < Test::Unit::TestCase
       should "unwrap exceptions that provide #continued_exception" do
         @hash = Airbrake.build_lookup_hash_for(@exception)
         assert_equal "NotifierTest::ContinuedException", @hash[:error_class]
+      end
+
+      should "keep exception if #continued_exception is nil" do
+        @exception.stubs(:continued_exception).returns(nil)
+        @hash = Airbrake.build_lookup_hash_for(@exception)
+        assert_equal "BacktracedException", @hash[:error_class]
       end
     end
   end


### PR DESCRIPTION
In Rails, when `ActionController::BadRequest` exception is raised, the exception object responds to `original_exception`, but that method returns a nil value.  This causes `error_class` and many other values for the Notice to be nil.

This change keeps the passed exception, if the exception responds to `original_exception` or `continued_exception`, but the method call returns nil
