### PR TITLE
Add backwards compatibility for filter_parameters in Rails 3

### DIFF
--- a/lib/airbrake/rails/controller_methods.rb
+++ b/lib/airbrake/rails/controller_methods.rb
@@ -42,19 +42,22 @@ module Airbrake
       def airbrake_filter_if_filtering(hash)
         return hash if ! hash.is_a?(Hash)
 
-
         if respond_to?(:filter_parameters) # Rails 2
           filter_parameters(hash)
-        elsif defined?(ActionDispatch::Http::ParameterFilter) && rails3? # Rails 3
-          ActionDispatch::Http::ParameterFilter.new(::Rails.application.config.filter_parameters).filter(hash)
+        elsif rails3?
+          filter_rails3_parameters(hash)
         else
           hash
         end
-
       end
 
       def rails3?
         defined?(::Rails.version) && ::Rails.version =~ /\A3/
+      end
+
+      def filter_rails3_parameters(hash)
+        ActionDispatch::Http::ParameterFilter.new(
+          ::Rails.application.config.filter_parameters).filter(hash)
       end
 
       def airbrake_session_data

--- a/test/controller_methods_test.rb
+++ b/test/controller_methods_test.rb
@@ -54,5 +54,24 @@ class ControllerMethodsTest < Test::Unit::TestCase
       assert_equal no_session, {:session => 'no session found'}
     end
   end
-end
 
+  context "Rails 3" do
+    setup do
+      @controller = TestController.new
+      ::Rails = Object.new
+      ::Rails.stubs(:version).returns("3.2.17")
+    end
+    should "respond to rails3? with true" do
+      assert @controller.send(:rails3?)
+    end
+    should "call filter_rails3_parameters" do
+      hash = {:a => "b"}
+      filtered_hash = {:c => "d"}
+
+      @controller.expects(:filter_rails3_parameters).with(hash).
+        returns(filtered_hash)
+      assert_equal filtered_hash,
+        @controller.send(:airbrake_filter_if_filtering, hash)
+    end
+  end
+end


### PR DESCRIPTION
Commit e93132c added support for Rails 4, but it broke the automatic
filter_parameters in Rails 3. This adds backwards compatibility for
Rails 3.

Fixes issue #249.
