### PR TITLE
Adjust integrations to return early when 'build_notice' returns 'nil'

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,3 +71,6 @@ Performance/StartWith:
 
 Style/Alias:
   Enabled: true
+
+Style/MultilineArrayBraceLayout:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 gemspec
 
 # Rubocop supports only >=1.9.3
-gem 'rubocop', '~> 0.34', require: false unless RUBY_VERSION == '1.9.2'
+gem 'rubocop', '~> 0.40', require: false unless RUBY_VERSION == '1.9.2'

--- a/lib/airbrake/rack/middleware.rb
+++ b/lib/airbrake/rack/middleware.rb
@@ -36,6 +36,8 @@ module Airbrake
 
       def notify_airbrake(exception, env)
         notice = NoticeBuilder.new(env).build_notice(exception)
+        return unless notice
+
         Airbrake.notify(notice)
       end
 

--- a/lib/airbrake/rack/notice_builder.rb
+++ b/lib/airbrake/rack/notice_builder.rb
@@ -39,7 +39,8 @@ module Airbrake
       # @param [Exception] exception
       # @return [Airbrake::Notice] the notice with extra information
       def build_notice(exception)
-        notice = Airbrake.build_notice(exception)
+        return unless (notice = Airbrake.build_notice(exception))
+
         NoticeBuilder.builders.each { |builder| builder.call(notice, @request) }
         notice
       end

--- a/lib/airbrake/rails/action_controller.rb
+++ b/lib/airbrake/rails/action_controller.rb
@@ -13,7 +13,8 @@ module Airbrake
       # Attaches information from the Rack env.
       # @see Airbrake#notify, #notify_airbrake_sync
       def notify_airbrake(exception, parameters = {}, notifier = :default)
-        Airbrake.notify(build_notice(exception), parameters, notifier)
+        return unless (notice = build_notice(exception))
+        Airbrake.notify(notice, parameters, notifier)
       end
 
       ##
@@ -21,7 +22,8 @@ module Airbrake
       # Attaches information from the Rack env.
       # @see Airbrake#notify_sync, #notify_airbrake
       def notify_airbrake_sync(exception, parameters = {}, notifier = :default)
-        Airbrake.notify_sync(build_notice(exception), parameters, notifier)
+        return unless (notice = build_notice(exception))
+        Airbrake.notify_sync(notice, parameters, notifier)
       end
 
       ##

--- a/lib/airbrake/rails/active_job.rb
+++ b/lib/airbrake/rails/active_job.rb
@@ -12,7 +12,7 @@ module Airbrake
         end
 
         rescue_from(Exception) do |exception|
-          notice = Airbrake.build_notice(exception)
+          next unless (notice = Airbrake.build_notice(exception))
 
           notice[:context][:component] = 'active_job'
           notice[:context][:action] = self.class.name

--- a/lib/airbrake/rake/task_ext.rb
+++ b/lib/airbrake/rake/task_ext.rb
@@ -18,7 +18,16 @@ module Rake
     def execute(args = nil)
       execute_without_airbrake(args)
     rescue Exception => ex
-      notice = Airbrake.build_notice(ex)
+      notify_airbrake(ex, args)
+      raise ex
+    end
+    # rubocop:enable Lint/RescueException
+
+    private
+
+    def notify_airbrake(exception, args)
+      return unless (notice = Airbrake.build_notice(exception))
+
       notice[:context][:component] = 'rake'
       notice[:context][:action] = name
       notice[:params] = {
@@ -28,11 +37,7 @@ module Rake
       }
 
       Airbrake.notify_sync(notice)
-      raise ex
     end
-    # rubocop:enable Lint/RescueException
-
-    private
 
     # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize
     def task_info

--- a/spec/integration/rails/rails_spec.rb
+++ b/spec/integration/rails/rails_spec.rb
@@ -101,6 +101,24 @@ RSpec.describe "Rails integration specs" do
           with(body: /"message":"active_job error"/)
         ).to have_been_made.at_least_once
       end
+
+      context "when Airbrake is not configured" do
+        it "doesn't report errors" do
+          allow(Airbrake).to receive(:build_notice).and_return(nil)
+          allow(Airbrake).to receive(:notify)
+
+          get '/active_job'
+          sleep 2
+
+          wait_for(
+            a_request(:post, endpoint).
+            with(body: /"message":"active_job error"/)
+          ).not_to have_been_made
+
+          expect(Airbrake).to have_received(:build_notice)
+          expect(Airbrake).not_to have_received(:notify)
+        end
+      end
     end
   end
 

--- a/spec/unit/rack/middleware_spec.rb
+++ b/spec/unit/rack/middleware_spec.rb
@@ -77,4 +77,17 @@ RSpec.describe Airbrake::Rack::Middleware do
       expect(response[2]).to eq('Bingo bango content')
     end
   end
+
+  context "when Airbrake is not configured" do
+    it "returns nil" do
+      allow(Airbrake).to receive(:build_notice).and_return(nil)
+      allow(Airbrake).to receive(:notify)
+
+      expect { described_class.new(faulty_app).call(env_for('/')) }.
+        to raise_error(AirbrakeTestError)
+
+      expect(Airbrake).to have_received(:build_notice)
+      expect(Airbrake).not_to have_received(:notify)
+    end
+  end
 end

--- a/spec/unit/rack/notice_builder_spec.rb
+++ b/spec/unit/rack/notice_builder_spec.rb
@@ -79,5 +79,15 @@ RSpec.describe Airbrake::Rack::NoticeBuilder do
       notice = notice_builder.build_notice(AirbrakeTestError.new)
       expect(notice[:params][:remoteIp]).to eq("127.0.0.1")
     end
+
+    context "when Airbrake is not configured" do
+      it "returns nil" do
+        allow(Airbrake).to receive(:build_notice).and_return(nil)
+        notice_builder = described_class.new('bingo' => 'bango')
+
+        expect(notice_builder.build_notice('bongo')).to be_nil
+        expect(Airbrake).to have_received(:build_notice)
+      end
+    end
   end
 end

--- a/spec/unit/rake/tasks_spec.rb
+++ b/spec/unit/rake/tasks_spec.rb
@@ -32,8 +32,7 @@ RSpec.describe "airbrake/rake/tasks" do
      %w(username john),
      %w(revision 123abcdef),
      %w(repository https://github.com/airbrake/airbrake'),
-     %w(version v2.0)
-    ].each do |(key, val)|
+     %w(version v2.0)].each do |(key, val)|
       include_examples 'deploy payload', key, val
     end
   end


### PR DESCRIPTION
This change along with https://github.com/airbrake/airbrake-ruby/pull/75
fix https://github.com/airbrake/airbrake/issues/546.

Due to the breaking change in airbrake-ruby we need to update some of
our integrations that use `Airbrake.build_notice`.

/cc @khustochka (could you please verify if `airbrake-ruby` master with this PR work for you? I've done some manual testing and it is works good for me).