### PR TITLE
Release v5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Airbrake Changelog
 
 ### master
 
+### [v5.3.0][v5.3.0] (May 11, 2016)
+
 * Fixed bug in the ActiveJob+Resque integration, where the gem couldn't report
   any exceptions ([#542](https://github.com/airbrake/airbrake/pull/542))
 * Started depending on
@@ -105,3 +107,4 @@ Airbrake Changelog
 [v5.2.1]: https://github.com/airbrake/airbrake/releases/tag/v5.2.1
 [v5.2.2]: https://github.com/airbrake/airbrake/releases/tag/v5.2.2
 [v5.2.3]: https://github.com/airbrake/airbrake/releases/tag/v5.2.3
+[v5.3.0]: https://github.com/airbrake/airbrake/releases/tag/v5.3.0

--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ commands to invoke them.
 [pricing]: https://airbrake.io/pricing
 [heroku-addon]: https://elements.heroku.com/addons/airbrake
 [heroku-docs]: https://devcenter.heroku.com/articles/airbrake
-[semver]: https://img.shields.io/:semver-5.2.3-brightgreen.svg?style=flat
+[semver]: https://img.shields.io/:semver-5.3.0-brightgreen.svg?style=flat
 [migration-guide]: docs/Migration_guide_from_v4_to_v5.md
 [dashboard]: https://s3.amazonaws.com/airbrake-github-assets/airbrake/airbrake-dashboard.png
 [arthur-ruby]: https://s3.amazonaws.com/airbrake-github-assets/airbrake/arthur-ruby.jpg

--- a/lib/airbrake/version.rb
+++ b/lib/airbrake/version.rb
@@ -2,5 +2,5 @@
 # We use Semantic Versioning v2.0.0
 # More information: http://semver.org/
 module Airbrake
-  AIRBRAKE_VERSION = '5.2.3'.freeze
+  AIRBRAKE_VERSION = '5.3.0'.freeze
 end


### PR DESCRIPTION
Why v5.3.0 and not v5.2.4? Well, it's because airbrake-ruby's MINOR
version was bumped. SemVer doesn't define what to do in this situation.
This gem's API stays the same. However the logic here is that users are
directly affected by this change because airbrake-ruby doesn't raise
an important exception that it used to raise.

Depends on https://github.com/airbrake/airbrake/pull/548 & https://github.com/airbrake/airbrake/pull/549.