### PR TITLE
Remove "API_KEY" set from ENV Variable in Capistrano and airbrake:deploy

### DIFF
--- a/lib/airbrake/capistrano.rb
+++ b/lib/airbrake/capistrano.rb
@@ -82,7 +82,6 @@ module Airbrake
             notify_command << " RAILS_ENV=#{rails_env}" if rails_env
             notify_command << " airbrake:deploy TO=#{airbrake_env} REVISION=#{current_revision} REPO=#{repository} USER=#{Airbrake::Capistrano::shellescape(local_user)}"
             notify_command << " DRY_RUN=true" if dry_run
-            notify_command << " API_KEY=#{ENV['API_KEY']}" if ENV['API_KEY']
             logger.info "Notifying Airbrake of Deploy (#{notify_command})"
             if configuration.dry_run
               logger.info "DRY RUN: Notification not actually run."

--- a/lib/airbrake/shared_tasks.rb
+++ b/lib/airbrake/shared_tasks.rb
@@ -17,7 +17,6 @@ namespace :airbrake do
                          :scm_revision   => ENV['REVISION'],
                          :scm_repository => ENV['REPO'],
                          :local_username => ENV['USER'],
-                         :api_key        => ENV['API_KEY'],
                          :dry_run        => ENV['DRY_RUN'])
   end
 
@@ -46,8 +45,8 @@ namespace :airbrake do
       repo             = `git config --get remote.origin.url` || ENV["REPO"]
 
       command = %Q(heroku addons:add deployhooks:http --url="http://airbrake.io/deploys.txt?api_key=#{heroku_api_key})
-      command << "&deploy[local_username]={{user}}"    
-      command << "&deploy[scm_revision]={{head_long}}" 
+      command << "&deploy[local_username]={{user}}"
+      command << "&deploy[scm_revision]={{head_long}}"
       command << "&deploy[rails_env]=#{heroku_rails_env}"  if heroku_rails_env
       command << "&deploy[scm_repository]=#{repo}"         if repo
       command << '"'

--- a/lib/airbrake/tasks/airbrake.cap
+++ b/lib/airbrake/tasks/airbrake.cap
@@ -17,7 +17,6 @@ namespace :airbrake do
           notify_command << " TO=#{airbrake_env}"
           notify_command << " REVISION=#{fetch(:current_revision)} REPO=#{fetch(:repo_url)}"
           notify_command << " USER=#{local_user.strip.shellescape}"
-          notify_command << " API_KEY=#{ENV['API_KEY']}" if ENV['API_KEY']
 
           info "Notifying Airbrake of Deploy (#{notify_command})"
           execute :rake, notify_command

--- a/lib/airbrake_tasks.rb
+++ b/lib/airbrake_tasks.rb
@@ -8,15 +8,13 @@ module AirbrakeTasks
   #
   # @param [Hash] opts Data about the deploy that is set to Airbrake
   #
-  # @option opts [String] :api_key Api key of you Airbrake application
   # @option opts [String] :rails_env Environment of the deploy (production, staging)
   # @option opts [String] :scm_revision The given revision/sha that is being deployed
   # @option opts [String] :scm_repository Address of your repository to help with code lookups
   # @option opts [String] :local_username Who is deploying
   def self.deploy(opts = {})
-    api_key = opts.delete(:api_key) || Airbrake.configuration.api_key
-    unless api_key =~ /\S/
-      puts "I don't seem to be configured with an API key.  Please check your configuration."
+    unless Airbrake.configuration.api_key =~ /\S/
+      puts "I don't seem to be configured with an API key. Please check your configuration."
       return false
     end
 
@@ -26,7 +24,7 @@ module AirbrakeTasks
     end
 
     dry_run = opts.delete(:dry_run)
-    params = {'api_key' => api_key}
+    params = {'api_key' => Airbrake.configuration.api_key}
     opts.each {|k,v| params["deploy[#{k}]"] = v }
 
     host = Airbrake.configuration.host || 'api.airbrake.io'

--- a/test/airbrake_tasks_test.rb
+++ b/test/airbrake_tasks_test.rb
@@ -92,12 +92,6 @@ class AirbrakeTasksTest < Test::Unit::TestCase
             end
           end
 
-          before_should "use the :api_key param if it's passed in." do
-            @options[:api_key] = "value"
-            @post.expects(:set_form_data).
-              with(has_entries("api_key" => "value"))
-          end
-
           before_should "puts the response body on success" do
             AirbrakeTasks.expects(:puts).with("body")
             @http_proxy.expects(:request).with(any_parameters).returns(successful_response('body'))
@@ -125,7 +119,7 @@ class AirbrakeTasksTest < Test::Unit::TestCase
 
     context "in a configured project with custom host" do
       setup do
-        Airbrake.configure do |config| 
+        Airbrake.configure do |config|
           config.api_key = "1234123412341234"
           config.host = "custom.host"
         end


### PR DESCRIPTION
Removed "API_KEY" param being set in Capistrano tasks and airbrake:deploy task
due to possible conflict with ENV and since it's not needed there and is not
mentioned in Docs regarding deployment.

**Bug / Conflict with ENV variable description:**
If you have ENV variable called API_KEY either locally during deployment or
in your application used somewhere else, Airbrake.configuration.api_key will
be ignored and ENV variable called API_KEY used instead.
