### PR TITLE
Check if user is truthy before trying to build from it

### DIFF
--- a/lib/airbrake/rack/user.rb
+++ b/lib/airbrake/rack/user.rb
@@ -18,7 +18,7 @@ module Airbrake
 
         # Fallback mode (OmniAuth support included). Works only for Rails.
         controller = rack_env['action_controller.instance']
-        new(controller.current_user) if controller.respond_to?(:current_user)
+        new(controller.current_user) if controller.respond_to?(:current_user) && controller.current_user
       end
 
       def initialize(user)


### PR DESCRIPTION
Would otherwise cause an issue if the controller responds to current user but the value was e.g. nil