### PR TITLE
Insert Airbrake Rails Middleware after Better Errors Middleware

### DIFF
--- a/lib/airbrake/railtie.rb
+++ b/lib/airbrake/railtie.rb
@@ -12,13 +12,16 @@ module Airbrake
 
     initializer "airbrake.middleware" do |app|
 
-      middleware = if defined?(ActionDispatch::DebugExceptions)
-        # Rails >= 3.2.0
-        "ActionDispatch::DebugExceptions"
-      else
-        # Rails < 3.2.0
-        "ActionDispatch::ShowExceptions"
-      end
+      middleware =
+        if !::Rails.env.production? && defined?(::BetterErrors::Middleware)
+          "BetterErrors::Middleware"
+        elsif defined?(::ActionDispatch::DebugExceptions)
+          # Rails >= 3.2.0
+          "ActionDispatch::DebugExceptions"
+        else
+          # Rails < 3.2.0
+          "ActionDispatch::ShowExceptions"
+        end
 
       app.config.middleware.insert_after middleware,
         "Airbrake::Rails::Middleware"


### PR DESCRIPTION
Insert Airbrake Rails Middleware after Better Errors Middleware if Better Errors Middleware defined.

This will work when `airbrake` gem is loaded after `better_errors` gem:
https://gist.github.com/shifi/0e4b30554d1bbce7e808

It will not work if `airbrake` gem is loaded before `better_errors` gem:
https://gist.github.com/shifi/ead7c6a5ede5b943abb2

- [ ] If we decide to go with this solution, add note in readme how to order gems/middlewares

**Note** Placing `airbrake` gem after `better_errors` gem doesn't have to give the same middleware stack like mine, it depends on many things
Example: for [this middleware](https://github.com/airbrake/airbrake/issues/347#issuecomment-108133583), `airbrake` gem is loaded before `better_errors` gem and it has different order than mine middleware