### PR TITLE
rack: report current_user if it's available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Added better support for user reporting for Rails applications (including
+  OmniAuth support) ([#466](https://github.com/airbrake/airbrake/pull/466))
+
 ### [v5.0.2][v5.0.2] (January 3, 2015)
 
 * Fixed the bug when Warden user is `nil`

--- a/lib/airbrake/rack/notice_builder.rb
+++ b/lib/airbrake/rack/notice_builder.rb
@@ -62,7 +62,7 @@ module Airbrake
           context[:action] = @controller.action_name
         end
 
-        notice[:context].merge!(@user.to_hash) if @user
+        notice[:context].merge!(@user.as_json) if @user
 
         nil
       end

--- a/spec/integration/rails/rails_spec.rb
+++ b/spec/integration/rails/rails_spec.rb
@@ -132,4 +132,18 @@ RSpec.describe "Rails integration specs" do
       sleep 2
     end
   end
+
+  describe "notice payload when a user is authenticated without Warden" do
+    context "when the current_user method is defined" do
+      it "contains the user information" do
+        user = OpenStruct.new(id: 1, email: 'qa@example.com', username: 'qa-dept')
+        allow_any_instance_of(DummyController).to receive(:current_user) { user }
+
+        get '/crash'
+        wait_for_a_request_with_body(
+          /"user":{"id":"1","username":"qa-dept","email":"qa@example.com"}/
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
This change indirectly adds support for [OmniAuth][1] users. The way
OmniAuth integrates with Rails is described [here][2]. Note: this only
works for Rails apps, which I believe should be sufficient for now.

[1]: https://github.com/intridea/omniauth
[2]: https://github.com/testbrian/omniauth-github/blob/patch-2/README.md