### PR TITLE
Add ability to define whitelist filters for parameters

### DIFF
--- a/lib/airbrake/configuration.rb
+++ b/lib/airbrake/configuration.rb
@@ -6,7 +6,7 @@ module Airbrake
         :development_lookup, :environment_name, :host,
         :http_open_timeout, :http_read_timeout, :ignore, :ignore_by_filters,
         :ignore_user_agent, :notifier_name, :notifier_url, :notifier_version,
-        :params_filters, :project_root, :port, :protocol, :proxy_host,
+        :params_filters, :params_whitelist_filters, :project_root, :port, :protocol, :proxy_host,
         :proxy_pass, :proxy_port, :proxy_user, :secure, :use_system_ssl_cert_chain,
         :framework, :user_information, :rescue_rake_exceptions, :rake_environment_filters,
         :test_mode].freeze
@@ -54,6 +54,11 @@ module Airbrake
     # A list of parameters that should be filtered out of what is sent to Airbrake.
     # By default, all "password" attributes will have their contents replaced.
     attr_accessor :params_filters
+
+    # A list of whitelisted parameters that will be sent to Airbrake.
+    # All other parameters will be filtered and their content replaced.
+    # By default this list is empty (all parameters are whitelisted).
+    attr_accessor :params_whitelist_filters
 
     # A list of filters for cleaning and pruning the backtrace. See #filter_backtrace.
     attr_reader :backtrace_filters
@@ -121,6 +126,7 @@ module Airbrake
     alias_method :test_mode?, :test_mode
 
     DEFAULT_PARAMS_FILTERS  = %w(password password_confirmation).freeze
+    DEFAULT_PARAMS_WHITELIST_FILTERS = [].freeze
 
     DEFAULT_USER_ATTRIBUTES = %w(id).freeze
 
@@ -166,6 +172,7 @@ module Airbrake
       @http_open_timeout        = 2
       @http_read_timeout        = 5
       @params_filters           = DEFAULT_PARAMS_FILTERS.dup
+      @params_whitelist_filters = DEFAULT_PARAMS_WHITELIST_FILTERS.dup
       @backtrace_filters        = DEFAULT_BACKTRACE_FILTERS.dup
       @ignore_by_filters        = []  # These filters are applied to both server requests and Rake tasks
       @ignore                   = IGNORE_DEFAULT.dup

--- a/lib/airbrake/notice.rb
+++ b/lib/airbrake/notice.rb
@@ -47,6 +47,9 @@ module Airbrake
     # See Configuration#params_filters
     attr_reader :params_filters
 
+    # See Configuration#params_whitelist_filters
+    attr_reader :params_whitelist_filters
+
     # A hash of parameters from the query string or post body.
     attr_reader :parameters
     alias_method :params, :parameters
@@ -104,10 +107,12 @@ module Airbrake
       @notifier_version = args[:notifier_version]
       @notifier_url     = args[:notifier_url]
 
-      @ignore              = args[:ignore]              || []
-      @ignore_by_filters   = args[:ignore_by_filters]   || []
-      @backtrace_filters   = args[:backtrace_filters]   || []
-      @params_filters      = args[:params_filters]      || []
+      @ignore                   = args[:ignore]                      || []
+      @ignore_by_filters        = args[:ignore_by_filters]           || []
+      @backtrace_filters        = args[:backtrace_filters]           || []
+      @params_filters           = args[:params_filters]              || []
+      @params_whitelist_filters = args[:params_whitelist_filters]    || []
+
       @parameters          = args[:parameters] ||
                                    action_dispatch_params ||
                                    rack_env(:params) ||
@@ -131,8 +136,9 @@ module Airbrake
       find_session_data
 
       @cleaner = args[:cleaner] || 
-        Airbrake::Utils::ParamsCleaner.new(:filters => params_filters,
-                                           :to_clean => data_to_clean)
+        Airbrake::Utils::ParamsCleaner.new(:blacklist_filters => params_filters,
+                                            :whitelist_filters => params_whitelist_filters,
+                                            :to_clean => data_to_clean)
 
       clean_data!
     end

--- a/test/params_cleaner_test.rb
+++ b/test/params_cleaner_test.rb
@@ -3,8 +3,9 @@ require File.expand_path '../helper', __FILE__
 class ParamsCleanerTest < Test::Unit::TestCase
 
   def clean(opts = {})
-    cleaner = Airbrake::Utils::ParamsCleaner.new(:filters  => opts.delete(:params_filters),
-                                               :to_clean => opts)
+    cleaner = Airbrake::Utils::ParamsCleaner.new(:blacklist_filters  => opts.delete(:params_filters),
+                                                  :whitelist_filters  => opts.delete(:whitelist_params_filters),
+                                                  :to_clean => opts)
     cleaner.clean
   end
 
@@ -77,6 +78,23 @@ class ParamsCleanerTest < Test::Unit::TestCase
 
   should "filter parameters" do
     assert_filters_hash(:parameters)
+  end
+
+  should "whitelist filter parameters" do
+    whitelist_filters  = ["abc", :def]
+    original = { 'abc' => "123", 'def' => "456", 'ghi' => "789", 'nested' => { 'abc' => '100' },
+      'something_with_abc' => 'match the entire string'}
+    filtered = { 'abc'    => "123",
+      'def'    => "456",
+      'something_with_abc' => "[FILTERED]",
+      'ghi'    => "[FILTERED]",
+      'nested' => "[FILTERED]" }
+
+    clean_params = clean(:whitelist_params_filters => whitelist_filters,
+                    :parameters => original)
+
+    assert_equal(filtered,
+                 clean_params.send(:parameters))
   end
 
   should "filter cgi data" do


### PR DESCRIPTION
I found that filtering parameters from being sent to Airbrake using the :params_filters attribute is something that I constantly need to update and think about. (In my company we need to make sure no personal customer information is shared with 3rd party services)

Since there is only a small number of parameters I actually care about when examining an Airbrake notification, I think that the ability to whitelist the parameters I am interested in, is a simpler, safer approach.

By setting the :params_whitelist_filters list, all other parameters will be filtered (and their content replaced).
If a parameter is both whitelisted and "blacklisted" it will be filtered.