### PR TITLE
airbrake: load Rake integration only if Rake::Task is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Airbrake Changelog
 
 ### master
 
+* Improved RubyMine support
+  ([#469](https://github.com/airbrake/airbrake/pull/469))
 * Added better support for user reporting for Rails applications (including
   OmniAuth support) ([#466](https://github.com/airbrake/airbrake/pull/466))
 

--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -16,7 +16,7 @@ if defined?(Rack)
   require 'airbrake/rails/railtie' if defined?(Rails)
 end
 
-require 'airbrake/rake/task_ext' if defined?(Rake)
+require 'airbrake/rake/task_ext' if defined?(Rake::Task)
 require 'airbrake/resque/failure' if defined?(Resque)
 require 'airbrake/sidekiq/error_handler' if defined?(Sidekiq)
 require 'airbrake/delayed_job/plugin' if defined?(Delayed)


### PR DESCRIPTION
Fixes #449 (Airbrake 5 Breaks Debugging)

The problem occurs *only* in RubyMine. For some reason when running
tests with help of it (via the GUI) the `Rake` constant is defined,
but none of the Rake library is loaded. I tried to debug this for a
while, but couldn't find any clues.

The fix is to rely on other constant being present - `Rake::Task`.