### PR TITLE
Bugfix rails env in capistrano3 deployment

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+Version 3.2.1 - 2014-05-27 15:58:24 -0700
+===============================================================================
+
+Ali Faiz (3):
+      Bumping to version 3.2.0
+      Revert "Merge pull request #297 from airbrake/remove-js-notifier"
+      Add deprecation warning when using  .
+
+
 Version 3.2.0 - 2014-05-23 17:37:35 -0700
 ===============================================================================
 
@@ -1346,6 +1355,7 @@ Nick Quaranto (3):
       Fixing the capistrano hook bit in the readme
       Adding changeling:minor and changeling:patch to automate notifier releases
       Adding rake changeling:push
+
 
 
 

--- a/lib/airbrake/tasks/airbrake.cap
+++ b/lib/airbrake/tasks/airbrake.cap
@@ -12,12 +12,12 @@ namespace :airbrake do
       current_revision = capture("cd #{repo_path} && git rev-parse HEAD")
       repository = ENV['REPO'] || ENV['REPONAME']
 
-      notify_command = "airbrake:deploy TO=#{airbrake_env} REVISION=#{current_revision} REPO=#{repo_url} USER=#{Airbrake::Capistrano::shellescape(local_user)}"
+      notify_command = "RAILS_ENV=#{rails_env} airbrake:deploy TO=#{airbrake_env} REVISION=#{current_revision} REPO=#{repo_url} USER=#{Airbrake::Capistrano::shellescape(local_user)}"
       notify_command << " API_KEY=#{ENV['API_KEY']}" if ENV['API_KEY']
       info "Notifying Airbrake of Deploy (#{notify_command})"
       result = ""
       within release_path do
-        execute :rake, notify_command, :once => true do |ch, stream, data| 
+        execute :rake, notify_command, :once => true do |ch, stream, data|
           result << data
         end
       end

--- a/lib/airbrake/version.rb
+++ b/lib/airbrake/version.rb
@@ -1,3 +1,3 @@
 module Airbrake
-  VERSION = "3.2.0".freeze
+  VERSION = "3.2.1".freeze
 end


### PR DESCRIPTION
Hi,

I'm experiencing problems when trying to deploy a rails4.2 / capistrano3 / airbrake3.2.1 application with airbrakes capistrano-integreation
```
require 'airbrake/capistrano3'
...
after 'deploy:finished', 'airbrake:deploy'
```
```
cap staging deploy
....
INFO [1589d92c] Running ~/.rvm/bin/rvm default do bundle exec rake airbrake:deploy TO=production REVISION=5e8cb71b0d0f0b432633a647248a1aa82891c043 REPO=xxx USER=michael as deploy@app
DEBUG [1589d92c] Command: cd /srv/app/releases/20160208135503 && ~/.rvm/bin/rvm default do bundle exec rake airbrake:deploy TO=production REVISION=5e8cb71b0d0f0b432633a647248a1aa82891c043 REPO=xxx USER=michael
DEBUG [1589d92c] 	rake aborted!
DEBUG [1589d92c] 	ActiveRecord::AdapterNotSpecified: 'development' database is not configured. Available: ["production"]
```

My deployment file includes `set :rails_env, 'production'` but the task seems to ignore that. I found that the [cap-task thats responsible for that](https://github.com/airbrake/airbrake/blob/v3.2.1/lib/airbrake/tasks/airbrake.cap#L8-L15) does not consider Capistranos rails_env (actually, it fetches the rails_env, but never uses it).

I've branched this off the tag v3.2.1 and cannot create a pull request. Maybe you can have a look at it and include it in a bugfix release of 3.x?


