### PR TITLE
Allow use_system_ssl_cert_chain to work with missing DEFAULT_CERT_FILE

### DIFF
--- a/lib/airbrake/configuration.rb
+++ b/lib/airbrake/configuration.rb
@@ -310,8 +310,8 @@ module Airbrake
     end
 
     def ca_bundle_path
-      if use_system_ssl_cert_chain? && File.exist?(OpenSSL::X509::DEFAULT_CERT_FILE)
-        OpenSSL::X509::DEFAULT_CERT_FILE
+      if use_system_ssl_cert_chain?
+        OpenSSL::X509::DEFAULT_CERT_FILE if File.exist?(OpenSSL::X509::DEFAULT_CERT_FILE)
       else
         local_cert_path # ca-bundle.crt built from source, see resources/README.md
       end


### PR DESCRIPTION
We're using the `airbrake` v4 gem with [Errbit](https://github.com/errbit/errbit) and ran into an issue where we're not able to verify our peer SSL certificate, which was issued from an internal CA.

I tried setting `use_system_ssl_cert_chain = true`, but was thwarted by the `File.exist?(OpenSSL::X509::DEFAULT_CERT_FILE)` check since our systems do not have a CA cert bundle where the `openssl` gem expects it. Leaving `http.ca_file` set to `nil` works fine, however, since `openssl` *does* have a correctly configured CA cert *directory*.

This PR makes it so that `use_system_ssl_cert_chain` is respected regardless of whether `OpenSSL::X509::DEFAULT_CERT_FILE` exists. If it does not exist, then the `openssl` library is allowed to use its normal behavior to find its SSL trust roots. Looking at the source for the v5 gem and `airbrake-ruby`, it seems that the local CA bundle was dispensed with anyways, so hopefully you guys are cool with this change. I know it mostly will affect Errbit users, but I could imagine it could affect older installations of the self-hosted Airbrake Custom product where the client is using the v4 gem.