### PR TITLE
Existing information in the notice's environment should be merged, not replaced

### DIFF
--- a/docs/Migration_guide_from_v4_to_v5.md
+++ b/docs/Migration_guide_from_v4_to_v5.md
@@ -406,7 +406,7 @@ README](https://github.com/airbrake/airbrake-ruby#notice).
 
   ```ruby
   Airbrake.add_filter do |notice|
-    notice[:environment] = ENV
+    notice[:environment].merge!(ENV)
   end
   ```
 

--- a/lib/airbrake/rack/notice_builder.rb
+++ b/lib/airbrake/rack/notice_builder.rb
@@ -82,11 +82,11 @@ module Airbrake
       end
 
       def add_environment(notice)
-        notice[:environment] = {
+        notice[:environment].merge!(
           httpMethod: @request.request_method,
           referer: @request.referer,
           headers: request_headers
-        }
+        )
       end
 
       def request_headers

--- a/spec/unit/rack/notice_builder_spec.rb
+++ b/spec/unit/rack/notice_builder_spec.rb
@@ -31,5 +31,19 @@ RSpec.describe Airbrake::Rack::NoticeBuilder do
 
       expect(notice[:params]).to eq(params)
     end
+
+    it "adds CONTENT_TYPE, CONTENT_LENGTH and HTTP_* headers in the environment" do
+      headers = { "HTTP_HOST" => "example.com", "CONTENT_TYPE" => "text/html", "CONTENT_LENGTH" => 100500 }
+      notice_builder = described_class.new(headers.dup)
+      notice = notice_builder.build_notice(AirbrakeTestError.new)
+      expect(notice[:environment][:headers]).to eq(headers)
+    end
+
+    it "skips headers that were not selected to be stored in the environment" do
+      headers = { "HTTP_HOST" => "example.com", "CONTENT_TYPE" => "text/html", "CONTENT_LENGTH" => 100500 }
+      notice_builder = described_class.new(headers.merge("X-SOME-HEADER" => "value"))
+      notice = notice_builder.build_notice(AirbrakeTestError.new)
+      expect(notice[:environment][:headers]).to eq(headers)
+    end
   end
 end

--- a/spec/unit/rack/notice_builder_spec.rb
+++ b/spec/unit/rack/notice_builder_spec.rb
@@ -33,17 +33,41 @@ RSpec.describe Airbrake::Rack::NoticeBuilder do
     end
 
     it "adds CONTENT_TYPE, CONTENT_LENGTH and HTTP_* headers in the environment" do
-      headers = { "HTTP_HOST" => "example.com", "CONTENT_TYPE" => "text/html", "CONTENT_LENGTH" => 100500 }
+      headers = {
+        "HTTP_HOST" => "example.com",
+        "CONTENT_TYPE" => "text/html",
+        "CONTENT_LENGTH" => 100500
+      }
       notice_builder = described_class.new(headers.dup)
       notice = notice_builder.build_notice(AirbrakeTestError.new)
       expect(notice[:environment][:headers]).to eq(headers)
     end
 
     it "skips headers that were not selected to be stored in the environment" do
-      headers = { "HTTP_HOST" => "example.com", "CONTENT_TYPE" => "text/html", "CONTENT_LENGTH" => 100500 }
+      headers = {
+        "HTTP_HOST" => "example.com",
+        "CONTENT_TYPE" => "text/html",
+        "CONTENT_LENGTH" => 100500
+      }
       notice_builder = described_class.new(headers.merge("X-SOME-HEADER" => "value"))
       notice = notice_builder.build_notice(AirbrakeTestError.new)
       expect(notice[:environment][:headers]).to eq(headers)
+    end
+
+    it "preserves data that already has been added to the environment" do
+      headers = {
+        "HTTP_HOST" => "example.com",
+        "CONTENT_TYPE" => "text/html",
+        "CONTENT_LENGTH" => 100500
+      }
+      allow(Airbrake).to receive(:build_notice).and_wrap_original do |method, *args|
+        notice = method.call(*args)
+        notice[:environment]["SOME_KEY"] = "SOME_VALUE"
+        notice
+      end
+      notice_builder = described_class.new(headers)
+      notice = notice_builder.build_notice(AirbrakeTestError.new)
+      expect(notice[:environment]["SOME_KEY"]).to eq("SOME_VALUE")
     end
   end
 end


### PR DESCRIPTION
Information about ENV should be merged into the notice[:environment] to not replace already stored data. And `Airbrake::Rack::NoticeBuilder` should not replace lost information during building, too.

Please, take a look on this issue for additional details: https://git.io/vg1W0.