### PR TITLE
README: fix link to migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,6 @@ commands to invoke them.
 [pricing]: https://airbrake.io/pricing
 [heroku-addon]: https://elements.heroku.com/addons/airbrake
 [heroku-docs]: https://devcenter.heroku.com/articles/airbrake
-[migration-guide]: docs/Migration_guide_from_v4_to_v5.md
+[migration-guide]: https://github.com/airbrake/airbrake/blob/master/docs/Migration_guide_from_v4_to_v5.md
 [dashboard]: https://s3.amazonaws.com/airbrake-github-assets/airbrake/airbrake-dashboard.png
 [arthur-ruby]: https://s3.amazonaws.com/airbrake-github-assets/airbrake/arthur-ruby.jpg


### PR DESCRIPTION
Fixes #599 (I get a 404. The second link in the README works.)