### PR TITLE
test/integration: don't require abstract_controller

### DIFF
--- a/test/integration.rb
+++ b/test/integration.rb
@@ -1,7 +1,6 @@
 require File.expand_path '../helper', __FILE__
 
 silence_warnings do
-  require 'abstract_controller'
   require 'action_controller'
   require 'action_dispatch'
   require 'active_support/dependencies'


### PR DESCRIPTION
This is an attempt to fix #427. I'm not sure why we need to require it
explicitly, so let's try removing it.