### PR TITLE
[#419] don't fail on request param containing |

### DIFF
--- a/lib/airbrake/rails/controller_methods.rb
+++ b/lib/airbrake/rails/controller_methods.rb
@@ -98,7 +98,7 @@ module Airbrake
           url << ":#{request.port}"
         end
 
-        URI.join(url, request.fullpath).to_s
+        url << "/" << request.fullpath
       end
 
       def airbrake_current_user

--- a/test/controller_methods_test.rb
+++ b/test/controller_methods_test.rb
@@ -36,6 +36,14 @@ class NoSessionTestController < TestController
   end
 end
 
+class ParamTestController < TestController
+  QUERY_PARAMS = { name: "|" } # URI parameter with invalid character
+  def request
+    query = QUERY_PARAMS.map { |k, v| "#{k}=#{v}"}.join("&")
+    OpenStruct.new(:port=> 80, :protocol => 'http://', host: 'example.com', :fullpath => "path?#{query}", :env => [])
+  end
+end
+
 class ControllerMethodsTest < Test::Unit::TestCase
   include DefinesConstants
 
@@ -121,6 +129,11 @@ class ControllerMethodsTest < Test::Unit::TestCase
     should "return correct request url" do
       request_url = @controller.send(:airbrake_request_url)
       assert_equal request_url, "http://example.com/path"
+    end
+
+    should "handle invalid character in param" do
+      request_url = ParamTestController.new.send(:airbrake_request_url)
+      assert_equal request_url, "http://example.com/path?name=|"
     end
   end
 


### PR DESCRIPTION
Replace URI.join