### PR TITLE
Make rack vars filters configurable

### DIFF
--- a/lib/airbrake/configuration.rb
+++ b/lib/airbrake/configuration.rb
@@ -6,9 +6,10 @@ module Airbrake
         :development_lookup, :environment_name, :host,
         :http_open_timeout, :http_read_timeout, :ignore, :ignore_by_filters,
         :ignore_user_agent, :notifier_name, :notifier_url, :notifier_version,
-        :params_filters, :params_whitelist_filters, :project_root, :port, :protocol, :proxy_host,
-        :proxy_pass, :proxy_port, :proxy_user, :secure, :use_system_ssl_cert_chain,
-        :framework, :user_information, :rescue_rake_exceptions, :rake_environment_filters,
+        :params_filters, :params_whitelist_filters, :rack_vars_filters,
+        :project_root, :port, :protocol, :proxy_host, :proxy_pass, :proxy_port,
+        :proxy_user, :secure, :use_system_ssl_cert_chain, :framework,
+        :user_information, :rescue_rake_exceptions, :rake_environment_filters,
         :test_mode].freeze
 
     # The API key for your project, found on the project edit form.
@@ -53,6 +54,10 @@ module Airbrake
     # All other parameters will be filtered and their content replaced.
     # By default this list is empty (all parameters are whitelisted).
     attr_accessor :params_whitelist_filters
+
+    # A list of rack vars that should be filtered out of what is sent to Airbrake.
+    # For default list see: Airbrake::FILTERED_RACK_VARS
+    attr_accessor :rack_vars_filters
 
     # A list of filters for cleaning and pruning the backtrace. See #filter_backtrace.
     attr_reader :backtrace_filters
@@ -122,6 +127,8 @@ module Airbrake
     DEFAULT_PARAMS_FILTERS  = %w(password password_confirmation).freeze
     DEFAULT_PARAMS_WHITELIST_FILTERS = [].freeze
 
+    DEFAULT_RACK_VARS_FILTERS = Airbrake::FILTERED_RACK_VARS.freeze
+
     DEFAULT_USER_ATTRIBUTES = %w(id).freeze
 
     VALID_USER_ATTRIBUTES   = %w(id name username email).freeze
@@ -164,6 +171,7 @@ module Airbrake
       @http_read_timeout        = 5
       @params_filters           = DEFAULT_PARAMS_FILTERS.dup
       @params_whitelist_filters = DEFAULT_PARAMS_WHITELIST_FILTERS.dup
+      @rack_vars_filters        = DEFAULT_RACK_VARS_FILTERS.dup
       @backtrace_filters        = DEFAULT_BACKTRACE_FILTERS.dup
       @ignore_by_filters        = []  # These filters are applied to both server requests and Rake tasks
       @ignore                   = IGNORE_DEFAULT.dup

--- a/lib/airbrake/notice.rb
+++ b/lib/airbrake/notice.rb
@@ -50,6 +50,9 @@ module Airbrake
     # See Configuration#params_whitelist_filters
     attr_reader :params_whitelist_filters
 
+    # See Configuration#rack_vars_filters
+    attr_reader :rack_vars_filters
+
     # A hash of parameters from the query string or post body.
     attr_reader :parameters
     alias_method :params, :parameters
@@ -112,6 +115,7 @@ module Airbrake
       @backtrace_filters        = args[:backtrace_filters]        || []
       @params_filters           = args[:params_filters]           || []
       @params_whitelist_filters = args[:params_whitelist_filters] || []
+      @rack_vars_filters        = args[:rack_vars_filters]        || []
 
       @parameters          = args[:parameters] ||
                                    action_dispatch_params ||
@@ -138,6 +142,7 @@ module Airbrake
       @cleaner = args[:cleaner] ||
         Airbrake::Utils::ParamsCleaner.new(:blacklist_filters => params_filters,
                                            :whitelist_filters => params_whitelist_filters,
+                                           :rack_vars_filters => rack_vars_filters,
                                            :to_clean => data_to_clean)
 
       clean_data!

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -27,6 +27,8 @@ class ConfigurationTest < Test::Unit::TestCase
                           Airbrake::Configuration::DEFAULT_PARAMS_WHITELIST_FILTERS
     assert_config_default :backtrace_filters,
                           Airbrake::Configuration::DEFAULT_BACKTRACE_FILTERS
+    assert_config_default :rack_vars_filters,
+                          Airbrake::Configuration::DEFAULT_RACK_VARS_FILTERS
     assert_config_default :rake_environment_filters, []
     assert_config_default :ignore,
                           Airbrake::Configuration::IGNORE_DEFAULT
@@ -127,6 +129,10 @@ class ConfigurationTest < Test::Unit::TestCase
 
   should "allow rake environment filters to be appended" do
     assert_appends_value :rake_environment_filters
+  end
+
+  should "allow rack vars filters to be appended" do
+    assert_appends_value :rack_vars_filters
   end
 
   should "allow ignored user agents to be appended" do

--- a/test/params_cleaner_test.rb
+++ b/test/params_cleaner_test.rb
@@ -5,6 +5,7 @@ class ParamsCleanerTest < Test::Unit::TestCase
   def clean(opts = {})
     cleaner = Airbrake::Utils::ParamsCleaner.new(:blacklist_filters  => opts.delete(:params_filters) || [],
                                                  :whitelist_filters  => opts.delete(:whitelist_params_filters) || [],
+                                                 :rack_vars_filters  => opts.delete(:rack_vars_filters) || [],
                                                  :to_clean => opts)
     cleaner.clean
   end
