### PR TITLE
Use ::Rails namespace for Rails::VERSION

### DIFF
--- a/generators/airbrake/airbrake_generator.rb
+++ b/generators/airbrake/airbrake_generator.rb
@@ -76,7 +76,7 @@ class AirbrakeGenerator < Rails::Generator::Base
   end
 
   def use_initializer?
-    Rails::VERSION::MAJOR > 1
+    ::Rails::VERSION::MAJOR > 1
   end
 
   def api_key_configured?

--- a/generators/airbrake/templates/initializer.rb
+++ b/generators/airbrake/templates/initializer.rb
@@ -1,4 +1,4 @@
-<% if Rails::VERSION::MAJOR < 3 && Rails::VERSION::MINOR < 2 -%>
+<% if ::Rails::VERSION::MAJOR < 3 && ::Rails::VERSION::MINOR < 2 -%>
 require 'airbrake/rails'
 <% end -%>
 <%= configuration_output %>


### PR DESCRIPTION
Experienced issue #330 on Rails 4.2.3/Airbrake 4.3.0:

```
(erb):1:in `template': uninitialized constant Thor::Rails::VERSION (NameError)
	from /Users/pete/.rubies/ruby-2.2.2/lib/ruby/2.2.0/erb.rb:863:in `eval'
	from /Users/pete/.rubies/ruby-2.2.2/lib/ruby/2.2.0/erb.rb:863:in `result'
	from /Users/pete/.gem/ruby/2.2.2/gems/thor-0.19.1/lib/thor/actions/file_manipulation.rb:116:in `block in template'
	from /Users/pete/.gem/ruby/2.2.2/gems/thor-0.19.1/lib/thor/actions/create_file.rb:53:in `call'
	from /Users/pete/.gem/ruby/2.2.2/gems/thor-0.19.1/lib/thor/actions/create_file.rb:53:in `render'
	from /Users/pete/.gem/ruby/2.2.2/gems/thor-0.19.1/lib/thor/actions/create_file.rb:62:in `block (2 levels) in invoke!'
	from /Users/pete/.gem/ruby/2.2.2/gems/thor-0.19.1/lib/thor/actions/create_file.rb:62:in `open'
	from /Users/pete/.gem/ruby/2.2.2/gems/thor-0.19.1/lib/thor/actions/create_file.rb:62:in `block in invoke!'
	from /Users/pete/.gem/ruby/2.2.2/gems/thor-0.19.1/lib/thor/actions/empty_directory.rb:116:in `call'
	from /Users/pete/.gem/ruby/2.2.2/gems/thor-0.19.1/lib/thor/actions/empty_directory.rb:116:in `invoke_with_conflict_check'
	from /Users/pete/.gem/ruby/2.2.2/gems/thor-0.19.1/lib/thor/actions/create_file.rb:60:in `invoke!'
	from /Users/pete/.gem/ruby/2.2.2/gems/thor-0.19.1/lib/thor/actions.rb:94:in `action'
	from /Users/pete/.gem/ruby/2.2.2/gems/thor-0.19.1/lib/thor/actions/create_file.rb:25:in `create_file'
	from /Users/pete/.gem/ruby/2.2.2/gems/thor-0.19.1/lib/thor/actions/file_manipulation.rb:115:in `template'
	from /Users/pete/.gem/ruby/2.2.2/gems/airbrake-4.3.0/lib/rails/generators/airbrake/airbrake_generator.rb:93:in `generate_initializer'
```

This is most likely conflicting with another gem that uses `Thor::Rails`.