### PR TITLE
Always re-raise exception in ActiveJob integration (replaces #583)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* **IMPORTANT**: fixed ActiveJob integration not re-raising exceptions, which
+  resulted into marking failed jobs as successfully completed
+  ([#591](https://github.com/airbrake/airbrake/issues/591))
 * Fixed Rails runner integration not reporting errors
   ([#582](https://github.com/airbrake/airbrake/issues/580))
 * Fixed bug with the [enum_field](https://github.com/jamesgolick/enum_field) gem

--- a/lib/airbrake/rails/active_job.rb
+++ b/lib/airbrake/rails/active_job.rb
@@ -12,19 +12,19 @@ module Airbrake
         end
 
         rescue_from(Exception) do |exception|
-          next unless (notice = Airbrake.build_notice(exception))
+          if (notice = Airbrake.build_notice(exception))
+            notice[:context][:component] = 'active_job'
+            notice[:context][:action] = self.class.name
 
-          notice[:context][:component] = 'active_job'
-          notice[:context][:action] = self.class.name
+            notice[:params] = as_json
 
-          notice[:params] = as_json
-
-          # We special case Resque because it kills our workers by forking, so
-          # we use synchronous delivery instead.
-          if is_resque_adapter
-            Airbrake.notify_sync(notice)
-          else
-            Airbrake.notify(notice)
+            # We special case Resque because it kills our workers by forking, so
+            # we use synchronous delivery instead.
+            if is_resque_adapter
+              Airbrake.notify_sync(notice)
+            else
+              Airbrake.notify(notice)
+            end
           end
 
           raise exception

--- a/spec/integration/rails/rails_spec.rb
+++ b/spec/integration/rails/rails_spec.rb
@@ -117,6 +117,14 @@ RSpec.describe "Rails integration specs" do
           allow(Airbrake).to receive(:build_notice).and_return(nil)
           allow(Airbrake).to receive(:notify)
 
+          # Make sure we don't call `build_notice` more than 1 time. Rack
+          # integration will try to handle error 500 and we want to prevent
+          # that: https://github.com/airbrake/airbrake/pull/583
+          allow_any_instance_of(Airbrake::Rack::Middleware).to(
+            receive(:notify_airbrake).
+            and_return(nil)
+          )
+
           get '/active_job'
           sleep 2
 


### PR DESCRIPTION
Description by @confiks from https://github.com/airbrake/airbrake/pull/583:

> In pull request https://github.com/airbrake/airbrake-ruby/pull/75, code was introduced in every integration to return early when `build_notice` returns nil because Airbrake is not configured.

> In at least the ActiveJob integration, the exception is not re-raised when returning early, and thus any ActiveJob queue adapter will happily mark the job successfully completed.

> This pull request contains a fix for the ActiveJob integration

