### PR TITLE
Update appraisals to use released airbrake-ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'airbrake-ruby', git: ENV['AIRBRAKE_RUBY_ADDRESS'], branch: 'master'
-
 # Rubocop supports only >=1.9.3
 gem 'rubocop', '~> 0.34', require: false unless RUBY_VERSION == '1.9.2'

--- a/gemfiles/rack.gemfile
+++ b/gemfiles/rack.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "airbrake-ruby", :git => ENV['AIRBRAKE_RUBY_ADDRESS'], :branch => "master"
 gem "rubocop", "~> 0.34", :require => false
 gem "warden", "~> 1.2.3"
 

--- a/gemfiles/rails_3.2.gemfile
+++ b/gemfiles/rails_3.2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "airbrake-ruby", :git => ENV['AIRBRAKE_RUBY_ADDRESS'], :branch => "master"
 gem "rubocop", "~> 0.34", :require => false
 gem "rails", "~> 3.2.22"
 gem "warden", "~> 1.2.3"

--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "airbrake-ruby", :git => ENV['AIRBRAKE_RUBY_ADDRESS'], :branch => "master"
 gem "rubocop", "~> 0.34", :require => false
 gem "rails", "~> 4.0.13"
 gem "warden", "~> 1.2.3"

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "airbrake-ruby", :git => ENV['AIRBRAKE_RUBY_ADDRESS'], :branch => "master"
 gem "rubocop", "~> 0.34", :require => false
 gem "rails", "~> 4.1.13"
 gem "warden", "~> 1.2.3"

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "airbrake-ruby", :git => ENV['AIRBRAKE_RUBY_ADDRESS'], :branch => "master"
 gem "rubocop", "~> 0.34", :require => false
 gem "rails", "~> 4.2.4"
 gem "warden", "~> 1.2.3"

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "airbrake-ruby", :git => ENV['AIRBRAKE_RUBY_ADDRESS'], :branch => "master"
 gem "rubocop", "~> 0.34", :require => false
 gem "rails", :github => "rails/rails"
 gem "arel", :github => "rails/arel"

--- a/gemfiles/sinatra.gemfile
+++ b/gemfiles/sinatra.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "airbrake-ruby", :git => ENV['AIRBRAKE_RUBY_ADDRESS'], :branch => "master"
 gem "rubocop", "~> 0.34", :require => false
 gem "sinatra", "~> 1.4.6"
 gem "rack-test", "~> 0.6.3"


### PR DESCRIPTION
I simply forgot to delete this when we released v5.