### PR TITLE
Allowed custom exceptions to provide more context to Airbrake

### DIFF
--- a/lib/airbrake/notice.rb
+++ b/lib/airbrake/notice.rb
@@ -112,6 +112,7 @@ module Airbrake
                                    action_dispatch_params ||
                                    rack_env(:params) ||
                                    {}
+      @parameters          = parameters.merge(exception.airbrake_parameters) if exception.respond_to?(:airbrake_parameters)
       @component           = args[:component] || args[:controller] || parameters['controller']
       @action              = args[:action] || parameters['action']
 

--- a/test/notice_test.rb
+++ b/test/notice_test.rb
@@ -129,6 +129,26 @@ class NoticeTest < Test::Unit::TestCase
                  "backtrace was not correctly set from a hash"
   end
 
+  should "accept parameters from an exception" do
+    exception = build_exception
+    def exception.airbrake_parameters
+      {:extra_context => "for Airbrake"}
+    end
+    notice_from_exception = build_notice(:exception => exception)
+
+    assert_equal "for Airbrake", notice_from_exception.parameters[:extra_context]
+  end
+
+  should "merge parameters from an exception with those from a hash" do
+    exception = build_exception
+    def exception.airbrake_parameters
+      {"one" => 1}
+    end
+    notice_from_exception = build_notice(:exception => exception, :parameters => {"two" => 2})
+
+    assert_equal %w{one two}, notice_from_exception.parameters.keys.sort
+  end
+
   should "accept user" do
     assert_equal user.id, build_notice(:user => user).user.id
     assert_equal user.email, build_notice(:user => user).user.email


### PR DESCRIPTION
#### The problem I'm having

The Airbrake gem allows you to set parameters when you notify of an exception (`Airbrake.notify($!, parameters: {})`); but I often call `Airbrake.notify` several frames away from the method that is raising the exception (particularly when the exception is I/O related) — and it would be useful to provide additional context.

I could move calls to `Airbrake.notify` to lower-level sections of code; but this has two drawbacks:

 1. More calls to `Airbrake.notify` are scattered throughout the codebase. (It's harder to call that—and configure it as—a generic policy.)
 2. Frames _between_ the one raising the exception and the one notifying Airbrake can no longer rescue from specific exceptions and recover.

#### This proposed solution

It would be ideal if I could add more information to an exception at its source (or even progressively attach context to it as it works its way up the stack!) and to report all that to Airbrake.

In this Pull Request, new notices merge the result of `exception.airbrake_parameters` into `Notice#parameters` if `exception` responds to `airbrake_parameters`.

#### Example of using it

This, of course, lets exceptions provide additional context to Airbrake; and it seems to me that it should be easy to implement by users of the gem with modules:

```ruby
module SuppliesHttpResponseToAirbrake
  def airbrake_parameters
    {request_method: request.method, request_url: request.url, response_code: status}
  end
end

# ...

def a_method_that_makes_a_web_request
  # ...
rescue HTTP::ServerError => exception
  exception.extend SuppliesHttpResponseToAirbrake
  raise exception
end
```