### PR TITLE
Add support for java exceptions in jruby.

### DIFF
--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -174,7 +174,16 @@ module Airbrake
       exception = unwrap_exception(exception)
       opts = opts.merge(:exception => exception) if exception.is_a?(Exception)
       opts = opts.merge(exception.to_hash) if exception.respond_to?(:to_hash)
-      Notice.new(configuration.merge(opts))
+      is_java_exception = RUBY_PLATFORM == 'java' && e.kind_of?(java.lang.Throwable)
+      opts = opts.merge(:exception => exception) if is_java_exception
+      notice = Notice.new(configuration.merge(opts))
+      if is_java_exception
+        lines = e.stack_trace.map do |element|
+          Airbrake::Backtrace::element.new(element.file_name, element.line_number, "#{element.class_name}.#{element.method_name}")
+        end
+        notice.backtrace.lines.replace(lines)
+      end
+      notice
     end
 
     def unwrap_exception(exception)


### PR DESCRIPTION
## Problem

In jruby, if a java exception is raised, then none of the exception information will be included, since Airbrake.build_notice_for checks for `if exception.is_a?(Exception)` which returns `false` for a java.lang.Exception.

jruby has java extensions to make java.lang.Exception behave as a ruby Exception, but the backtrace doesn't use the same format, so `Airbrake::Notice.new(Airbrake.configuration.merge(exception: java_exception))` will pick up the error class and message, but all the fields in the backtrace will be blank.

## Solution

This is a proof of concept for creating an Airbrake::Notice from a java exception.

Is there any interest in having jruby specific code in the airbrake gem?  Or are all jruby users expected to build an Airbrake::Notice in this way like this in their application code?

The code could probably be made cleaner, by allowing a Airbrake::Backtrace to be provided as an option to Airbrake::Notice.new.