### PR TITLE
Fix Airbrake::Rack::Middleware regression

### DIFF
--- a/spec/unit/rack/middleware_spec.rb
+++ b/spec/unit/rack/middleware_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Airbrake::Rack::Middleware do
           end
         end
 
-        ['action_dispatch.exception', 'sinatra.error'].each do |type|
+        ['rack.exception', 'action_dispatch.exception', 'sinatra.error'].each do |type|
           include_examples 'stored exception', type
         end
       end


### PR DESCRIPTION
In v4, Airbrake::Rack would check for framework-saved exceptions in the
Rack env under rack.exception or sinatra.error:
https://github.com/airbrake/airbrake/blob/34fcbe8e6aae20aad0e4f5174df16945dd6f1356/lib/airbrake/rack.rb#L60

Now v5's Airbrake::Rack::Middleware looks under
action_dispatch.exception or sinatra.error. I'm not sure whether Rails
or Sinatra ever set env['rack.exception'] on their own. That key does
not appear to be part of the Rack standard, and I can't find any trace
of the string 'rack.exception' in the Rails codebase, or even in a `git
log -G 'rack\.exception'`.

Presumably Rails (or maybe a middleware it depends on?) set that key at
some point, since Airbrake v4 checked for it. I also presume v5
continues to work fine with Rails and Sinatra. However, the
rack.exception key still exists out in the ecosystem. In particular,
upgrading to Airbrake v5 introduced broke my Goliath app:
- https://github.com/postrank-labs/goliath/blob/4d7bd448bf292802d30d971be97f49d191c3359f/lib/goliath/constants.rb#L25
- https://github.com/postrank-labs/goliath/blob/4d7bd448bf292802d30d971be97f49d191c3359f/lib/goliath/api.rb#L180

This patch reintroduces the check for rack.exception. This may be
hinting that we need an overall cleaner way of handling frameworks'
weird ways of stashing middleware exceptions, but this was the simplest
path towards getting my app working again.