### PR TITLE
Update Migration_guide_from_v4_to_v5.md

### DIFF
--- a/docs/Migration_guide_from_v4_to_v5.md
+++ b/docs/Migration_guide_from_v4_to_v5.md
@@ -125,6 +125,7 @@ test_mode | removed | n/a
 
   # New way
   Airbrake.configure do |c|
+    c.environment = Rails.env
     c.ignore_environments = %w(development test)
 
     # OR to collection exceptions in all envs


### PR DESCRIPTION
filter_chain.rb#env_filter receives two parameters: environment, ignore_environments, however - config (which comes from user config) never initializes environment parameter which is always null, and so airbrake receives development errors - this is a crud and rude workaround until you (I suggest) force feed config with the actual env