### PR TITLE
capistrano: fix the Capistrano 2 integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Airbrake Changelog
   ([#469](https://github.com/airbrake/airbrake/pull/469))
 * Added better support for user reporting for Rails applications (including
   OmniAuth support) ([#466](https://github.com/airbrake/airbrake/pull/466))
+* Fixed the Capistrano 2 integration, which was not working at all
+  ([#475](https://github.com/airbrake/airbrake/pull/475))
 
 ### [v5.0.2][v5.0.2] (January 3, 2015)
 

--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -1,6 +1,8 @@
 # For 'Socket.gethostname' only.
 require 'socket'
 
+require 'shellwords'
+
 # Core library that sends notices.
 # See: https://github.com/airbrake/airbrake-ruby
 require 'airbrake-ruby'

--- a/lib/airbrake/capistrano/tasks.rb
+++ b/lib/airbrake/capistrano/tasks.rb
@@ -1,6 +1,3 @@
-require 'shellwords'
-require 'fileutils'
-
 if defined?(Capistrano::VERSION) &&
    Gem::Version.new(Capistrano::VERSION).release >= Gem::Version.new('3.0.0')
   namespace :airbrake do
@@ -29,7 +26,6 @@ else
     ##
     # The Capistrano v2 integration.
     module Capistrano
-      # rubocop:disable Metrics/AbcSize
       def self.load_into(config)
         config.load do
           after 'deploy',            'airbrake:deploy'
@@ -39,25 +35,24 @@ else
           namespace :airbrake do
             desc "Notify Airbrake of the deploy"
             task :deploy, except: { no_release: true }, on_error: :continue do
-              FileUtils.cd(config.release_path) do
-                username = Shellwords.shellescape(ENV['USER'] || ENV['USERNAME'])
+              username = Shellwords.shellescape(ENV['USER'] || ENV['USERNAME'])
+              command = <<-CMD
+                cd #{config.release_path} && \
 
-                system(<<-CMD)
-                  bundle exec rake airbrake:deploy \
-                    USERNAME=#{username} \
-                    ENVIRONMENT=#{fetch(:rails_env, 'production')} \
-                    REVISION=#{current_revision.strip} \
-                    REPOSITORY=#{repository} \
-                    VERSION=#{fetch(:app_version, nil)}
-                CMD
-              end
+                bundle exec rake airbrake:deploy \
+                  USERNAME=#{username} \
+                  ENVIRONMENT=#{fetch(:rails_env, 'production')} \
+                  REVISION=#{current_revision.strip} \
+                  REPOSITORY=#{repository} \
+                  VERSION=#{fetch(:app_version, nil)}
+              CMD
 
+              run(command, once: true)
               logger.info 'Notified Airbrake of the deploy'
             end
           end
         end
       end
-      # rubocop:enable Metrics/AbcSize
     end
   end
 


### PR DESCRIPTION
Fixes #468 (Capistrano 2.x deployment notification broken)

The command we're running here should be run on the remote machine
(only once). The previous code was running it locally.