### PR TITLE
rake: fix parsing variable in Heroku deploy hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Fixed Heroku deploy hook error when parsing variables containing `=`
+  ([#577](https://github.com/airbrake/airbrake/pull/577))
+
 ### [v5.4.1][v5.4.1] (June 21, 2016)
 
 * Fixed Capistrano 3 bug when system has conflicting Rake versions, which would

--- a/lib/airbrake/rake/tasks.rb
+++ b/lib/airbrake/rake/tasks.rb
@@ -92,7 +92,7 @@ namespace :airbrake do
     end
 
     heroku_env = config.each_line.with_object({}) do |line, h|
-      h.merge!(Hash[*line.rstrip.split('=')])
+      h.merge!(Hash[*line.rstrip.split("\n").flat_map { |v| v.split('=', 2) }])
     end
 
     id = heroku_env['AIRBRAKE_PROJECT_ID']

--- a/spec/unit/rake/tasks_spec.rb
+++ b/spec/unit/rake/tasks_spec.rb
@@ -36,4 +36,32 @@ RSpec.describe "airbrake/rake/tasks" do
       include_examples 'deploy payload', key, val
     end
   end
+
+  describe "airbrake:install_heroku_deploy_hook" do
+    let(:task) { Rake::Task['airbrake:install_heroku_deploy_hook'] }
+
+    after { task.reenable }
+
+    let(:airbrake_vars) { "AIRBRAKE_PROJECT_ID=1\nAIRBRAKE_API_KEY=2\nRAILS_ENV=3\n" }
+    let(:silenced_stdout) { File.new(File::NULL, 'w') }
+
+    before do
+      @original_stdout = $stdout
+      $stdout = silenced_stdout
+    end
+
+    after do
+      $stdout.close
+      $stdout = @original_stdout
+    end
+
+    describe "parsing environment variables" do
+      it "does not raise when an env variable value contains '='" do
+        heroku_config = airbrake_vars + "URL=https://airbrake.io/docs?key=11\n"
+        expect(Bundler).to receive(:with_clean_env).twice.and_return(heroku_config)
+
+        task.invoke
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #574 (rake airbrake:install_heroku_deploy_hook parsing env vars
inocrrectly)