### PR TITLE
More specific constant name in ActiveRecord

### DIFF
--- a/lib/airbrake/rails/active_record.rb
+++ b/lib/airbrake/rails/active_record.rb
@@ -14,7 +14,7 @@ module Airbrake
     module ActiveRecord
       ##
       # @return [Array<Symbol>] the hooks that needs fixing
-      KINDS = [:commit, :rollback].freeze
+      HOOK_KINDS = [:commit, :rollback].freeze
 
       ##
       # Patches default +run_callbacks+ with our version, which is capable of
@@ -23,7 +23,7 @@ module Airbrake
       # rubocop:disable Lint/RescueException
       def run_callbacks(kind, *args, &block)
         # Let the post process handle the exception if it's not a bugged hook.
-        return super unless KINDS.include?(kind)
+        return super unless HOOK_KINDS.include?(kind)
 
         # Handle the exception ourselves. The 'ex' exception won't be
         # propagated, therefore we must notify it here.


### PR DESCRIPTION
By using a more specific constant name than `KINDS`, it is less likely that our constant will stomp on user model constants in ActiveRecord. Closes #586.