### PR TITLE
Always re-raise exception in ActiveJob integration

### DIFF
--- a/lib/airbrake/rails/active_job.rb
+++ b/lib/airbrake/rails/active_job.rb
@@ -12,19 +12,19 @@ module Airbrake
         end
 
         rescue_from(Exception) do |exception|
-          next unless (notice = Airbrake.build_notice(exception))
+          if (notice = Airbrake.build_notice(exception))
+            notice[:context][:component] = 'active_job'
+            notice[:context][:action] = self.class.name
 
-          notice[:context][:component] = 'active_job'
-          notice[:context][:action] = self.class.name
+            notice[:params] = as_json
 
-          notice[:params] = as_json
-
-          # We special case Resque because it kills our workers by forking, so
-          # we use synchronous delivery instead.
-          if is_resque_adapter
-            Airbrake.notify_sync(notice)
-          else
-            Airbrake.notify(notice)
+            # We special case Resque because it kills our workers by forking, so
+            # we use synchronous delivery instead.
+            if is_resque_adapter
+              Airbrake.notify_sync(notice)
+            else
+              Airbrake.notify(notice)
+            end
           end
 
           raise exception


### PR DESCRIPTION
In pull request https://github.com/airbrake/airbrake-ruby/pull/75, code was introduced in every integration to return early when `build_notice` returns nil because Airbrake is not configured.

In at least the ActiveJob integration, the exception is not re-raised when returning early, and thus any ActiveJob queue adapter will happily mark the job successfully completed. That is not the expected behavior, and it took me a while to figure out jobs were falsely successful because the Airbrake gem was included without configuring it.

This pull request contains a fix for the ActiveJob integration, but I suspect more integrations suffer from this problem.

(I also modified Rubocop's Gemfile version to exclude 0.42, because it barfed on CircleCI's MRI 1.9.3)