### PR TITLE
Preventing Airbrake from collecting IO objects

### DIFF
--- a/lib/airbrake/utils/params_cleaner.rb
+++ b/lib/airbrake/utils/params_cleaner.rb
@@ -125,7 +125,7 @@ module Airbrake
             data.to_hash.inject({}) do |result, (key, value)|
               result.merge!(key => clean_unserializable_data(value, stack + [data.object_id]))
             end
-          elsif data.respond_to?(:collect) and !data.is_a?(IO)
+          elsif data.respond_to?(:collect) and !(data.is_a?(IO) || data.is_a?(File) || data.is_a?(Tempfile))
             data = data.collect do |value|
               clean_unserializable_data(value, stack + [data.object_id])
             end


### PR DESCRIPTION
It appears as though IO#collect attempts to close the object. This causes
mayhem in applications that leverage Airbrake. The problem I encountered
was that Airbrake was swallowing an underlying exception thrown during a
POST request that included an attachment.

These are ugly `is_a?` checks, I'd prefer to test behavior instead of
classification. Would `respond_to?(:readlines)` be acceptable? Working
with IO, File, and Tempfile is like playing whack-a-mole.

Closes #396