### PR TITLE
spec_helper: fix build by requiring sinatra in its test file

### DIFF
--- a/spec/integration/sinatra/sinatra_spec.rb
+++ b/spec/integration/sinatra/sinatra_spec.rb
@@ -1,4 +1,6 @@
+require 'sinatra'
 require 'spec_helper'
+require 'apps/sinatra/dummy_app'
 require 'integration/shared_examples/rack_examples'
 
 RSpec.describe "Sinatra integration specs" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,11 +7,6 @@ require 'rack'
 require 'rack/test'
 require 'rake'
 
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0')
-  require 'sidekiq'
-  require 'sidekiq/cli'
-end
-
 require 'airbrake'
 require 'airbrake/rake/tasks'
 
@@ -69,20 +64,11 @@ if ENV['APPRAISAL_INITIALIZED']
     puts '** Skipped Rails specs'
   end
 
-  # Load a Sinatra app or skip.
-  begin
-    # Resque depends on Sinatra, so when we launch Rails specs, we also
-    # accidentally load Sinatra.
-    raise LoadError if defined?(Resque)
-
-    require 'sinatra'
-    require 'apps/sinatra/dummy_app'
-  rescue LoadError
-    puts '** Skipped Sinatra specs'
-  end
-
   # Load a Rack app or skip.
   begin
+    # Don't load the Rack app since we want to test Sinatra if it's loaded.
+    raise LoadError if defined?(Sinatra)
+
     require 'apps/rack/dummy_app'
   rescue LoadError
     puts '** Skipped Rack specs'
@@ -120,7 +106,6 @@ versions = <<EOS
 EOS
 versions << "# JRUBY_VERSION #{JRUBY_VERSION}\n" if defined?(JRUBY_VERSION)
 versions << "# Rails version: #{Rails.version}\n" if defined?(Rails)
-versions << "# Sinatra version: #{Sinatra::VERSION}\n" if defined?(Sinatra)
 versions << "# Rack release: #{Rack.release}\n"
 versions << '#' * 80
 

--- a/spec/unit/sidekiq/error_handler_spec.rb
+++ b/spec/unit/sidekiq/error_handler_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0')
+  require 'sidekiq'
+  require 'sidekiq/cli'
+  require 'airbrake/sidekiq/error_handler'
+
   RSpec.describe "airbrake/sidekiq/error_handler" do
     let(:endpoint) do
       'https://airbrake.io/api/v3/projects/113743/notices?key=fd04e13d806a90f96614ad8e529b2822'


### PR DESCRIPTION
The bug was introduced by:
https://github.com/mperham/sidekiq/issues/3042

It resulted in loading Sinatra when we run tests against Rack (we
need Sidekiq for unit tests, so we load it).

Example build that fails:
https://circleci.com/gh/airbrake/airbrake/781