### PR TITLE
Add ability to filter arrays

### DIFF
--- a/lib/airbrake/utils/params_cleaner.rb
+++ b/lib/airbrake/utils/params_cleaner.rb
@@ -80,6 +80,10 @@ module Airbrake
               hash[key] = "[FILTERED]"
             elsif value.respond_to?(:to_hash)
               filter(hash[key])
+            elsif value.is_a?(Array)
+              hash[key] = value.inject(Array.new) do |result, item|
+                result.push(filter(item))
+              end
             end
           end
         end

--- a/test/params_cleaner_test.rb
+++ b/test/params_cleaner_test.rb
@@ -29,20 +29,27 @@ class ParamsCleanerTest < Test::Unit::TestCase
   end
 
   def assert_filters_hash(attribute)
-    filters  = ["abc", :def]
-    original = { 'abc' => "123", 'def' => "456", 'ghi' => "789", 'nested' => { 'abc' => '100' },
-      'something_with_abc' => 'match the entire string'}
-    filtered = { 'abc'    => "[FILTERED]",
-      'def'    => "[FILTERED]",
-      'something_with_abc' => "match the entire string",
-      'ghi'    => "789",
-      'nested' => { 'abc' => '[FILTERED]' } }
+    filters  = ['abc', :def]
+    original = {
+      'abc' => '123',
+      'def' => '456',
+      'ghi' => '789',
+      'something_with_abc' => 'match the entire string',
+      'nested_hash' => { 'abc' => '100', 'ghi' => '789' },
+      'nested_array' => [{ 'abc' => '100' }, { 'ghi' => '789' }]
+    }
+    filtered = {
+      'abc' => '[FILTERED]',
+      'def' => '[FILTERED]',
+      'ghi' => '789',
+      'something_with_abc' => 'match the entire string',
+      'nested_hash' => { 'abc' => '[FILTERED]', 'ghi' => '789' },
+      'nested_array' => [{ 'abc' => '[FILTERED]' }, { 'ghi' => '789' }]
+    }
 
-    clean_params = clean(:params_filters => filters,
-                    attribute => original)
+    clean_params = clean(:params_filters => filters, attribute => original)
 
-    assert_equal(filtered,
-                 clean_params.send(attribute))
+    assert_equal(filtered, clean_params.send(attribute))
   end
 
   should "should always remove a Rails application's secret token" do


### PR DESCRIPTION
It turned out that when you pass `Array` like this:

``` ruby
[{ foo: :bar }, { bar: :baz }]
```

as parameters, it doesn't get filtered event when keys `:foo` and `:bar` are added to `params_filters` list.

This PR fixes that issue.
