### PR TITLE
Remove indents created by generator automatically

### DIFF
--- a/lib/rails/generators/airbrake/airbrake_generator.rb
+++ b/lib/rails/generators/airbrake/airbrake_generator.rb
@@ -51,8 +51,8 @@ class AirbrakeGenerator < Rails::Generators::Base
     if File.exists?('config/deploy.rb') && File.exists?('Capfile')
       append_file('config/deploy.rb', <<-HOOK)
 
-        require './config/boot'
-        require 'airbrake/capistrano'
+require './config/boot'
+require 'airbrake/capistrano'
       HOOK
     end
   end


### PR DESCRIPTION
So far, the lines inserted by generator have been indented like the
following lines. I think it is wrong.

```
        require './config/boot'
        require 'airbrake/capistrano'
```