### PR TITLE
rack: rely on airbrake-ruby's hostname information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Airbrake Changelog
 
 * Set RACK_ENV and RAILS_ENV in Capistrano 2 integration
   ([#489](https://github.com/airbrake/airbrake/pull/489))
+* Removed the hostname information from the Rack integration because the new
+  `airbrake-ruby` sends it by default
+  ([#495](https://github.com/airbrake/airbrake/pull/495))
 
 ### [v5.0.3][v5.0.3] (January 19, 2015)
 

--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -1,6 +1,3 @@
-# For 'Socket.gethostname' only.
-require 'socket'
-
 require 'shellwords'
 
 # Core library that sends notices.

--- a/lib/airbrake/rack/notice_builder.rb
+++ b/lib/airbrake/rack/notice_builder.rb
@@ -5,10 +5,6 @@ module Airbrake
     # coming from the Rack environment.
     class NoticeBuilder
       ##
-      # @return [String] the name of the host machine
-      HOSTNAME = Socket.gethostname.freeze
-
-      ##
       # @param [Hash{String=>Object}] rack_env The Rack environment
       def initialize(rack_env)
         @rack_env = rack_env
@@ -49,7 +45,6 @@ module Airbrake
 
         context[:url] = @request.url
         context[:userAgent] = @request.user_agent
-        context[:hostname] = HOSTNAME
 
         if context.key?(:version)
           context[:version] += " #{@framework_version}"


### PR DESCRIPTION
The new airbrake-ruby sends that information by default.