### PR TITLE
airbrake_initializer: update blacklist_keys to the new API

### DIFF
--- a/lib/generators/airbrake_initializer.rb.erb
+++ b/lib/generators/airbrake_initializer.rb.erb
@@ -50,12 +50,14 @@ Airbrake.configure do |c|
   # NOTE: This option *does not* work if you don't set the 'environment' option.
   # https://github.com/airbrake/airbrake-ruby#ignore_environments
   c.ignore_environments = %w(test)
-end
 
-# A list of parameters that should be filtered out of what is sent to Airbrake.
-# By default, all "password" attributes will have their contents replaced.
-# https://github.com/airbrake/airbrake-ruby#blacklist_keys
-Airbrake.blacklist_keys(/password/i)
+
+  # A list of parameters that should be filtered out of what is sent to
+  # Airbrake. By default, all "password" attributes will have their contents
+  # replaced.
+  # https://github.com/airbrake/airbrake-ruby#blacklist_keys
+  c.blacklist_keys = [/password/i]
+end
 
 # If Airbrake doesn't send any expected exceptions, we suggest to uncomment the
 # line below. It might simplify debugging of background Airbrake workers, which


### PR DESCRIPTION
This should've been in airbrake-5.2.0, but I forgot to update it :(