### PR TITLE
Pass middleware class directly, not as a string

### DIFF
--- a/lib/airbrake/railtie.rb
+++ b/lib/airbrake/railtie.rb
@@ -14,16 +14,16 @@ module Airbrake
 
       middleware = if defined?(ActionDispatch::DebugExceptions)
         # Rails >= 3.2.0
-        "ActionDispatch::DebugExceptions"
+        ActionDispatch::DebugExceptions
       else
         # Rails < 3.2.0
-        "ActionDispatch::ShowExceptions"
+        ActionDispatch::ShowExceptions
       end
 
       app.config.middleware.insert_after middleware,
-        "Airbrake::Rails::Middleware"
+        Airbrake::Rails::Middleware
 
-      app.config.middleware.insert 0, "Airbrake::UserInformer"
+      app.config.middleware.insert 0, Airbrake::UserInformer
     end
 
     config.after_initialize do


### PR DESCRIPTION
There's some deprecation warnings on Rails 5.0.0.beta1 and .beta2 because of the middleware being passed as string. This should remove the deprecations.

@kyrylo maybe?