### PR TITLE
fix bug: rails request.fullpath behavior change in 4.1.6 -- no longer has leading /

### DIFF
--- a/lib/airbrake/rails/controller_methods.rb
+++ b/lib/airbrake/rails/controller_methods.rb
@@ -90,8 +90,7 @@ module Airbrake
           url << ":#{request.port}"
         end
 
-        url << request.fullpath
-        url
+        URI.join(url, request.fullpath).to_s
       end
 
       def airbrake_current_user


### PR DESCRIPTION
According to the issue: https://github.com/rails/rails/issues/16926

When rails version > 4.1.6, request.fullpath no longer has leading /, which will break Airbrake::Rails::ControllerMethods#airbrake_request_url, so make the code support those two cases.