### PR TITLE
Fix DEFAULT_BACKTRACE_FILTERS bug that caused backtrace to not show up i...

### DIFF
--- a/lib/airbrake/configuration.rb
+++ b/lib/airbrake/configuration.rb
@@ -130,11 +130,8 @@ module Airbrake
       },
       lambda { |line| line.gsub(/^\.\//, "") },
       lambda { |line|
-        if defined?(Gem)
-          Gem.path.inject(line) do |l, path|
-            l.gsub(/#{path}/, "[GEM_ROOT]")
-          end
-        end
+        Gem.path.each{ |path| line.sub!(/#{path}/, "[GEM_ROOT]") unless path.to_s.strip.empty? } if defined?(Gem) 
+        line
       },
       lambda { |line| line if line !~ %r{lib/airbrake} }
     ].freeze


### PR DESCRIPTION
This commit fixes a bug in DEFAULT_BACKTRACE_FILTERS which sometimes resulted in the backtrace to display as :0:in.

See https://github.com/airbrake/airbrake/issues/343.