### PR TITLE
rails: insert our middleware after ConnectionManagement

### DIFF
--- a/lib/airbrake/rails/railtie.rb
+++ b/lib/airbrake/rails/railtie.rb
@@ -13,12 +13,18 @@ module Airbrake
 
         if ::Rails.version.start_with?('5.')
           # Avoid the warning about deprecated strings.
+          # Insert after DebugExceptions, since ConnectionManagement doesn't
+          # exist in Rails 5 anymore.
           app.config.middleware.insert_after(
-            ActionDispatch::DebugExceptions, Airbrake::Rack::Middleware
+            ActionDispatch::DebugExceptions,
+            Airbrake::Rack::Middleware
           )
         else
+          # Insert after ConnectionManagement to avoid DB connection leakage:
+          # https://github.com/airbrake/airbrake/pull/568
           app.config.middleware.insert_after(
-            ActionDispatch::DebugExceptions, 'Airbrake::Rack::Middleware'
+            ActiveRecord::ConnectionAdapters::ConnectionManagement,
+            'Airbrake::Rack::Middleware'
           )
         end
       end

--- a/spec/integration/rails/rails_spec.rb
+++ b/spec/integration/rails/rails_spec.rb
@@ -8,11 +8,21 @@ RSpec.describe "Rails integration specs" do
 
   include_examples 'rack examples'
 
-  it "inserts the Airbrake Rack middleware after DebugExceptions" do
-    middlewares = Rails.configuration.middleware.middlewares.map(&:inspect)
-    own_idx = middlewares.index('Airbrake::Rack::Middleware')
+  if ::Rails.version.start_with?('5.')
+    it "inserts the Airbrake Rack middleware after DebugExceptions" do
+      middlewares = Rails.configuration.middleware.middlewares.map(&:inspect)
+      own_idx = middlewares.index('Airbrake::Rack::Middleware')
 
-    expect(middlewares[own_idx - 1]).to eq('ActionDispatch::DebugExceptions')
+      expect(middlewares[own_idx - 1]).to eq('ActionDispatch::DebugExceptions')
+    end
+  else
+    it "inserts the Airbrake Rack middleware after ConnectionManagement" do
+      middlewares = Rails.configuration.middleware.middlewares.map(&:inspect)
+      own_idx = middlewares.index('Airbrake::Rack::Middleware')
+
+      expect(middlewares[own_idx - 1]).
+        to eq('ActiveRecord::ConnectionAdapters::ConnectionManagement')
+    end
   end
 
   shared_examples 'context payload content' do |route|


### PR DESCRIPTION
An alternative fix to https://github.com/airbrake/airbrake/pull/562.

We have to have this extra safety measure to ensure we don't leak DB
connections. More information:
https://blog.codefront.net/2009/06/15/activerecord-rails-metal-too-many-connections/