### PR TITLE
Ignore ActionController::UnknownFormat

### DIFF
--- a/lib/airbrake/configuration.rb
+++ b/lib/airbrake/configuration.rb
@@ -152,7 +152,8 @@ module Airbrake
                       'ActionController::UnknownHttpMethod',
                       'ActionController::UnknownAction',
                       'AbstractController::ActionNotFound',
-                      'Mongoid::Errors::DocumentNotFound']
+                      'Mongoid::Errors::DocumentNotFound',
+                      'ActionController::UnknownFormat']
 
     alias_method :secure?, :secure
     alias_method :use_system_ssl_cert_chain?, :use_system_ssl_cert_chain


### PR DESCRIPTION
In rails 4+, ActionController now raises an exception for an unhandled format which is converted into an appropriate response in middleware which is above the Airbrake middleware. This just ignores that error by default.
