### PR TITLE
require rake

### DIFF
--- a/lib/airbrake/rake_handler.rb
+++ b/lib/airbrake/rake_handler.rb
@@ -68,6 +68,7 @@ module Airbrake::RakeHandler
   end
 end
 
+require 'rake'
 Rake.application.instance_eval do
   class << self
     include Airbrake::RakeHandler


### PR DESCRIPTION
fixes #361 

I'm not 100% sure but `airbrake/rake_handler` seems to be loaded before `rake` is required by Rails in some way.