### PR TITLE
Ignore current_user with > 0 params

### DIFF
--- a/lib/airbrake/rack/user.rb
+++ b/lib/airbrake/rack/user.rb
@@ -27,6 +27,7 @@ module Airbrake
         return unless [-1, 0].include?(controller.method(:current_user).arity)
         controller.current_user
       end
+      private_class_method :try_current_user
 
       def initialize(user)
         @user = user

--- a/lib/airbrake/rack/user.rb
+++ b/lib/airbrake/rack/user.rb
@@ -19,7 +19,7 @@ module Airbrake
         # Fallback mode (OmniAuth support included). Works only for Rails.
         controller = rack_env['action_controller.instance']
         return unless controller.respond_to?(:current_user)
-        return unless [-1,0].include(controller.method(:current_user).arity)
+        return unless [-1,0].include?(controller.method(:current_user).arity)
         new(controller.current_user) if controller.current_user
       end
 

--- a/lib/airbrake/rack/user.rb
+++ b/lib/airbrake/rack/user.rb
@@ -18,9 +18,8 @@ module Airbrake
 
         # Fallback mode (OmniAuth support included). Works only for Rails.
         controller = rack_env['action_controller.instance']
-        return unless controller.respond_to?(:current_user)
-        return unless [-1,0].include?(controller.method(:current_user).arity)
-        new(controller.current_user) if controller.current_user
+        user = try_current_user(controller)
+        new(user) if user
       end
 
       def initialize(user)
@@ -49,6 +48,12 @@ module Airbrake
         # Try to get first and last names. If that fails, try to get just 'name'.
         name = [try_to_get(:first_name), try_to_get(:last_name)].compact.join(' ')
         name.empty? ? try_to_get(:name) : name
+      end
+      
+      def self.try_current_user(controller)
+        return unless controller.respond_to?(:current_user)
+        return unless [-1, 0].include?(controller.method(:current_user).arity)
+        return controller.current_user
       end
     end
   end

--- a/lib/airbrake/rack/user.rb
+++ b/lib/airbrake/rack/user.rb
@@ -21,6 +21,12 @@ module Airbrake
         user = try_current_user(controller)
         new(user) if user
       end
+      
+      def self.try_current_user(controller)
+        return unless controller.respond_to?(:current_user)
+        return unless [-1, 0].include?(controller.method(:current_user).arity)
+        return controller.current_user
+      end
 
       def initialize(user)
         @user = user
@@ -48,12 +54,6 @@ module Airbrake
         # Try to get first and last names. If that fails, try to get just 'name'.
         name = [try_to_get(:first_name), try_to_get(:last_name)].compact.join(' ')
         name.empty? ? try_to_get(:name) : name
-      end
-      
-      def self.try_current_user(controller)
-        return unless controller.respond_to?(:current_user)
-        return unless [-1, 0].include?(controller.method(:current_user).arity)
-        return controller.current_user
       end
     end
   end

--- a/lib/airbrake/rack/user.rb
+++ b/lib/airbrake/rack/user.rb
@@ -17,12 +17,12 @@ module Airbrake
         end
 
         # Fallback mode (OmniAuth support included). Works only for Rails.
-        controller = rack_env['action_controller.instance']
-        user = try_current_user(controller)
+        user = try_current_user(rack_env)
         new(user) if user
       end
 
-      def self.try_current_user(controller)
+      def self.try_current_user(rack_env)
+        controller = rack_env['action_controller.instance']
         return unless controller.respond_to?(:current_user)
         return unless [-1, 0].include?(controller.method(:current_user).arity)
         controller.current_user

--- a/lib/airbrake/rack/user.rb
+++ b/lib/airbrake/rack/user.rb
@@ -25,7 +25,7 @@ module Airbrake
       def self.try_current_user(controller)
         return unless controller.respond_to?(:current_user)
         return unless [-1, 0].include?(controller.method(:current_user).arity)
-        return controller.current_user
+        controller.current_user
       end
 
       def initialize(user)

--- a/lib/airbrake/rack/user.rb
+++ b/lib/airbrake/rack/user.rb
@@ -21,7 +21,7 @@ module Airbrake
         user = try_current_user(controller)
         new(user) if user
       end
-      
+
       def self.try_current_user(controller)
         return unless controller.respond_to?(:current_user)
         return unless [-1, 0].include?(controller.method(:current_user).arity)

--- a/lib/airbrake/rack/user.rb
+++ b/lib/airbrake/rack/user.rb
@@ -19,6 +19,7 @@ module Airbrake
         # Fallback mode (OmniAuth support included). Works only for Rails.
         controller = rack_env['action_controller.instance']
         return unless controller.respond_to?(:current_user)
+        return unless [-1,0].include(controller.method(:current_user).arity)
         new(controller.current_user) if controller.current_user
       end
 

--- a/spec/unit/rack/user_spec.rb
+++ b/spec/unit/rack/user_spec.rb
@@ -73,19 +73,67 @@ RSpec.describe Airbrake::Rack::User do
         end
 
         context "but it requires parameters" do
-          before do
-            class DummyController
-              def current_user(_)
-                "username"
+          let(:controller) { dummy_controller.new }
+          subject { described_class.extract(env) }
+
+          context ": current_user(a)" do
+            let(:dummy_controller) do
+              Class.new do
+                def current_user(_a)
+                  "username"
+                end
               end
             end
-          end
-          let(:controller) { DummyController.new }
-          after { Object.send(:remove_const, :DummyController) }
 
-          it "returns nil" do
-            retval = described_class.extract(env)
-            expect(retval).to be_nil
+            it { should be_nil }
+          end
+
+          context ": current_user(a, b)" do
+            let(:dummy_controller) do
+              Class.new do
+                def current_user(_a, _b)
+                  "username"
+                end
+              end
+            end
+
+            it { should be_nil }
+          end
+
+          context ": current_user(a, *b)" do
+            let(:dummy_controller) do
+              Class.new do
+                def current_user(_a, *_b)
+                  "username"
+                end
+              end
+            end
+
+            it { should be_nil }
+          end
+
+          context ": current_user(a, b, *c, &d)" do
+            let(:dummy_controller) do
+              Class.new do
+                def current_user(_a, _b, *_c, &_d)
+                  "username"
+                end
+              end
+            end
+
+            it { should be_nil }
+          end
+
+          context ": current_user(*a)" do
+            let(:dummy_controller) do
+              Class.new do
+                def current_user(*_a)
+                  "username"
+                end
+              end
+            end
+
+            it { should be_a(described_class) }
           end
         end
       end


### PR DESCRIPTION
Fixes #618 
If there is a current_user method that requires parameters, skip calling it (to avoid crashing the app while reporting an exception)