### PR TITLE
ignore_only=[] was removed form Airbrake 5

### DIFF
--- a/docs/Migration_guide_from_v4_to_v5.md
+++ b/docs/Migration_guide_from_v4_to_v5.md
@@ -71,6 +71,7 @@ framework | removed | n/a
 rescue_rake_exceptions | removed | n/a
 user_attributes | removed | n/a
 test_mode | removed | n/a
+ignore_only | removed | n/a
 
 * <a name="api-key"></a>
   The `api_key` option was renamed to `project_key`.


### PR DESCRIPTION
I use to use it as:

```
+  #if ENV['CONTAINER_ROLE'] == "sidekiq"
+    #config.ignore_only = []
+  #end
```

to allow raise erros from `ActiveRecord::NotFound`

by not having this in the change-log I had pretty hard time last 2 hours, would be helpful for others