### PR TITLE
Avoid Rails 5 deprecation warning

### DIFF
--- a/lib/airbrake/railtie.rb
+++ b/lib/airbrake/railtie.rb
@@ -14,16 +14,16 @@ module Airbrake
 
       middleware = if defined?(ActionDispatch::DebugExceptions)
         # Rails >= 3.2.0
-        "ActionDispatch::DebugExceptions"
+        ActionDispatch::DebugExceptions
       else
         # Rails < 3.2.0
         "ActionDispatch::ShowExceptions"
       end
 
       app.config.middleware.insert_after middleware,
-        "Airbrake::Rails::Middleware"
+        Airbrake::Rails::Middleware
 
-      app.config.middleware.insert 0, "Airbrake::UserInformer"
+      app.config.middleware.insert 0, Airbrake::UserInformer
     end
 
     config.after_initialize do


### PR DESCRIPTION
Passing strings or symbols to the middleware builder is deprecated since Rails 5

Fix airbrake/airbrake#413