### PR TITLE
Added integration with Phusion Passenger v5.0.x

### DIFF
--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -40,4 +40,5 @@ DESC
   s.add_development_dependency 'webmock', '~> 1'
   s.add_development_dependency 'rack-test', '~> 0'
   s.add_development_dependency 'sidekiq', '~> 4'
+  s.add_development_dependency 'passenger', '>= 4', '<= 5.1'
 end

--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -10,6 +10,8 @@ require 'airbrake-ruby'
 require 'airbrake/version'
 
 # Automatically load needed files for the environment the library is running in.
+require 'airbrake/passenger/integration' if defined?(PhusionPassenger)
+
 if defined?(Rack)
   require 'airbrake/rack/user'
   require 'airbrake/rack/notice_builder'

--- a/lib/airbrake/passenger/integration.rb
+++ b/lib/airbrake/passenger/integration.rb
@@ -1,0 +1,53 @@
+module Airbrake
+  # Integration for Phusion Passenger
+  module Passenger
+    IntegrationError = Class.new(::StandardError)
+    class << self
+      def notifier
+        @notifier || :default
+      end
+
+      def notifier=(val)
+        is_sym = val.is_a?(Symbol)
+        @notifier = is_sym ? val.to_sym : val
+      end
+    end
+    # Implementation of Passenger Integration for Versions 4.0 thru 5.0
+    module Integration
+      VERSION_REQUIREMENT = Gem::Requirement.new('>= 4.0', '< 5.1').freeze
+      class << self
+        def integrate!
+          return @integrated if defined?(@integrated)
+          raise IntegrationError, "Your version of PhusionPassenger " \
+            "is not currently supported by the airbrake gem." unless compatible?
+          unless defined?(::PhusionPassenger::LoaderSharedHelpers)
+            ::PhusionPassenger.require_passenger_lib 'loader_shared_helpers'
+          end
+          ::PhusionPassenger::LoaderSharedHelpers.send :extend, ClassMethods
+          @integrated = true
+        rescue IntegrationError => e
+          Kernel.warn e
+        end
+
+        def compatible?
+          @compatible ||= VERSION_REQUIREMENT.satisfied_by?(passenger_version)
+        end
+
+        private
+
+        def passenger_version
+          @passenger_version ||= begin
+            unless defined?(::PhusionPassenger)
+              raise IntegrationError, "PhusionPassenger not detected."
+            end
+            Gem::Version.new(::PhusionPassenger::VERSION_STRING)
+          end
+        end
+      end
+
+      autoload :ClassMethods, 'airbrake/passenger/integration/class_methods'
+    end
+  end
+end
+
+::Airbrake::Passenger::Integration.integrate!

--- a/lib/airbrake/passenger/integration/class_methods.rb
+++ b/lib/airbrake/passenger/integration/class_methods.rb
@@ -1,0 +1,29 @@
+require 'airbrake/passenger/integration'
+module Airbrake
+  module Passenger
+    module Integration
+      # Module to be extended into ::PhusionPassenger::LoaderSharedHelpers
+      module ClassMethods
+        def self.extended(klass)
+          if klass.respond_to?(:about_to_abort)
+            klass.send :alias_method, :about_to_abort_without_notifier, :about_to_abort
+          end
+        end
+
+        def about_to_abort(*args)
+          options = args.first.is_a?(Hash) ? args.first.clone : {}
+          exception = args.last.clone if args.last.is_a?(Exception)
+          if exception
+            params = {}
+            params[:component] = "PhusionPassenger/" + ::PhusionPassenger::VERSION_STRING
+            params[:action] = options['process_title'] || 'Unknown'
+            # TODO: Add more contextual info here
+            ::Airbrake.notify_sync(exception, params, ::Airbrake::Passenger.notifier)
+          end
+          return unless respond_to?(:about_to_abort_without_notifier)
+          about_to_abort_without_notifier(*args)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Following up on #470, here is what I have as a rough-draft. It's totally not ready for merging yet (apparently my original code greatly "offended" `rubocop`s style requirements), but I'd appreciate initial thoughts, both on below and the changes themselves.

Items on my TODO list are (to be edited/whittled down as I go along):
* Figure out what, if any, additional contextual info from `passenger` or elsewhere should be sent up to `airbrake`. (Perhaps a list of gems? Suggestions welcome.)
* CI Testing, of course. (Not quite sure how to set this up, actually..)
  * I'm used to `Travis` rather than `circle`, which is apparently what you have, but I wouldn't even be sure how to set it up on the former off the top of my head, so this may require some trial and error.
    * This is if testing is to include running a web server with a `passenger` module.
* "We currently use Airbrake::Error for every possible error this gem can raise."