### PR TITLE
generators/airbrake_initializer: clarify 'ignore_environments'

### DIFF
--- a/lib/generators/airbrake_initializer.rb.erb
+++ b/lib/generators/airbrake_initializer.rb.erb
@@ -38,6 +38,8 @@ Airbrake.configure do |c|
   # Configures the environment the application is running in. Helps the Airbrake
   # dashboard to distinguish between exceptions occurring in different
   # environments. By default, it's not set.
+  # NOTE: This option must be set in order to make the 'ignore_environments'
+  # option work.
   # https://github.com/airbrake/airbrake-ruby#environment
   c.environment = Rails.env
 
@@ -45,6 +47,7 @@ Airbrake.configure do |c|
   # unwanted environments such as :test. By default, it is equal to an empty
   # Array, which means Airbrake Ruby sends exceptions occurring in all
   # environments.
+  # NOTE: This option *does not* work if you don't set the 'environment' option.
   # https://github.com/airbrake/airbrake-ruby#ignore_environments
   c.ignore_environments = %w(test)
 end


### PR DESCRIPTION
Apparently it's confusing for many people that 'ignore_environments'
doesn't work in certain conditions.