### PR TITLE
Fix: rake task wasn't being called with current environment.

### DIFF
--- a/lib/airbrake/tasks/airbrake.cap
+++ b/lib/airbrake/tasks/airbrake.cap
@@ -17,8 +17,10 @@ namespace :airbrake do
       info "Notifying Airbrake of Deploy (#{notify_command})"
       result = ""
       within release_path do
-        execute :rake, notify_command, :once => true do |ch, stream, data| 
-          result << data
+        with rails_env: rails_env do
+          execute :rake, notify_command, :once => true do |ch, stream, data|
+            result << data
+          end
         end
       end
       # TODO: Check if SSL is active on account via result content.


### PR DESCRIPTION
It's important to execute the remote rake task in the correct environment.

I had to update this for my own application as I haven't defined database settings for `development` environment in the server. As no database settings couldn't be loaded, the whole rake task was failing.

To reproduce this problem:
1. Remove `development` environment from `database.yml` in remote server.
2. Run `cap production airbrake:deploy`.
