### PR TITLE
Fix notice in logs when running test

### DIFF
--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -167,7 +167,7 @@ module Airbrake
           sender.send_to_airbrake(notice)
         end
       else
-        report_notice_not_sent_for_configuration
+        report_notice_not_sent_for_configuration unless configuration.test_environment?
       end
     end
 

--- a/lib/airbrake/configuration.rb
+++ b/lib/airbrake/configuration.rb
@@ -270,6 +270,10 @@ module Airbrake
       @port || default_port
     end
 
+    def test_environment?
+      environment_name == 'test'
+    end
+
     # Determines whether protocol should be "http" or "https".
     # @return [String] Returns +"http"+ if you've set secure to +false+ in
     # configuration, and +"https"+ otherwise.


### PR DESCRIPTION
When using airbrake in background worker. I'm having report notice
inside my logs. It adds some noise.

Bug reported here :
https://github.com/airbrake/airbrake/issues/399
Original code
https://github.com/airbrake/airbrake/pull/295/files

Not sure it's properly written. Feedbacks welcome.