### PR TITLE
Explained how to preserve the old value for development environments

### DIFF
--- a/docs/Migration_guide_from_v4_to_v5.md
+++ b/docs/Migration_guide_from_v4_to_v5.md
@@ -110,7 +110,10 @@ test_mode | removed | n/a
   The `development_environments` option was renamed to `ignore_environments`.
   Its behaviour was also slightly changed. By default, the library sends
   exceptions in _all_ environments, so you don't need to assign an empty Array
-  anymore.
+  anymore to get this behavior. If you relied on the default value of
+  `development_environments` before upgrading, you should explicitly set
+  `ignore_environments` to `%w(development test cucumber)` to preserve the old
+  behavior.
 <sup>[[link](#development-environments)]</sup>
 
   ```ruby
@@ -121,6 +124,8 @@ test_mode | removed | n/a
     # OR to collect exceptions in all envs
 
     c.development_environments = []
+    
+    # OR don't set this option to get the default (development, test, cucumber)
   end
 
   # New way
@@ -131,6 +136,10 @@ test_mode | removed | n/a
     # OR to collection exceptions in all envs
 
     # Simply don't set this option
+    
+    # OR use the old default value
+    
+    c.ignore_environments = %w(development test cucumber)
   end
   ```
 


### PR DESCRIPTION
Between Airbrake v4 and v5 the default environments that are ignored has changed from `[:development, :test, :cucumber]` to `[]`. This means that any apps which did not explicitly define `ignore_environments` before and upgrade to v5 will suddenly start sending errors to airbrake in development and test.