### PR TITLE
[Fix] filtering multidim-arrays from cgi-data's 'action_dispatch.cookies'

### DIFF
--- a/lib/airbrake/utils/params_cleaner.rb
+++ b/lib/airbrake/utils/params_cleaner.rb
@@ -98,7 +98,7 @@ module Airbrake
 
         def filter(hash)
           hash.each do |key, value|
-            if filter_key?(key)
+            if hash.is_a?(Hash) && filter_key?(key)
               hash[key] = "[FILTERED]"
             elsif value.respond_to?(:to_hash)
               filter(hash[key])

--- a/test/params_cleaner_test.rb
+++ b/test/params_cleaner_test.rb
@@ -190,4 +190,15 @@ class ParamsCleanerTest < Test::Unit::TestCase
     assert_match(/\A#<(Temp)?[Ff]ile:0x.+>\z/, clean_params.parameters[:files][0])
     assert_match(/\A#<IO:0x.+>\z/, clean_params.parameters[:files][1])
   end
+
+  should "not break on filtering multi-dimensional array as possible in action_dispatch.cookies" do
+    original = { 'cgi_cookies_to_filter' => [['any_cookie_key', 'some_cookie_value'], ['secret', 'some_secret_value']] }
+    clean_params = clean(:params_filters => [:secret],
+                         :params_whitelist_filters => [:secret],
+                         :parameters => original)
+    assert_nothing_raised do
+      clean_params.send(:parameters)
+    end
+  end
+
 end


### PR DESCRIPTION
## Details
Issue Type: Bug Report
Airbrake Gem Version: current (4.3.2)
Ruby Version: 2.3.2
Framework Name/Version: Rails 4.2.4
Airbrake Configuration: basic (only api-key in initializer)

## Steps To Reproduce:
Having cookies set with key, that should be filtered.

## Expected Results:
It should filter the cookie value. But in any case airbrake should not break (so it notifies at least about ANY error).

## Actual Results:
Airbrake breaks on params-filtering and nobody notices.


# PullRequest fix details
When cleaning cgi-data in `utils/params_cleaner.rb`, there might be cookies set on the key `action_dispatch.cookies` (Rails 4.2.4), which contain a filter-key. 

E.g.: 
```
# key to be filtered
@blacklist_filters = %(secret)

# cgi hash, including cookies
cgi_data = {
  'action_dispatch.cookies' => [
    ['_session', 'htRkVDRGI1NEpNcElVNGZSdHRUR0hpdUxlWWJnZjRqUjFVaUVwNU1nSW9'],
    ['secret', 'usually this value would be filtered'],
  ]
}
```

This cgi-data would break the params-cleaner, when it's attempting to write a hash-key onto an array (see `utils/params_cleaner.rb` line 102). Even worse, this breakage hides any raised exception from the application and usually nobody would notice if no other error-logger is active.

I also assume, avoiding this error-case was also intended by #308. The only difference in my PR is skipping a non-hash on the `if` statement, but allowing deeper lookup in the last `elsif` statement.