### PR TITLE
Add apikey to certain cucumber tests for changes for configured

### DIFF
--- a/features/metal.feature
+++ b/features/metal.feature
@@ -4,6 +4,7 @@ Feature: Rescue errors in Rails middleware
     And I cd to "rails_root"
     And I configure the notifier to use the following configuration lines:
     """
+      config.api_key = "myapikey"
       config.logger = Logger.new STDOUT
     """
     And I configure the Airbrake shim

--- a/features/rails.feature
+++ b/features/rails.feature
@@ -134,6 +134,7 @@ Feature: Install the Gem in a Rails application
     And I run `rails generate airbrake -k myapikey -t`
     When I configure the notifier to use the following configuration lines:
       """
+      config.api_key = "myapikey"
       config.logger = Logger.new STDOUT
       """
     And I configure the application to filter parameter "secret"

--- a/features/user_informer.feature
+++ b/features/user_informer.feature
@@ -22,6 +22,7 @@ Feature: Inform the user of the airbrake notice that was just created
   Scenario: Rescue an exception in a controller with a custom error string
     When I configure the notifier to use the following configuration lines:
     """
+    config.api_key = "myapikey"
     config.user_information = 'Error #{{ error_id }}'
     """
     And I run `rails generate airbrake -k myapikey`


### PR DESCRIPTION
I mistakenly assumed the tests would pass for the merge of https://github.com/airbrake/airbrake/pull/268

I updated the `cucumber` tests to set the `api_key` so that they continue to work as expected.
