### PR TITLE
Added method add_metadata to Airbrake::Rack::NoticeBuilder.

### DIFF
--- a/lib/airbrake/rack/notice_builder.rb
+++ b/lib/airbrake/rack/notice_builder.rb
@@ -44,6 +44,7 @@ module Airbrake
         add_session(notice)
         add_params(notice)
         add_environment(notice)
+        add_metadata(notice)
 
         notice
       end
@@ -79,6 +80,11 @@ module Airbrake
       def add_params(notice)
         params = @request.env['action_dispatch.request.parameters']
         notice[:params] = params if params
+      end
+
+      def add_metadata(notice)
+        # This method does nothing by default, but it can be overridden to add any custom
+        # data from RACK environment to the notice.
       end
 
       def add_environment(notice)

--- a/spec/unit/rack/notice_builder_spec.rb
+++ b/spec/unit/rack/notice_builder_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Airbrake::Rack::NoticeBuilder do
           end
         }
       end
-      notice_builder = extended_class.new({ 'REMOTE_IP' => '127.0.0.1' })
+      notice_builder = extended_class.new('REMOTE_IP' => '127.0.0.1')
       notice = notice_builder.build_notice(AirbrakeTestError.new)
       expect(notice[:params][:remoteIp]).to eq("127.0.0.1")
     end

--- a/spec/unit/rack/notice_builder_spec.rb
+++ b/spec/unit/rack/notice_builder_spec.rb
@@ -69,5 +69,18 @@ RSpec.describe Airbrake::Rack::NoticeBuilder do
       notice = notice_builder.build_notice(AirbrakeTestError.new)
       expect(notice[:environment]["SOME_KEY"]).to eq("SOME_VALUE")
     end
+
+    it "allows to add custom metadata by overridding of add_metadata" do
+      extended_class = described_class.dup.class_eval do
+        prepend Module.new {
+          def add_metadata(notice)
+            notice[:params][:remoteIp] = @rack_env['REMOTE_IP']
+          end
+        }
+      end
+      notice_builder = extended_class.new({ 'REMOTE_IP' => '127.0.0.1' })
+      notice = notice_builder.build_notice(AirbrakeTestError.new)
+      expect(notice[:params][:remoteIp]).to eq("127.0.0.1")
+    end
   end
 end


### PR DESCRIPTION
This method does nothing by default, but it can be overridden to add any custom data from RACK environment to the notice.