### PR TITLE
rails/railtie: fix support of apps, which don't use ActiveRecord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Changelog
 
 ### master
 
+* **IMPORTANT**: Fixed support for apps, which don't use ActiveRecord. In v5.4.2
+  it broke, so it's recommended to upgrade to the current version (or use v5.4.1
+  instead) ([#580](https://github.com/airbrake/airbrake/issues/580))
+
 ### [v5.4.2][v5.4.2] (July 15, 2016)
 
 * Fixed Heroku deploy hook error when parsing variables containing `=`

--- a/lib/airbrake/rails/railtie.rb
+++ b/lib/airbrake/rails/railtie.rb
@@ -19,11 +19,17 @@ module Airbrake
             ActionDispatch::DebugExceptions,
             Airbrake::Rack::Middleware
           )
-        else
+        elsif defined?(ActiveRecord)
           # Insert after ConnectionManagement to avoid DB connection leakage:
           # https://github.com/airbrake/airbrake/pull/568
           app.config.middleware.insert_after(
             ActiveRecord::ConnectionAdapters::ConnectionManagement,
+            'Airbrake::Rack::Middleware'
+          )
+        else
+          # Insert after DebugExceptions for apps without ActiveRecord.
+          app.config.middleware.insert_after(
+            ActionDispatch::DebugExceptions,
             'Airbrake::Rack::Middleware'
           )
         end


### PR DESCRIPTION
Fixes #579 (Middleware ConnectionManagement only for ActiveRecord)