### PR TITLE
Fix duplicate notifications for ActiveJob on Resque

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,10 @@ new initializer in `config/initializers/resque.rb` with the following content:
 ```ruby
 # config/initializers/resque.rb
 require 'airbrake/resque/failure'
-Resque::Failure.backend = Resque::Failure::Airbrake
+require 'resque/failure/redis'
+require 'resque/failure/multiple'
+Resque::Failure::Multiple.classes = [Resque::Failure::Redis, Resque::Failure::Airbrake]
+Resque::Failure.backend = Resque::Failure::Multiple
 ```
 
 That's all configuration.

--- a/lib/airbrake/resque/failure.rb
+++ b/lib/airbrake/resque/failure.rb
@@ -7,12 +7,19 @@ module Resque
     # @see https://github.com/resque/resque/wiki/Failure-Backends
     class Airbrake < Base
       def save
+        return if activejob_exception?
         params = payload.merge(
           component: 'resque',
           action: payload['class'].to_s
         )
 
         ::Airbrake.notify_sync(exception, params)
+      end
+
+      # AirBrake gem already attaches error notifications to ActiveJob
+      # so it needs to be skipped or duplicate exception will be logged
+      def activejob_exception?
+        payload['class'].to_s == 'ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper'
       end
     end
   end


### PR DESCRIPTION
ActiveJob has it's own ErrorHandler which is sending exceptions, there is no need to raise Exception again in Resque error handler
Fixed README.md description how to integrate Airbrake with Resque - multiple backends are required to make failed jobs appear in Resque web panel