### PR TITLE
Adds gem zip to fix an error running rails server

### DIFF
--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("builder")
   s.add_runtime_dependency("multi_json")
+  s.add_runtime_dependency("zip")
 
   s.add_development_dependency("bourne",        "~> 1.4.0")
   s.add_development_dependency("cucumber-rails","~> 1.1.1")
@@ -33,7 +34,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency("shoulda-context")
   s.add_development_dependency("pry")
   s.add_development_dependency("coveralls")
-  s.add_development_dependency("zip")
 
   s.authors = ["Airbrake"]
   s.email   = %q{support@airbrake.io}


### PR DESCRIPTION
The zip/zip dependency was causing a load error when trying to run rails server.  I narrowed down the dependency to airbrake.  Adding `s.add_runtime_dependency("zip")` fixes the problem.  The project is currently working by requiring my fork. I'm not sure if this is from another gem that airbrake requires or is from airbrake itself, but it will fix any issues from said dependency

The error from my command line:

```
/Users/tristansiegel/.rvm/gems/ruby-2.0.0-p451/gems/activesupport-4.0.3/lib/active_support/dependencies.rb:229:in `require': cannot load such file -- zip/zip (LoadError)
```
