### PR TITLE
Use `clear_active_connections!` instead of `release_connection`

### DIFF
--- a/lib/airbrake/rails/controller_methods.rb
+++ b/lib/airbrake/rails/controller_methods.rb
@@ -137,8 +137,8 @@ module Airbrake
       ensure
         # The Airbrake middleware is first in the chain, before ActiveRecord::ConnectionAdapters::ConnectionManagement
         # kicks in to do its thing. This can cause the connection pool to run out of connections.
-        if defined?(ActiveRecord::Base) && ActiveRecord::Base.respond_to?(:connection_pool)
-          ActiveRecord::Base.connection_pool.release_connection
+        if defined?(ActiveRecord::Base) && ActiveRecord::Base.respond_to?(:clear_active_connections!)
+          ActiveRecord::Base.clear_active_connections!
         end
       end
     end

--- a/test/controller_methods_test.rb
+++ b/test/controller_methods_test.rb
@@ -124,9 +124,8 @@ class ControllerMethodsTest < Test::Unit::TestCase
       end
 
       should "release DB connections" do
-        ::POOL = Object.new
-        module ::ActiveRecord; class Base; def self.connection_pool; ::POOL; end; end; end
-        ::POOL.expects(:release_connection)
+        module ::ActiveRecord; class Base; end; end
+        ::ActiveRecord::Base.expects(:clear_active_connections!)
 
         CurrentUserTestController.new.airbrake_request_data
       end


### PR DESCRIPTION
`ActiveRecord::Base.connection_pool.release_connection` handles
only one of connection_pools which belongs to `ActiveRecord::Base`.
When developers use `establish_connection` and `User` model uses
an established connection, we should use `clear_active_connections!`
to release all connection_pools.