### PR TITLE
rake: make the integration synchronous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Fixed Rake integration sometimes not reporting errors
+  ([#513](https://github.com/airbrake/airbrake/pull/513))
+
 ### [v5.0.5][v5.0.5] (February 9, 2016)
 
 * Fixes issue in the Rack integration when `current_user` is `nil` and we try to

--- a/lib/airbrake/rake/task_ext.rb
+++ b/lib/airbrake/rake/task_ext.rb
@@ -27,7 +27,7 @@ module Rake
         argv: ARGV.join(' ')
       }
 
-      Airbrake.notify(notice)
+      Airbrake.notify_sync(notice)
       raise ex
     end
     # rubocop:enable Lint/RescueException


### PR DESCRIPTION
This allows us to send a notice before the Rake process quits.
Originally reported on [StackOverflow][1].

[1]: http://stackoverflow.com/q/35462531/511205