### PR TITLE
No SystemStackError with any active jobs

### DIFF
--- a/lib/airbrake/rails/active_job.rb
+++ b/lib/airbrake/rails/active_job.rb
@@ -16,7 +16,7 @@ module Airbrake
             notice[:context][:component] = 'active_job'
             notice[:context][:action] = self.class.name
 
-            notice[:params] = as_json
+            notice[:params] = serialize
 
             # We special case Resque because it kills our workers by forking, so
             # we use synchronous delivery instead.

--- a/spec/apps/rails/dummy_app.rb
+++ b/spec/apps/rails/dummy_app.rb
@@ -58,7 +58,14 @@ if Gem::Version.new(Rails.version) >= Gem::Version.new('4.2')
   class BingoJob < ActiveJob::Base
     queue_as :bingo
 
+    class BingoWrapper
+      def initialize(bingo)
+        @bingo = bingo
+      end
+    end
+
     def perform(*_args)
+      @wrapper = BingoWrapper.new(self)
       raise AirbrakeTestError, 'active_job error'
     end
   end

--- a/spec/integration/rails/rails_spec.rb
+++ b/spec/integration/rails/rails_spec.rb
@@ -112,6 +112,16 @@ RSpec.describe "Rails integration specs" do
         ).to have_been_made.at_least_once
       end
 
+      it "does not raise SystemStackError" do
+        get '/active_job'
+        sleep 2
+
+        wait_for(
+          a_request(:post, endpoint).
+          with(body: /"type":"SystemStackError"/)
+        ).not_to have_been_made
+      end
+
       context "when Airbrake is not configured" do
         it "doesn't report errors" do
           allow(Airbrake).to receive(:build_notice).and_return(nil)


### PR DESCRIPTION
Hi, I got SystemStackError and found tiny improvement for this gem 💎 

Since AS's `Object#as_json` simply dump all instance variables, setting
params with `#as_json` can waste resource. Moreover, if the job has
circular reference, calling `#as_json` fails with `SystemStackError`.

We can get parameter information safely by using
`ActiveJob::Base#serialize` method and it will be enough for this
use case.

How about stopping dumping all instance variables? I didn't found any reason to do this.