### PR TITLE
Fix dumping notice object to xml for rails 2.3.10 and builder 2.1.2

### DIFF
--- a/lib/airbrake/notice.rb
+++ b/lib/airbrake/notice.rb
@@ -154,7 +154,7 @@ module Airbrake
           notifier.version(notifier_version)
           notifier.url(notifier_url)
         end
-        notice.error do |error|
+        notice.tag!('error') do |error|
           error.tag!('class', error_class)
           error.message(error_message)
           error.backtrace do |backtrace|


### PR DESCRIPTION
Hallo. I have rails app (2.3.10), errbit (latest version for today).

In the case if I want generate airbrake notification with Airbrake.notify(e) it sends to errbit wrong xml, without data about error. This patch fix the problem.