### PR TITLE
README,Migration_guide: fix Capistrano 3 instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,16 @@ Capfile:
 require 'airbrake/capistrano/tasks'
 ```
 
+If you use Capistrano 3, define the `after :finished` hook, which executes the
+deploy notification task (Capistrano 2 doesn't require this step).
+
+```ruby
+# config/deploy.rb
+namespace :deploy do
+  after :finished, 'airbrake:deploy'
+end
+```
+
 If you version your application, you can set the `:app_version` variable in
 `config/deploy.rb`, so that information will be attached to your deploy.
 

--- a/docs/Migration_guide_from_v4_to_v5.md
+++ b/docs/Migration_guide_from_v4_to_v5.md
@@ -520,13 +520,22 @@ Capistrano 3 you no longer need an `after` hook.
 ```ruby
 # Old way
 # For Capistrano 2
+# Capfile
 require 'airbrake/capistrano'
 # For Capistrano 3
+# Capfile
 require 'airbrake/capistrano3'
+# config/deploy.rb
 after 'deploy:finished', 'airbrake:deploy'
 
 # New way
+# For Capistrano 2
 require 'airbrake/capistrano/tasks'
+# For Capistrano 3
+# Capfile
+require 'airbrake/capistrano/tasks'
+# config/deploy.rb
+after :finished, 'airbrake:deploy'
 ```
 
 <div align="right">


### PR DESCRIPTION
I'm not sure why I considered the hook is not needed. Even if it
worked without the hook for me, turns out defining it is a much
more robust solution.

Thanks to @nick-desteffen for [pointing this out][1]

[1]: https://github.com/airbrake/airbrake/pull/443#issuecomment-166363714