### PR TITLE
rails/active_job: amend `component` and `action` to fix grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Fixed grouping for the ActiveJob integration
+  ([#533](https://github.com/airbrake/airbrake/pull/533))
+
 ### [v5.2.1][v5.2.1] (March 21, 2016)
 
 * **Quickfix**: updated the Rails generator to use the newer

--- a/lib/airbrake/rails/active_job.rb
+++ b/lib/airbrake/rails/active_job.rb
@@ -9,8 +9,8 @@ module Airbrake
         rescue_from(Exception) do |exception|
           notice = Airbrake.build_notice(exception)
 
-          notice[:context][:component] = self.class.name
-          notice[:context][:action] = job_id
+          notice[:context][:component] = 'active_job'
+          notice[:context][:action] = self.class.name
 
           notice[:params] = as_json
 


### PR DESCRIPTION
Fixes #532 (Same exceptions occurred from ActiveJob have different
action values)