### PR TITLE
Fix params cleaner for deep nested arrays

### DIFF
--- a/lib/airbrake/utils/params_cleaner.rb
+++ b/lib/airbrake/utils/params_cleaner.rb
@@ -97,16 +97,15 @@ module Airbrake
         end
 
         def filter(hash)
+          return hash unless hash.is_a?(Hash)
+
           hash.each do |key, value|
-            if hash.is_a?(Hash) && filter_key?(key)
+            if filter_key?(key)
               hash[key] = "[FILTERED]"
             elsif value.respond_to?(:to_hash)
-              filter(hash[key])
+              filter(value)
             elsif value.is_a?(Array)
-              hash[key] = value.inject(Array.new) do |result, item|
-                item = filter(item) if item.is_a?(Enumerable)
-                result.push(item)
-              end
+              hash[key] = value.map { |item| filter(item) }
             end
           end
         end

--- a/test/params_cleaner_test.rb
+++ b/test/params_cleaner_test.rb
@@ -37,7 +37,7 @@ class ParamsCleanerTest < Test::Unit::TestCase
       'ghi' => '789',
       'something_with_abc' => 'match the entire string',
       'nested_hash' => { 'abc' => '100', 'ghi' => '789' },
-      'nested_array' => [{ 'abc' => '100' }, { 'ghi' => '789' }, 'xyz']
+      'nested_array' => [{ 'abc' => '100' }, { 'ghi' => '789' }, 'xyz', [['asd', []]]]
     }
     filtered = {
       'abc' => '[FILTERED]',
@@ -45,7 +45,7 @@ class ParamsCleanerTest < Test::Unit::TestCase
       'ghi' => '789',
       'something_with_abc' => 'match the entire string',
       'nested_hash' => { 'abc' => '[FILTERED]', 'ghi' => '789' },
-      'nested_array' => [{ 'abc' => '[FILTERED]' }, { 'ghi' => '789' }, 'xyz']
+      'nested_array' => [{ 'abc' => '[FILTERED]' }, { 'ghi' => '789' }, 'xyz', [['asd', []]]]
     }
 
     clean_params = clean(:params_filters => filters, attribute => original)


### PR DESCRIPTION
Issue Type: _Bug Report_
Airbrake Gem Version: **4.3.6**

Fix `#filter` method in `ParamsCleaner` class to be able to process nested arrays with any nesting level.
This error occurs in our sidekiq worker with unknown exact steps, but it can be easily reproduced in tests (which is done in this pull request).

According to [this page](https://github.com/airbrake/airbrake/blob/master/docs/Migration_guide_from_v4_to_v5.md), v4 is still supported and, I hope, is open for bug fixes, as we would like to avoid migration to v5 for our current production apps.

Thanks.