### PR TITLE
Add missing RAILS_ENV to the deploy notification task for Capistrano 3

### DIFF
--- a/lib/airbrake/tasks/airbrake.cap
+++ b/lib/airbrake/tasks/airbrake.cap
@@ -12,7 +12,7 @@ namespace :airbrake do
       current_revision = capture("cd #{repo_path} && git rev-parse HEAD")
       repository = ENV['REPO'] || ENV['REPONAME']
 
-      notify_command = "airbrake:deploy TO=#{airbrake_env} REVISION=#{current_revision} REPO=#{repo_url} USER=#{Airbrake::Capistrano::shellescape(local_user)}"
+      notify_command = "RAILS_ENV=#{rails_env} airbrake:deploy TO=#{airbrake_env} REVISION=#{current_revision} REPO=#{repo_url} USER=#{Airbrake::Capistrano::shellescape(local_user)}"
       notify_command << " API_KEY=#{ENV['API_KEY']}" if ENV['API_KEY']
       info "Notifying Airbrake of Deploy (#{notify_command})"
       result = ""


### PR DESCRIPTION
The `RAILS_ENV` environment variable is set in the `airbrake:deploy` task for Capistrano 3, but not added to the command. It cause the rake task to run in development environment.

This pull request adds it to the same position in the task for Capistrano 2.

Please have a look to see if this is an appropriate change. Thanks! :smile: 
