### PR TITLE
Add minitest 4.x as an explicit dependency

### DIFF
--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("shoulda-context")
   s.add_development_dependency("pry")
   s.add_development_dependency("coveralls")
+  s.add_development_dependency("minitest", ["~> 4.0"])
 
   s.authors = ["Airbrake"]
   s.email   = %q{support@airbrake.io}


### PR DESCRIPTION
In the CI builds (currently with CircleCI), we use minitest 4.7. Using
minitest 5 introduces an error, so we should lock to 4.x for the time
being.

See: https://github.com/seattlerb/minitest/issues/283
