### PR TITLE
Expose configuration settings to set api version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ Then from your project's RAILS_ROOT, and in your development environment, run:
 
 The generator creates a file under `config/initializers/airbrake.rb` configuring Airbrake with your API key. This file should be checked into your version control system so that it is deployed to your staging and production environments.
 
+#### Enabling the v3 JSON api
+
+Airbrake provides two APIs for notifiers to submit notices. The classic API, currently at v2.4, uses XML docs to transmit errors to airbrake. This is the default API.
+To enable the JSON-based v3 of the API, add the following in the config block of your Airbrake configuration (`config/initializers/airbrake.rb`):
+
+    config.api_version = 3
+    config.project_id = <YOUR AIRBRAKE PROJECT ID>
+
 ### Rails 2.x
 
 Add the airbrake gem to your app. In config/environment.rb:
@@ -136,7 +144,7 @@ Credits
 
 ![thoughtbot](https://secure.gravatar.com/avatar/a95a04df2dae60397c38c9bd04492c53)
 
-Airbrake is maintained and funded by [airbrake.io](http://airbrake.io).
+Airbrake is maintained and funded by [airbrake.io](https://airbrake.io).
 
 Thank you to all [the contributors](https://github.com/airbrake/airbrake/contributors)!
 
@@ -145,4 +153,4 @@ The names and logos for Airbrake, thoughtbot are trademarks of their respective 
 License
 -------
 
-Airbrake is Copyright © 2008-2013 Airbrake.
+Airbrake is Copyright © 2008-2014 Airbrake.

--- a/lib/airbrake/configuration.rb
+++ b/lib/airbrake/configuration.rb
@@ -9,7 +9,12 @@ module Airbrake
         :params_filters, :project_root, :port, :protocol, :proxy_host,
         :proxy_pass, :proxy_port, :proxy_user, :secure, :use_system_ssl_cert_chain,
         :framework, :user_information, :rescue_rake_exceptions, :rake_environment_filters,
-        :test_mode].freeze
+        :test_mode, :api_version].freeze
+
+    # The Airbrake API version to use. Defaults to 2.4, which is XML based.
+    # Version 3 (current) is JSON based; when using this version the :project_id
+    # must be set.
+    attr_accessor :api_version
 
     # The API key for your project, found on the project edit form.
     attr_accessor :api_key
@@ -157,6 +162,7 @@ module Airbrake
       @use_system_ssl_cert_chain= false
       @host                     = 'api.airbrake.io'
       @port                     = nil
+      @api_version              = Airbrake::API_VERSION.to_f
       @http_open_timeout        = 2
       @http_read_timeout        = 5
       @params_filters           = DEFAULT_PARAMS_FILTERS.dup

--- a/lib/airbrake/sender.rb
+++ b/lib/airbrake/sender.rb
@@ -173,8 +173,7 @@ module Airbrake
     end
 
     def json_api_enabled?
-      !!(host =~ /collect.airbrake.io/) &&
-        project_id =~ /\S/
+      Airbrake.configuration.api_version > 2.4 && project_id =~ /\S/
     end
   end
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -32,6 +32,7 @@ class ConfigurationTest < Test::Unit::TestCase
     assert_config_default :framework, 'Standalone'
     assert_config_default :async, nil
     assert_config_default :project_id, nil
+    assert_config_default :api_version, 2.4
   end
 
   should "set GirlFriday/SuckerPunch-callable for async=true" do
@@ -93,6 +94,7 @@ class ConfigurationTest < Test::Unit::TestCase
     assert_config_overridable :logger
     assert_config_overridable :async
     assert_config_overridable :project_id
+    assert_config_overridable :api_version
     assert_config_overridable :params_filters
   end
 
@@ -108,7 +110,7 @@ class ConfigurationTest < Test::Unit::TestCase
      :http_read_timeout, :ignore, :ignore_by_filters, :ignore_user_agent,
      :notifier_name, :notifier_url, :notifier_version, :params_filters,
      :project_root, :port, :protocol, :proxy_host, :proxy_pass, :proxy_port,
-     :proxy_user, :secure, :development_lookup, :async].each do |option|
+     :proxy_user, :secure, :development_lookup, :async, :api_version].each do |option|
       assert_equal config[option], hash[option], "Wrong value for #{option}"
     end
   end

--- a/test/sender_test.rb
+++ b/test/sender_test.rb
@@ -101,7 +101,7 @@ class SenderTest < Test::Unit::TestCase
 
       http = stub_http
 
-      sender = build_sender(:project_id => "PROJECT_ID", :host => "collect.airbrake.io")
+      sender = build_sender(:api_version => 3, :project_id => "PROJECT_ID")
       sender.send_to_airbrake(json_notice)
 
       assert_received(http, :post) do |expect|
@@ -115,7 +115,7 @@ class SenderTest < Test::Unit::TestCase
 
       http = stub_http
 
-      sender = build_sender(:project_id => "PROJECT_ID", :host => "collect.airbrake.io")
+      sender = build_sender(:api_version => 3, :project_id => "PROJECT_ID")
       sender.send_to_airbrake(notice)
 
       assert_received(http, :post) do |expect|


### PR DESCRIPTION
This PR exposes a way for users to pick the Airbrake API version to use to submit errors. The default is maintained to the old 2.4 XML-based api. This default will change to use v3 in a near future.