### PR TITLE
rake: handle response errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Fixed bug in the Rake integration where it couldn't display error message
+  coming from the API ([#536](https://github.com/airbrake/airbrake/pull/536))
+
 ### [v5.2.2][v5.2.2] (March 24, 2016)
 
 * Fixed grouping for the ActiveJob integration

--- a/lib/airbrake/rake/tasks.rb
+++ b/lib/airbrake/rake/tasks.rb
@@ -15,7 +15,23 @@ namespace :airbrake do
       "#{name}:\n  " + [cfg, filters].pretty_inspect
     end.join("\n")
 
-    if response
+    if !response
+      puts <<NORESPONSE
+Couldn't send a test exception. There are two reasons for this:
+
+1. Airbrake ignored this exception due to misconfigured filters
+2. Airbrake was configured to ignore the '#{Rails.env}' environment.
+   To fix this try one of the following:
+     * specify another environment via RAILS_ENV
+     * temporarily unignore the '#{Rails.env}' environment
+NORESPONSE
+    elsif response['error']
+      puts <<ERROR
+Error occurred: #{response['error']}
+Make sure that your Project ID and Project Key are correct:
+https://github.com/airbrake/airbrake-ruby#project_id--project_key
+ERROR
+    else
       puts <<OUTPUT
 [ruby]
 description: #{RUBY_DESCRIPTION}
@@ -40,16 +56,6 @@ team may request this information if you have problems using the Airbrake gem;
 we would be really grateful if you could attach the output to your message.
 
 The test exception was sent. Find it here: #{response['url']}
-OUTPUT
-    else
-      puts <<OUTPUT
-Couldn't send a test exception. There are two reasons for this:
-
-1. Airbrake ignored this exception due to misconfigured filters
-2. Airbrake was configured to ignore the '#{Rails.env}' environment.
-   To fix this try one of the following:
-     * specify another environment via RAILS_ENV
-     * temporarily unignore the '#{Rails.env}' environment
 OUTPUT
     end
   end

--- a/lib/airbrake/rake/tasks.rb
+++ b/lib/airbrake/rake/tasks.rb
@@ -16,47 +16,47 @@ namespace :airbrake do
     end.join("\n")
 
     if !response
-      puts <<NORESPONSE
-Couldn't send a test exception. There are two reasons for this:
-
-1. Airbrake ignored this exception due to misconfigured filters
-2. Airbrake was configured to ignore the '#{Rails.env}' environment.
-   To fix this try one of the following:
-     * specify another environment via RAILS_ENV
-     * temporarily unignore the '#{Rails.env}' environment
-NORESPONSE
+      puts <<-NORESPONSE.gsub(/^\s+\|/, '')
+        |Couldn't send a test exception. There are two reasons for this:
+        |
+        |1. Airbrake ignored this exception due to misconfigured filters
+        |2. Airbrake was configured to ignore the '#{Rails.env}' environment.
+        |   To fix this try one of the following:
+        |     * specify another environment via RAILS_ENV
+        |     * temporarily unignore the '#{Rails.env}' environment
+      NORESPONSE
     elsif response['error']
-      puts <<ERROR
-Error occurred: #{response['error']}
-Make sure that your Project ID and Project Key are correct:
-https://github.com/airbrake/airbrake-ruby#project_id--project_key
-ERROR
+      puts <<-ERROR.gsub(/^\s+\|/, '')
+        |Error occurred: #{response['error']}
+        |Make sure that your Project ID and Project Key are correct:
+        |https://github.com/airbrake/airbrake-ruby#project_id--project_key
+      ERROR
     else
-      puts <<OUTPUT
-[ruby]
-description: #{RUBY_DESCRIPTION}
-
-#{if defined?(Rails)
-    "[rails]\nversion: #{Rails::VERSION::STRING}"
-  elsif defined?(Sinatra)
-    "[sinatra]\nversion: #{Sinatra::VERSION}"
-  end}
-
-[airbrake]
-version: #{Airbrake::AIRBRAKE_VERSION}
-
-[airbrake-ruby]
-version: #{Airbrake::Notice::NOTIFIER[:version]}
-
-[notifiers]
-#{notifiers}
-
-The output above contains useful information about your environment. Our support
-team may request this information if you have problems using the Airbrake gem;
-we would be really grateful if you could attach the output to your message.
-
-The test exception was sent. Find it here: #{response['url']}
-OUTPUT
+      puts <<-OUTPUT.gsub(/^\s+\|/, '')
+        |[ruby]
+        |description: #{RUBY_DESCRIPTION}
+        |
+        |#{if defined?(Rails)
+             "[rails]\nversion: #{Rails::VERSION::STRING}"
+           elsif defined?(Sinatra)
+             "[sinatra]\nversion: #{Sinatra::VERSION}"
+           end}
+        |
+        |[airbrake]
+        |version: #{Airbrake::AIRBRAKE_VERSION}
+        |
+        |[airbrake-ruby]
+        |version: #{Airbrake::Notice::NOTIFIER[:version]}
+        |
+        |[notifiers]
+        |#{notifiers}
+        |
+        |The output above contains useful information about your environment. Our support
+        |team may request this information if you have problems using the Airbrake gem;
+        |we would be really grateful if you could attach the output to your message.
+        |
+        |The test exception was sent. Find it here: #{response['url']}
+      OUTPUT
     end
   end
 


### PR DESCRIPTION
If a project was configured with bad project ID or project key, the API
would return an error response. The Rake task, however, would print the
success text.

Instead, handle API errors and print a more relevant message. Example:

```
% bundle exec rake airbrake:test
Error occurred: Project not found or access denied.
Make sure that your Project ID and Project Key are correct:
https://github.com/airbrake/airbrake-ruby#project_id--project_key
```