### PR TITLE
Assumption of existence of :app role may not be valid

### DIFF
--- a/lib/airbrake/tasks/airbrake.cap
+++ b/lib/airbrake/tasks/airbrake.cap
@@ -6,7 +6,7 @@ namespace :airbrake do
   task :deploy do
     # update scm state to get the repository information
     invoke "#{scm}:update"
-    on roles(:app) do
+    on roles(:all) do
       within release_path do
         # XXX: Invoking deploy:set_rails_env would set :rails_env to proper
         # value, but that would make us depend on capistrano-rails


### PR DESCRIPTION
I was setting up a new deployment in cap3 after migrating from cap2.  I did not have an :app role defined for my stages, only :web and :db.  This caused the airbrake notification not to happen.  I recommend that this be changed to :all role to keep that from happening.

Looking at the file history, this is actually how it used to be defined.  Was this changed to :app for any reason?