### PR TITLE
rubocop: configure the new Metrics/BlockLength cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,3 +74,13 @@ Style/Alias:
 
 Style/MultilineArrayBraceLayout:
   Enabled: true
+
+Metrics/BlockLength:
+  CountComments: false
+  Max: 25
+  Exclude:
+    - 'Rakefile'
+    - '**/*.rake'
+    - 'spec/**/*.rb'
+    - 'airbrake.gemspec'
+    - 'lib/airbrake/rake/tasks.rb'


### PR DESCRIPTION
Fixes failing build.
The cop was introduced by:
https://github.com/bbatsov/rubocop/commit/96f308b4f5601f4642fadc5c5e2826d90df0c0f5