### PR TITLE
Ensure rake integration is enabled when rescue_rake_exceptions is true

### DIFF
--- a/lib/airbrake/configuration.rb
+++ b/lib/airbrake/configuration.rb
@@ -302,6 +302,13 @@ module Airbrake
         use_default_or_this
     end
 
+    def rescue_rake_exceptions=(val)
+      if val && !defined?(Airbrake::RakeHandler)
+        raise LoadError, "you must require 'airbrake/rake_handler' to rescue from rake exceptions"
+      end
+      @rescue_rake_exceptions = val
+    end
+
     def js_api_key
       @js_api_key || self.api_key
     end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -40,6 +40,11 @@ class ConfigurationTest < Test::Unit::TestCase
     assert config.async.respond_to?(:call)
   end
 
+  should "raise error for rake integration if rake handler isn't loaded" do
+    config = Airbrake::Configuration.new
+    assert_raises(LoadError) { config.rescue_rake_exceptions = true }
+  end
+
   should "set provided-callable for async {}" do
     config = Airbrake::Configuration.new
     config.async {|notice| :ok}


### PR DESCRIPTION
An LoadError exception is now raised when the client is configured to
rescue from rake exceptions and airbrake/rake_handler has not been
loaded.

Fixes #292
