### PR TITLE
Speed up notice generation by avoiding copying data and putting most common cases on top

### DIFF
--- a/lib/airbrake/configuration.rb
+++ b/lib/airbrake/configuration.rb
@@ -259,7 +259,7 @@ module Airbrake
     # Determines if the notifier will send notices.
     # @return [Boolean] Returns +false+ if in a development environment, +true+ otherwise.
     def public?
-      !development_environments.include?(environment_name)
+      @public ||= !development_environments.include?(environment_name)
     end
 
     def port

--- a/test/notice_test.rb
+++ b/test/notice_test.rb
@@ -408,7 +408,7 @@ class NoticeTest < Test::Unit::TestCase
 
   should "ensure #to_ary is called on objects that support it" do
     assert_nothing_raised do
-      build_notice(:session => { :object => stub(:to_ary => {}) })
+      build_notice(:session => { :object => stub(:to_ary => []) })
     end
   end
 


### PR DESCRIPTION
The speed up is quite substantial, 5-7 times faster.
