### PR TITLE
rack: check if user is truthy before trying to build from it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Airbrake Changelog
 
 ### master
 
+* Fixes issue in the Rack integration when `current_user` is `nil` and we try to
+  build from it ([#501](https://github.com/airbrake/airbrake/pull/501))
 * Improve the Rack integration by attaching more useful debugging information
   such as HTTP headers and HTTP methods
   ([#499](https://github.com/airbrake/airbrake/pull/499))

--- a/lib/airbrake/rack/user.rb
+++ b/lib/airbrake/rack/user.rb
@@ -18,7 +18,8 @@ module Airbrake
 
         # Fallback mode (OmniAuth support included). Works only for Rails.
         controller = rack_env['action_controller.instance']
-        new(controller.current_user) if controller.respond_to?(:current_user)
+        return unless controller.respond_to?(:current_user)
+        new(controller.current_user) if controller.current_user
       end
 
       def initialize(user)

--- a/spec/unit/rack/user_spec.rb
+++ b/spec/unit/rack/user_spec.rb
@@ -52,13 +52,26 @@ RSpec.describe Airbrake::Rack::User do
     end
 
     context "when the current_user Rails controller method is defined" do
-      it "returns the wrapped user" do
-        controller = instance_double('DummyController')
-        env = env_for('/', 'action_controller.instance' => controller)
-        allow(controller).to receive(:current_user) { user }
+      context "and it is nil" do
+        it "returns nil" do
+          controller = instance_double('DummyController')
+          env = env_for('/', 'action_controller.instance' => controller)
+          allow(controller).to receive(:current_user) { nil }
 
-        retval = described_class.extract(env)
-        expect(retval).to be_a(described_class)
+          retval = described_class.extract(env)
+          expect(retval).to be_nil
+        end
+      end
+
+      context "and it is not nil" do
+        it "returns the wrapped user" do
+          controller = instance_double('DummyController')
+          env = env_for('/', 'action_controller.instance' => controller)
+          allow(controller).to receive(:current_user) { user }
+
+          retval = described_class.extract(env)
+          expect(retval).to be_a(described_class)
+        end
       end
     end
   end


### PR DESCRIPTION
Would otherwise cause an issue if the controller responds to current user but
the value was e.g. nil

Replaces #498 because the original author hasn't responded yet and I feel like it's a quite important addition.