### PR TITLE
Corrected ControllerMethods test that could never fail

### DIFF
--- a/test/controller_methods_test.rb
+++ b/test/controller_methods_test.rb
@@ -39,7 +39,7 @@ end
 class ControllerMethodsTest < Test::Unit::TestCase
   include DefinesConstants
 
-  context "#airbrake_current_user" do
+  context "#airbrake_request_data" do
     context "without a logged in user" do
       setup do
 
@@ -59,7 +59,7 @@ class ControllerMethodsTest < Test::Unit::TestCase
       end
 
       should "not call #id on NilClass" do
-        @controller.send(:airbrake_current_user)
+        @controller.airbrake_request_data
         assert_equal false, NilClass.called
       end
     end


### PR DESCRIPTION
This test was previously checking the wrong thing. It was calling a
private method to load the user (`#airbrake_current_user`), then checking
that `#id` is never called on that user. However,
`#airbrake_current_user` never calls `#id` even when a valid user is
loaded. Therefore this test could never fail.

I've "corrected" it by making it call `#airbrake_request_data` instead,
which does attempt to call `#id` (this is also the method under test for
every other test in this context).