@@ -27,6 +28,30 @@ class ParamsCleanerTest < Test::Unit::TestCase
       assert_kind_of Array, hash[:array], "arrays should be kept"
       assert_equal object_serialized, hash[:array].first, "array members should be serialized"
     end
+  end
+
+  def sensitive_rack_vars
+    {
+      "HTTP_X_CSRF_TOKEN" => "remove_me",
+      "HTTP_COOKIE" => "remove_me",
+      "HTTP_AUTHORIZATION" => "remove_me",
+      "action_dispatch.request.unsigned_session_cookie" => "remove_me",
+      "action_dispatch.cookies" => "remove_me",
+      "action_dispatch.unsigned_session_cookie" => "remove_me",
+      "action_dispatch.secret_key_base" => "remove_me",
+      "action_dispatch.signed_cookie_salt" => "remove_me",
+      "action_dispatch.encrypted_cookie_salt" => "remove_me",
+      "action_dispatch.encrypted_signed_cookie_salt" => "remove_me",
+      "action_dispatch.http_auth_salt" => "remove_me",
+      "action_dispatch.secret_token" => "remove_me",
+      "rack.request.cookie_hash" => "remove_me",
+      "rack.request.cookie_string" => "remove_me",
+      "rack.request.form_vars" => "remove_me",
+      "rack.session" => "remove_me",
+      "rack.session.options" => "remove_me",
+      "rack.request.form_vars" => "story%5Btitle%5D=The+TODO+label",
+      "abc" => "123"
+    }
   end
 
   def assert_filters_hash(attribute)
@@ -53,50 +78,52 @@ class ParamsCleanerTest < Test::Unit::TestCase
     assert_equal(filtered, clean_params.send(attribute))
   end
 
-  should "should always remove a Rails application's secret token" do
+  should "should remove a Rails application's secret token by default" do
+    rack_vars_filters = Airbrake::Configuration::DEFAULT_RACK_VARS_FILTERS
     original = {
       "action_dispatch.secret_token" => "abc123xyz456",
       "abc" => "123"
     }
-    clean_params = clean(:cgi_data => original)
+    clean_params = clean(:cgi_data => original,
+                         :rack_vars_filters => rack_vars_filters)
     assert_equal({"abc" => "123"}, clean_params.cgi_data)
   end
 
-  should "remove sensitive rack vars" do
+  should "remove sensitive rack vars by default" do
+    rack_vars_filters = Airbrake::Configuration::DEFAULT_RACK_VARS_FILTERS
+    clean_params = clean(:cgi_data => sensitive_rack_vars,
+                         :rack_vars_filters => rack_vars_filters)
+    assert_equal({"abc" => "123"}, clean_params.cgi_data)
+  end
+
+  should "not remove sensitive rack vars if rack vars filters empty" do
+    clean_params = clean(:cgi_data => sensitive_rack_vars)
+    assert_equal(sensitive_rack_vars, clean_params.cgi_data)
+  end
+
+  should "respect configuration for rack vars filters" do
+    rack_vars_filters = [:foo, /bar/, 'remove_me']
     original = {
-      "HTTP_X_CSRF_TOKEN" => "remove_me",
-      "HTTP_COOKIE" => "remove_me",
-      "HTTP_AUTHORIZATION" => "remove_me",
-      "action_dispatch.request.unsigned_session_cookie" => "remove_me",
-      "action_dispatch.cookies" => "remove_me",
-      "action_dispatch.unsigned_session_cookie" => "remove_me",
-      "action_dispatch.secret_key_base" => "remove_me",
-      "action_dispatch.signed_cookie_salt" => "remove_me",
-      "action_dispatch.encrypted_cookie_salt" => "remove_me",
-      "action_dispatch.encrypted_signed_cookie_salt" => "remove_me",
-      "action_dispatch.http_auth_salt" => "remove_me",
-      "action_dispatch.secret_token" => "remove_me",
-      "rack.request.cookie_hash" => "remove_me",
-      "rack.request.cookie_string" => "remove_me",
-      "rack.request.form_vars" => "remove_me",
-      "rack.session" => "remove_me",
-      "rack.session.options" => "remove_me",
-      "rack.request.form_vars" => "story%5Btitle%5D=The+TODO+label",
-      "abc" => "123"
+      'foo' => 'foo',
+      'good_bar' => 'bar',
+      'remove_me' => "remove",
+      "keep_me" => "keep"
     }
-
-    clean_params = clean(:cgi_data => original)
-    assert_equal({"abc" => "123"}, clean_params.cgi_data)
+    clean_params = clean(:cgi_data => original,
+                         :rack_vars_filters => rack_vars_filters)
+    assert_equal({"keep_me" => "keep"}, clean_params.cgi_data)
   end
 
-  should "remove secrets from cgi_data" do
+  should "remove secrets from cgi_data by default" do
+    rack_vars_filters = Airbrake::Configuration::DEFAULT_RACK_VARS_FILTERS
     original = {
       "aws_secret_key"   => "secret",
       "service_password" => "password",
       "abc" => "123"
     }
 
-    clean_params = clean(:cgi_data => original)
+    clean_params = clean(:cgi_data => original,
+                         :rack_vars_filters => rack_vars_filters)
     assert_equal({"abc" => "123"}, clean_params.cgi_data)
   end
 


### PR DESCRIPTION
Make rack vars filters configurable so users can replace or append to [default list](https://github.com/airbrake/airbrake/blob/master/lib/airbrake/utils/rack_filters.rb).

GH issue: #284 

New docs are ready once we push new gem release.