### PR TITLE
Improves documentation for notify method

### DIFF
--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -127,6 +127,7 @@ module Airbrake
     # @option opts [String] :rack_env The Rack environment.
     # @option opts [String] :session The contents of the user's session.
     # @option opts [String] :environment_name The application environment name.
+    # @option opts [String] :parameters Additional parameters.
     def notify(exception, opts = {})
       send_notice(build_notice_for(exception, opts))
     end


### PR DESCRIPTION
I wanted to pass additional context about errors and tried to search documentation.
Looking at Airbrake#notify method seems like it doesn't accept parameters:

https://github.com/airbrake/airbrake/blob/master/lib/airbrake.rb#L130

Comments above don't mention parameters hash.
But digging deeper I found:

https://github.com/airbrake/airbrake/blob/master/lib/airbrake/notice.rb#L111

Indeed it works. This pull request is attempt to improve `notify` method documentation.