### PR TITLE
migration_guide: mention the list of default ignored classes

### DIFF
--- a/docs/Migration_guide_from_v4_to_v5.md
+++ b/docs/Migration_guide_from_v4_to_v5.md
@@ -282,6 +282,11 @@ test_mode | removed | n/a
   Read the [`Airbrake.notify` docs](#airbrake-notify) for more information.
 <sup>[[link](#async)]</sup>
 
+* <a name="default-ignored-classes"></a>
+  The list of default ignored exceptions was relaxed. The library now ignores
+  only `SystemExit` exceptions.
+<sup>[[link](#default-ignored-classes)]</sup>
+
 #### Library API
 
 ##### Blacklist filter


### PR DESCRIPTION
Fixes #456 (Airbrake 5 -- "ActiveRecord::RecordNotFound" not ignored
by default)