### PR TITLE
Specify RAILS_ENV and RACK_ENV in capistrano rake task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Set RACK_ENV and RAILS_ENV in Capistrano 2 integration
+  ([#489](https://github.com/airbrake/airbrake/pull/489))
+
 ### [v5.0.3][v5.0.3] (January 19, 2015)
 
 * Improved RubyMine support

--- a/lib/airbrake/capistrano/tasks.rb
+++ b/lib/airbrake/capistrano/tasks.rb
@@ -39,6 +39,9 @@ else
               command = <<-CMD
                 cd #{config.release_path} && \
 
+                RACK_ENV=#{fetch(:rack_env, nil)} \
+                RAILS_ENV=#{fetch(:rails_env, nil)} \
+
                 bundle exec rake airbrake:deploy \
                   USERNAME=#{username} \
                   ENVIRONMENT=#{fetch(:rails_env, 'production')} \


### PR DESCRIPTION
Restore some of the Capistrano functionality that is missing in the latest version. We might also want to add back `:airbrake_env`.  