### PR TITLE
Fix for monkeypatched String#to_hash

### DIFF
--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -168,7 +168,9 @@ module Airbrake
     def build_notice_for(exception, opts = {})
       exception = unwrap_exception(exception)
       opts = opts.merge(:exception => exception) if exception.is_a?(Exception)
-      opts = opts.merge(exception.to_hash) if exception.respond_to?(:to_hash)
+      if exception.respond_to?(:to_hash) && !exception.is_a?(String)
+        opts = opts.merge(exception.to_hash)
+      end
       Notice.new(configuration.merge(opts))
     end
 

--- a/lib/airbrake/notice.rb
+++ b/lib/airbrake/notice.rb
@@ -130,7 +130,7 @@ module Airbrake
       also_use_rack_params_filters
       find_session_data
 
-      @cleaner = args[:cleaner] || 
+      @cleaner = args[:cleaner] ||
         Airbrake::Utils::ParamsCleaner.new(:filters => params_filters,
                                            :to_clean => data_to_clean)
 
@@ -336,7 +336,7 @@ module Airbrake
 
     def xml_vars_for(builder, hash)
       hash.each do |key, value|
-        if value.respond_to?(:to_hash)
+        if value.respond_to?(:to_hash) && !value.is_a?(String)
           builder.var(:key => key){|b| xml_vars_for(b, value.to_hash) }
         else
           builder.var(value.to_s, :key => key)

--- a/lib/airbrake/rails/controller_methods.rb
+++ b/lib/airbrake/rails/controller_methods.rb
@@ -62,7 +62,7 @@ module Airbrake
 
       def airbrake_session_data
         if session
-          if session.respond_to?(:to_hash)
+          if session.respond_to?(:to_hash) && !session.is_a?(String)
             session.to_hash
           else
             session.data

--- a/lib/airbrake/utils/params_cleaner.rb
+++ b/lib/airbrake/utils/params_cleaner.rb
@@ -5,7 +5,7 @@ module Airbrake
       attr_reader :parameters, :cgi_data, :session_data
 
       # Public: Initialize a new Airbrake::Utils::ParamsCleaner
-      #   
+      #
       # opts - The Hash options that contain filters and params (default: {}):
       #        :filters - The Array of param keys that should be filtered
       #        :to_clean - The Hash of unfiltered params
@@ -13,7 +13,7 @@ module Airbrake
         @filters     = opts[:filters] || {}
         @to_clean    = opts[:to_clean]
       end
-      
+
       # Public: Takes the params to_clean passed in an initializer
       #         and filters them out by filters passed.
       #
@@ -23,7 +23,7 @@ module Airbrake
       # could be extracted
       def clean
         clean_parameters
-        clean_session_data 
+        clean_session_data
         clean_cgi_data
         clean_rack_request_data
 
@@ -78,7 +78,7 @@ module Airbrake
           hash.each do |key, value|
             if filter_key?(key, @filters)
               hash[key] = "[FILTERED]"
-            elsif value.respond_to?(:to_hash)
+            elsif value.respond_to?(:to_hash) && !value.is_a?(String)
               filter(hash[key])
             end
           end
@@ -89,7 +89,7 @@ module Airbrake
         def clean_unserializable_data(data, stack = [])
           return "[possible infinite recursion halted]" if stack.any?{|item| item == data.object_id }
 
-          if data.respond_to?(:to_hash)
+          if data.respond_to?(:to_hash) && !data.is_a?(String)
             data.to_hash.inject({}) do |result, (key, value)|
               result.merge(key => clean_unserializable_data(value, stack + [data.object_id]))
             end


### PR DESCRIPTION
If one has a `String#to_hash` defined then all of the strings in
parameters, environments and such turn to hashes (depending on the
method), but might look something like `{ "foo" => { "bar" => nil } }`
instead of `{ "foo" => "bar" }`. This fixes that. Not the DRYest
solution and not sure if everyone wants to support things like that, but
does the job.
