### PR TITLE
If we cannot stringify then at least rescue the dup exceptions ...

### DIFF
--- a/lib/airbrake/rails/controller_methods.rb
+++ b/lib/airbrake/rails/controller_methods.rb
@@ -63,7 +63,11 @@ module Airbrake
 
       def recursive_stringify_keys(hash)
         hash = hash.stringify_keys
-        hash.each {|k,v| hash[k] = recursive_stringify_keys(v) if v.is_a?(Hash) && v.respond_to?(:stringify_keys) } # Rack::Session::Abstract::SessionHash has a stringify_keys method we should not call
+        hash.each do |k, v|
+          if v.is_a?(Hash)
+            hash[k] = v.respond_to?(:stringify_keys) ? recursive_stringify_keys(v) : nil # Rack::Session::Abstract::SessionHash has a stringify_keys method we should not call
+          end
+        end
         hash
       end
 


### PR DESCRIPTION
followup to https://github.com/airbrake/airbrake/pull/328

now I ran into a Rack::Session::Abstract::SessionHash with symbol keys -> kaboom again ...

@shifi @dvdplm
