### PR TITLE
ignore empty strings in gempath.

### DIFF
--- a/lib/airbrake/configuration.rb
+++ b/lib/airbrake/configuration.rb
@@ -131,7 +131,7 @@ module Airbrake
       lambda { |line| line.gsub(/^\.\//, "") },
       lambda { |line|
         if defined?(Gem)
-          Gem.path.inject(line) do |l, path|
+          Gem.path.reject(&:empty?).inject(line) do |l, path|
             l.gsub(/#{path}/, "[GEM_ROOT]")
           end
         end


### PR DESCRIPTION
This is a fix for an issue that happens when running rails with spring (see https://github.com/rails/spring/issues/310). For some reason Gem.path contains an empty string, which causes the default backtrace filter to behave incorrectly. With this change, empty strings in Gem.path are ignored.