### PR TITLE
rake: suggest how to airbrake:test when current env is ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Changelog
 
 ### master
 
+* Fixed bug when trying to send a test exception with help of the Rake task
+  results in an error due to the current environment being ignored
+  ([#523](https://github.com/airbrake/airbrake/pull/523))
+
 ### [v5.1.0][v5.1.0] (February 29, 2016)
 
 * Fixed Rake integration sometimes not reporting errors

--- a/lib/airbrake/rake/tasks.rb
+++ b/lib/airbrake/rake/tasks.rb
@@ -15,7 +15,8 @@ namespace :airbrake do
       "#{name}:\n  " + [cfg, filters].pretty_inspect
     end.join("\n")
 
-    puts <<OUTPUT
+    if response
+      puts <<OUTPUT
 [ruby]
 description: #{RUBY_DESCRIPTION}
 
@@ -40,6 +41,17 @@ we would be really grateful if you could attach the output to your message.
 
 The test exception was sent. Find it here: #{response['url']}
 OUTPUT
+    else
+      puts <<OUTPUT
+Couldn't send a test exception. There are two reasons for this:
+
+1. Airbrake ignored this exception due to misconfigured filters
+2. Airbrake was configured to ignore the '#{Rails.env}' environment.
+   To fix this try one of the following:
+     * specify another environment via RAILS_ENV
+     * temporarily unignore the '#{Rails.env}' environment
+OUTPUT
+    end
   end
 
   desc 'Notify Airbrake of a new deploy'


### PR DESCRIPTION
Fixes #521 (Test rake task doesn't work for ignored environments)