### PR TITLE
Migration_Guide: mention deprecation of 'filter_parameters'

### DIFF
--- a/docs/Migration_guide_from_v4_to_v5.md
+++ b/docs/Migration_guide_from_v4_to_v5.md
@@ -300,6 +300,12 @@ test_mode | removed | n/a
   only `SystemExit` exceptions.
 <sup>[[link](#default-ignored-classes)]</sup>
 
+* <a name="filter-parameters"></a>
+  Airbrake no longer reuses filters specified by
+  `Rails.application.config.filter_parameters`. Instead, use the
+  [`add_filter` API](#filtering).
+<sup>[[link](#filter-parameters)]</sup>
+
 #### Library API
 
 ##### Blacklist filter


### PR DESCRIPTION
A customer was confused that we didn't mention this in the guide.