### PR TITLE
Adds airbrake_stages and airbrake_role configurations.

### DIFF
--- a/lib/airbrake/tasks/airbrake.cap
+++ b/lib/airbrake/tasks/airbrake.cap
@@ -11,7 +11,7 @@ namespace :airbrake do
       - Run remotely so we use remote API keys, environment, etc.
   DESC
   task :deploy do
-    if fetch(:airbrake_stages).nil? || fetch(:airbrake_stages).include? fetch(:stage)
+    if fetch(:airbrake_stages).nil? || fetch(:airbrake_stages).include?(fetch(:stage))
       # update scm state to get the repository information
       invoke "#{scm}:update"
       on roles(fetch(:airbrake_role)) do

--- a/lib/airbrake/tasks/airbrake.cap
+++ b/lib/airbrake/tasks/airbrake.cap
@@ -1,7 +1,7 @@
 namespace :defaults do
   task :load do
     set :airbrake_role, :app
-    set :airbrake_stages, [:production]
+    set :airbrake_stages, nil
   end
 end
 
@@ -11,7 +11,7 @@ namespace :airbrake do
       - Run remotely so we use remote API keys, environment, etc.
   DESC
   task :deploy do
-    if fetch(:airbrake_stages).to_a.include? fetch(:stage)
+    if fetch(:airbrake_stages).nil? || fetch(:airbrake_stages).include? fetch(:stage)
       # update scm state to get the repository information
       invoke "#{scm}:update"
       on roles(fetch(:airbrake_role)) do

--- a/lib/airbrake/tasks/airbrake.cap
+++ b/lib/airbrake/tasks/airbrake.cap
@@ -1,27 +1,36 @@
+namespace :defaults do
+  task :load do
+    set :airbrake_role, :app
+    set :airbrake_stages, [:production]
+  end
+end
+
 namespace :airbrake do
   desc <<-DESC
     Notify Airbrake of the deployment by running the notification on the REMOTE machine.
       - Run remotely so we use remote API keys, environment, etc.
   DESC
   task :deploy do
-    # update scm state to get the repository information
-    invoke "#{scm}:update"
-    on roles(:app) do
-      within release_path do
-        # XXX: Invoking deploy:set_rails_env would set :rails_env to proper
-        # value, but that would make us depend on capistrano-rails
-        with rails_env: fetch(:rails_env, fetch(:stage)) do
-          # Compose the command notify_command
-          airbrake_env = fetch(:airbrake_env, fetch(:rails_env, fetch(:stage)))
-          notify_command = "airbrake:deploy"
-          notify_command << " TO=#{airbrake_env}"
-          notify_command << " REVISION=#{fetch(:current_revision)} REPO=#{fetch(:repo_url)}"
-          notify_command << " USER=#{local_user.strip.shellescape}"
-          notify_command << " API_KEY=#{ENV['API_KEY']}" if ENV['API_KEY']
-
-          info "Notifying Airbrake of Deploy (#{notify_command})"
-          execute :rake, notify_command
-          info "Airbrake Notification Complete."
+    if fetch(:airbrake_stages).to_a.include? fetch(:stage)
+      # update scm state to get the repository information
+      invoke "#{scm}:update"
+      on roles(fetch(:airbrake_role)) do
+        within release_path do
+          # XXX: Invoking deploy:set_rails_env would set :rails_env to proper
+          # value, but that would make us depend on capistrano-rails
+          with rails_env: fetch(:rails_env, fetch(:stage)) do
+            # Compose the command notify_command
+            airbrake_env = fetch(:airbrake_env, fetch(:rails_env, fetch(:stage)))
+            notify_command = "airbrake:deploy"
+            notify_command << " TO=#{airbrake_env}"
+            notify_command << " REVISION=#{fetch(:current_revision)} REPO=#{fetch(:repo_url)}"
+            notify_command << " USER=#{local_user.strip.shellescape}"
+            notify_command << " API_KEY=#{ENV['API_KEY']}" if ENV['API_KEY']
+  
+            info "Notifying Airbrake of Deploy (#{notify_command})"
+            execute :rake, notify_command
+            info "Airbrake Notification Complete."
+          end
         end
       end
     end


### PR DESCRIPTION
In an environment I'm working in we have multiple app servers and use multiple stages (dev, staging,  production). We really only want Airbrake to run notifications in when we deploy to production and only on one server (not for every app server) per deploy. I imagine other people would benefit from these capabilities as well.

I believe the way I have written these changes basic usage of Airbrake Capistrano v3 integration will operate exactly as it does now. In other words it is not necessary to configure any of these options, it will just work with the defaults. I have attempted to merely add further ability to limit when and how much Airbrake will be applied :)

I'll happily contribute further by updating the relevant documentation if my pull request is accepted.