### PR TITLE
railtie: insert our Rails middleware before Rails' one

### DIFF
--- a/features/step_definitions/rails_application_steps.rb
+++ b/features/step_definitions/rails_application_steps.rb
@@ -263,5 +263,5 @@ Then /^the Airbrake middleware should be placed correctly$/ do
   airbrake_index  = middleware.rindex("use Airbrake::Rails::Middleware")
   middleware_index = middleware.rindex("use ActionDispatch::DebugExceptions") ||
     middleware.rindex("use ActionDispatch::ShowExceptions")
-  (airbrake_index > middleware_index).should be_true
+  (airbrake_index < middleware_index).should be_true
 end

--- a/lib/airbrake/railtie.rb
+++ b/lib/airbrake/railtie.rb
@@ -20,7 +20,7 @@ module Airbrake
         "ActionDispatch::ShowExceptions"
       end
 
-      app.config.middleware.insert_after middleware,
+      app.config.middleware.insert_before middleware,
         "Airbrake::Rails::Middleware"
 
       app.config.middleware.insert 0, "Airbrake::UserInformer"


### PR DESCRIPTION
Fixes #401 (Track 404 with airbrake)

> The ActionDispatch::ShowExceptions middleware rescues any exception
> returned by the application and renders nice exception pages if the
> request is local or if config.consider_all_requests_local is set to
> true. If config.action_dispatch.show_exceptions is set to false,
> exceptions will be raised regardless.

Changing the order of middleware allows us to rescue the exception
coming from the Rails middleware. Please note that [we still ignore some
exceptions][1] such as ActionController::RoutingError, which we are able
to catch now.

[1]: https://github.com/airbrake/airbrake/blob/02d29ccde1c46f957c9cf8261835ec7f9386e041/lib/airbrake/configuration.rb#L146