### PR TITLE
allow `:params` in `Notify#initialize`

### DIFF
--- a/lib/airbrake/notice.rb
+++ b/lib/airbrake/notice.rb
@@ -109,6 +109,7 @@ module Airbrake
       @backtrace_filters   = args[:backtrace_filters]   || []
       @params_filters      = args[:params_filters]      || []
       @parameters          = args[:parameters] ||
+                                   args[:params] ||
                                    action_dispatch_params ||
                                    rack_env(:params) ||
                                    {}


### PR DESCRIPTION
Allows usage like:

```
Airbrake.notify_or_ignore e, params: { ... }
```

As opposed to:

```
Airbrake.notify_or_ignore e, parameters: { ... }
```

The former is a much more common idiom, especially in Rails projects.
