### PR TITLE
params_cleaner: do not attempt to "collect" closed IO objects

### DIFF
--- a/lib/airbrake/utils/params_cleaner.rb
+++ b/lib/airbrake/utils/params_cleaner.rb
@@ -125,7 +125,7 @@ module Airbrake
             data.to_hash.inject({}) do |result, (key, value)|
               result.merge!(key => clean_unserializable_data(value, stack + [data.object_id]))
             end
-          elsif data.respond_to?(:collect) and !data.is_a?(IO)
+          elsif data.respond_to?(:collect) && !data.respond_to?(:readlines)
             data = data.collect do |value|
               clean_unserializable_data(value, stack + [data.object_id])
             end

--- a/test/params_cleaner_test.rb
+++ b/test/params_cleaner_test.rb
@@ -181,4 +181,13 @@ class ParamsCleanerTest < Test::Unit::TestCase
     assert_serializes_hash(:cgi_data)
     assert_serializes_hash(:session_data)
   end
+
+  should "handle closed IO objects by converting them to strings" do
+    params = {
+      :files => [Tempfile.new('a').tap(&:close), IO.new(0).tap(&:close)]
+    }
+    clean_params = clean(:params_filters => ['files'], :parameters => params)
+    assert_match(/\A#<(Temp)?[Ff]ile:0x.+>\z/, clean_params.parameters[:files][0])
+    assert_match(/\A#<IO:0x.+>\z/, clean_params.parameters[:files][1])
+  end
 end


### PR DESCRIPTION
Fixes #396 (Airbrake attempting to close an already closed IO object)

This PR replaces #397.