### PR TITLE
Fix failing tests due to regex

### DIFF
--- a/features/step_definitions/rails_application_steps.rb
+++ b/features/step_definitions/rails_application_steps.rb
@@ -257,7 +257,7 @@ Then /^the Airbrake notification should not contain any of the sensitive Rack va
   sensitive_rack_data_regex = FILTERED_RACK_VARS.map do |var|
     var.instance_of?(Regexp) ? var : Regexp.quote(var)
   end.join("|")
-  step %{the last notice sent should not contain "#{'key\=\"('+sensitive_rack_data_regex+')\"'}"}
+  step %{the last notice sent should not contain keys with "#{sensitive_rack_data_regex}"}
 end
 
 Then /^the last notice sent should contain "([^\"]*)"$/ do |data|
@@ -265,9 +265,14 @@ Then /^the last notice sent should contain "([^\"]*)"$/ do |data|
   last_notice.should match(%r{#{data}})
 end
 
-Then /^the last notice sent should not contain "(.*)"$/ do |data|
+Then /^the last notice sent should not contain "([^\"]*)"$/ do |data|
   last_notice = File.read(LAST_NOTICE)
   last_notice.should_not match(%r{#{data}})
+end
+
+Then /^the last notice sent should not contain keys with "([^\"]*)"$/ do |data|
+  last_notice = File.read(LAST_NOTICE)
+  last_notice.should_not match(%r{key\=\"(#{data})\"})
 end
 
 Then /^the Airbrake notification should contain the framework information$/ do


### PR DESCRIPTION
Fix filtering checks in cucumber tests by checking for 'key=' instead of blind check
