### PR TITLE
rack: move the Rack env payload to 'environment'

### DIFF
--- a/lib/airbrake/rack/notice_builder.rb
+++ b/lib/airbrake/rack/notice_builder.rb
@@ -43,6 +43,7 @@ module Airbrake
         add_context(notice)
         add_session(notice)
         add_params(notice)
+        add_environment(notice)
 
         notice
       end
@@ -54,9 +55,6 @@ module Airbrake
 
         context[:url] = @request.url
         context[:userAgent] = @request.user_agent
-        context[:httpMethod] = @request.request_method
-        context[:referer] = @request.referer
-        context[:headers] = request_headers
 
         if context.key?(:version)
           context[:version] += " #{@framework_version}"
@@ -81,6 +79,14 @@ module Airbrake
       def add_params(notice)
         params = @request.env['action_dispatch.request.parameters']
         notice[:params] = params if params
+      end
+
+      def add_environment(notice)
+        notice[:environment] = {
+          httpMethod: @request.request_method,
+          referer: @request.referer,
+          headers: request_headers
+        }
       end
 
       def request_headers

--- a/spec/integration/shared_examples/rack_examples.rb
+++ b/spec/integration/shared_examples/rack_examples.rb
@@ -101,18 +101,26 @@ RSpec.shared_examples 'rack examples' do
       it "features userAgent" do
         wait_for_a_request_with_body(/"context":{.*"userAgent":"Bot".*}/)
       end
+    end
+  end
 
-      it "features referer" do
-        wait_for_a_request_with_body(/"context":{.*"referer":"bingo.com".*}/)
-      end
+  describe "environment payload" do
+    before do
+      get '/crash', nil, 'HTTP_REFERER' => 'bingo.com'
+    end
 
-      it "contains HTTP headers" do
-        wait_for_a_request_with_body(/"context":{.*"headers":{.*"CONTENT_LENGTH":"0".*}/)
-      end
+    it "features referer" do
+      wait_for_a_request_with_body(/"environment":{.*"referer":"bingo.com".*}/)
+    end
 
-      it "contains HTTP method" do
-        wait_for_a_request_with_body(/"context":{.*"httpMethod":"GET".*}/)
-      end
+    it "contains HTTP headers" do
+      wait_for_a_request_with_body(
+        /"environment":{.*"headers":{.*"CONTENT_LENGTH":"0".*}/
+      )
+    end
+
+    it "contains HTTP method" do
+      wait_for_a_request_with_body(/"environment":{.*"httpMethod":"GET".*}/)
     end
   end
 end


### PR DESCRIPTION
This is a follow-up to #499.

With the old approach the API can and probably will throw away our
data. Given that we're retrieving values about HTTP request from
the Rack env, let's attach it to the environment tab instead.