### PR TITLE
Fix missing api_key when using V3 endpoint URL

### DIFF
--- a/lib/airbrake/sender.rb
+++ b/lib/airbrake/sender.rb
@@ -51,7 +51,7 @@ module Airbrake
       http = setup_http_connection
 
       response = begin
-                   http.post(url.respond_to?(:path) ? url.path : url,
+                   http.post(request_uri,
                              data,
                              headers)
                  rescue *HTTP_ERRORS => e
@@ -175,6 +175,13 @@ module Airbrake
     def json_api_enabled?
       !!(host =~ /collect.airbrake.io/) &&
         project_id =~ /\S/
+    end
+
+    # Use request_uri[0] to keep the query since it contains the API_KEY.
+    #
+    # [0] http://ruby-doc.org/stdlib-2.2.2/libdoc/uri/rdoc/URI/HTTP.html#method-i-request_uri
+    def request_uri
+      url.respond_to?(:request_uri) ? url.request_uri : url
     end
   end
 

--- a/test/sender_test.rb
+++ b/test/sender_test.rb
@@ -107,7 +107,23 @@ class SenderTest < Test::Unit::TestCase
       assert_received(http, :post) do |expect|
         expect.with(anything, json_notice, Airbrake::Sender::HEADERS[:json])
       end
+    end
 
+    should "post to Airbrake keeping the apiKey in the URL" do
+      json_notice = Airbrake::Notice.new(:error_class => "FooBar", :error_message => "Foo Bar").to_json
+
+      http = stub_http
+
+      sender = build_sender(:project_id => "PROJECT_ID", :host => "collect.airbrake.io")
+      sender.send_to_airbrake(json_notice)
+
+      expected_url = format("%s/PROJECT_ID/notices?key=%s",
+        Airbrake::Sender::JSON_API_URI,
+        Airbrake.configuration[:api_key])
+
+      assert_received(http, :post) do |expect|
+        expect.with(expected_url, json_notice, Airbrake::Sender::HEADERS[:json])
+      end
     end
 
     should "post to Airbrake with notice passed" do


### PR DESCRIPTION
This PR would fix #364 

In `Airbrake::Sender`, using the `URI.path` method [here](https://github.com/airbrake/airbrake/blob/master/lib/airbrake/sender.rb#L54) the resulting URL is not compliant the format `/api/v3/projects/:project_id/notices?key=:api_key`.

IMHO, using [`request_url`](http://ruby-doc.org/stdlib-2.2.2/libdoc/uri/rdoc/URI/HTTP.html#method-i-request_uri) should fix this problem.

#### Issue Type:
- Bug Report

#### Airbrake Gem Version:
4.3.0

#### Ruby Version:

ruby 1.9.3/2.2.1

#### Airbrake Configuration:

```ruby
Airbrake.configure do |config|
  config.api_key = "aaaaaaaa"
  config.project_id = "000000"
  config.host = "collect.airbrake.io"
end
```

#### Summary:


#### Steps To Reproduce:

From a IRB/PRY session:

```ruby
require 'airbrake' ; 
Airbrake.configure do |c| 
  c.api_key = "000" ;  
  c.environment_name = 'test' ;  
  c.development_environments = []
end

Airbrake.notify(RuntimeError.new("[IGNORE_ME] ..." ))
```

#### Expected Results:

A notification reference

```
# => "1234567890"
```

#### Actual Results:

```
# => nil
```