### PR TITLE
README: remove issue stats badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ Airbrake
 [![Gem Version](https://badge.fury.io/rb/airbrake.svg)](http://badge.fury.io/rb/airbrake)
 [![Documentation Status](http://inch-ci.org/github/airbrake/airbrake.svg?branch=master)](http://inch-ci.org/github/airbrake/airbrake)
 [![Downloads](https://img.shields.io/gem/dt/airbrake.svg?style=flat)](https://rubygems.org/gems/airbrake)
-[![PR Stats](http://issuestats.com/github/airbrake/airbrake/badge/pr?style=flat)](http://issuestats.com/github/airbrake/airbrake)
-[![Issue Stats](http://issuestats.com/github/airbrake/airbrake/badge/issue?style=flat)](http://issuestats.com/github/airbrake/airbrake)
 
 ![The Airbrake notifier for Ruby][arthur-ruby]
 


### PR DESCRIPTION
I really like the idea of them, but unfortunately they are very
unreliable. They often fail to load because the main app stops working.


![airbrake airbrake the official airbrake library for ruby applications 2016-06-24 18-21-41](https://cloud.githubusercontent.com/assets/1079123/16342624/cfa802aa-3a3b-11e6-9825-d1281cbb1082.png)
