### PR TITLE
[#419] Fix build 314

### DIFF
--- a/lib/airbrake/rails/controller_methods.rb
+++ b/lib/airbrake/rails/controller_methods.rb
@@ -2,6 +2,8 @@ module Airbrake
   module Rails
     module ControllerMethods
 
+      SLASH = "/"
+
       def airbrake_request_data
         {
           :parameters       => airbrake_filter_if_filtering(to_hash(params)),
@@ -98,7 +100,11 @@ module Airbrake
           url << ":#{request.port}"
         end
 
-        URI.join(url, request.fullpath).to_s
+        unless request.fullpath[0] == SLASH
+          url << SLASH
+        end
+
+        url << request.fullpath
       end
 
       def airbrake_current_user

--- a/test/controller_methods_test.rb
+++ b/test/controller_methods_test.rb
@@ -57,6 +57,14 @@ class NoSessionTestController < TestController
   end
 end
 
+class ParamTestController < TestController
+  QUERY_PARAMS = { name: "|" } # URI parameter with invalid character
+  def request
+    query = QUERY_PARAMS.map { |k, v| "#{k}=#{v}"}.join("&")
+    OpenStruct.new(:port=> 80, :protocol => 'http://', host: 'example.com', :fullpath => "path?#{query}", :env => [])
+  end
+end
+
 class ControllerMethodsTest < Test::Unit::TestCase
   include DefinesConstants
 
@@ -168,6 +176,11 @@ class ControllerMethodsTest < Test::Unit::TestCase
     should "return correct request url" do
       request_url = @controller.send(:airbrake_request_url)
       assert_equal request_url, "http://example.com/path"
+    end
+
+    should "handle invalid character in param" do
+      request_url = ParamTestController.new.send(:airbrake_request_url)
+      assert_equal request_url, "http://example.com/path?name=|"
     end
   end
 


### PR DESCRIPTION
Do no prepend / if already in `fullpath`

These commands are now successful:

```
bundle exec rake test:unit
bundle exec rake integration_test
```