### PR TITLE
Support Rails 4 without ActiveRecord

### DIFF
--- a/lib/airbrake/rails/controller_methods.rb
+++ b/lib/airbrake/rails/controller_methods.rb
@@ -115,7 +115,7 @@ module Airbrake
       ensure
         # The Airbrake middleware is first in the chain, before ActiveRecord::ConnectionAdapters::ConnectionManagement
         # kicks in to do its thing. This can cause the connection pool to run out of connections.
-        if defined?(ActiveRecord) && ActiveRecord::Base.respond_to?(:connection_pool)
+        if defined?(ActiveRecord::Base) && ActiveRecord::Base.respond_to?(:connection_pool)
           ActiveRecord::Base.connection_pool.release_connection
         end
       end


### PR DESCRIPTION
In some Rails 4 configurations, `ActiveRecord` is defined, but `ActiveRecord::Base` is not.