### PR TITLE
fix having symbols in the environment blows up filter_parameters with blocks

### DIFF
--- a/features/step_definitions/rails_application_steps.rb
+++ b/features/step_definitions/rails_application_steps.rb
@@ -184,8 +184,8 @@ When /^I configure the application to filter parameter "([^\"]*)"$/ do |paramete
   application_definition_line       = application_lines.detect { |line| line =~ /Application/ }
   application_definition_line_index = application_lines.index(application_definition_line)
 
-  application_lines.insert(application_definition_line_index + 1,
-                           "    config.filter_parameters += [#{parameter.inspect}]")
+  parameter = (parameter == "block" ? "lambda { |x,y| x }" : parameter.inspect)
+  application_lines.insert(application_definition_line_index + 1, "    config.filter_parameters += [#{parameter}]")
 
   File.open(application_filename, "w") do |file|
     file.puts application_lines.join("\n")

--- a/lib/airbrake/rails/controller_methods.rb
+++ b/lib/airbrake/rails/controller_methods.rb
@@ -58,7 +58,13 @@ module Airbrake
       def filter_rails3_parameters(hash)
         ActionDispatch::Http::ParameterFilter.new(
           ::Rails.application.config.filter_parameters
-        ).filter(hash)
+        ).filter(recursive_stringify_keys(hash))
+      end
+
+      def recursive_stringify_keys(hash)
+        hash = hash.stringify_keys
+        hash.each {|k,v| hash[k] = recursive_stringify_keys(v) if v.is_a?(Hash) && v.respond_to?(:stringify_keys) } # Rack::Session::Abstract::SessionHash has a stringify_keys method we should not call
+        hash
       end
 
       def airbrake_session_data


### PR DESCRIPTION
fixes https://github.com/airbrake/airbrake/issues/315

```
TypeError (can't dup Symbol):
  actionpack (3.2.19) lib/action_dispatch/http/parameter_filter.rb:42:in `dup'
  actionpack (3.2.19) lib/action_dispatch/http/parameter_filter.rb:42:in `block (2 levels) in compiled_filter'
  actionpack (3.2.19) lib/action_dispatch/http/parameter_filter.rb:32:in `each'
  actionpack (3.2.19) lib/action_dispatch/http/parameter_filter.rb:32:in `block in compi
```

I tried making a test for this but could not .... this cucumber setup is super messy and unit-tests don't have rails :/

```
+  Scenario: Filtering vs symbols
+    When I configure the Airbrake shim
+    And I run `rails generate airbrake -k myapikey -t`
+    When I configure the notifier to use the following configuration lines:
+    """
+      config.api_key = "myapikey"
+      config.logger = Logger.new STDOUT
+      """
+    And I configure the application to filter parameter "block"
+    And I define a response for "TestController#index":
+    """
+      request.env["foo"] = {:foo => "bar"}
+      raise RuntimeError, "some message"
+      """
+    And I route "/test/index" to "test#index"
+    And I perform a request to "http://example.com:123/test/index" in the "production" environment
+    Then I should receive a Airbrake notification
+    And the Airbrake notification should not contain "dup"

+  parameter = (parameter == "block" ? "lambda { |x| x }" : parameter.inspect)
+  application_lines.insert(application_definition_line_index + 1, "    config.filter_parameters += [#{parameter}]")
```

Monkeypatch:

``` Ruby
# https://github.com/airbrake/airbrake/pull/328
require 'airbrake/rails/controller_methods'
Airbrake::Rails::ControllerMethods.class_eval do
  def filter_rails3_parameters(hash)
    ActionDispatch::Http::ParameterFilter.new(
      ::Rails.application.config.filter_parameters).filter(recursive_stringify_keys(hash))
  end

  def recursive_stringify_keys(hash)
    hash = hash.stringify_keys
    hash.each {|k,v| hash[k] = recursive_stringify_keys(v) if v.is_a?(Hash) && v.respond_to?(:stringify_keys) } # Rack::Session::Abstract::SessionHash has a private/broken stringify_keys we cannot not use
    hash
  end
end
```
