### PR TITLE
Introduced user defined builders in Airbrake::Rack::NoticeBuilder (#509)

### DIFF
--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -19,3 +19,25 @@ require 'airbrake/rake/task_ext' if defined?(Rake::Task)
 require 'airbrake/resque/failure' if defined?(Resque)
 require 'airbrake/sidekiq/error_handler' if defined?(Sidekiq)
 require 'airbrake/delayed_job/plugin' if defined?(Delayed)
+
+##
+# This module extends original module Airbrake from airbrake-ruby and
+# serves as a namespace for other classes and modules.
+module Airbrake
+  class << self
+    ##
+    # Allows users to add their own notice's builders. Useful if it's needed to
+    # attach some info from the rack environment or request to the notice.
+    #
+    # @example Adds remote ip from the rack_env to the notice
+    #   Airbrake.add_rack_builder |notice, request| do
+    #     notice[:params][:remoteIp] = request.env['REMOTE_IP']
+    #   end
+    #
+    # @yieldparam notice [Airbrake::Notice] notice that will be sent to the Airbrake
+    # @yieldparam request [Rack::Request] current rack request
+    def add_rack_builder(&block)
+      Airbrake::Rack::NoticeBuilder.add_builder(&block)
+    end
+  end
+end

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+RSpec.describe Airbrake do
+  describe ".add_rack_builder" do
+    let :builder do
+      proc { |_, _| nil }
+    end
+
+    after { Airbrake::Rack::NoticeBuilder.builders.delete(builder) }
+
+    it "adds new builder to the chain" do
+      expect { Airbrake.add_rack_builder(&builder) }.to change {
+        Airbrake::Rack::NoticeBuilder.builders.count
+      }.by(1)
+    end
+  end
+end

--- a/spec/unit/rack/notice_builder_spec.rb
+++ b/spec/unit/rack/notice_builder_spec.rb
@@ -69,5 +69,15 @@ RSpec.describe Airbrake::Rack::NoticeBuilder do
       notice = notice_builder.build_notice(AirbrakeTestError.new)
       expect(notice[:environment]["SOME_KEY"]).to eq("SOME_VALUE")
     end
+
+    it "runs user defined builders against notices" do
+      extended_class = described_class.dup
+      extended_class.add_builder do |notice, request|
+        notice[:params][:remoteIp] = request.env['REMOTE_IP']
+      end
+      notice_builder = extended_class.new('REMOTE_IP' => '127.0.0.1')
+      notice = notice_builder.build_notice(AirbrakeTestError.new)
+      expect(notice[:params][:remoteIp]).to eq("127.0.0.1")
+    end
   end
 end


### PR DESCRIPTION
Allows users to add their own builders for notice. So, for example, if it's needed to add a `REMOTE_IP` in the notice's params it can be easily done in standard initializer for airbrake like this:

```ruby
Airbrake.add_rack_builder |notice, request|
  notice[:params][:remoteIp] = request.env['REMOTE_IP']
end
```