### PR TITLE
rack/notice_builder: attach request body to notices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Airbrake Changelog
 * Fixed Rails bug with regard to the `current_user` method signature having
   parameters, while the library expected none
   ([#619](https://github.com/airbrake/airbrake/pull/619))
+* Started collecting HTTP request body for Rack compliant apps
+  ([#624](https://github.com/airbrake/airbrake/pull/624))
 
 ### [v5.6.0][v5.6.0] (October 18, 2016)
 

--- a/lib/airbrake/rack/notice_builder.rb
+++ b/lib/airbrake/rack/notice_builder.rb
@@ -90,8 +90,10 @@ module Airbrake
       ##
       # Adds HTTP request parameters.
       add_builder do |notice, request|
-        params = request.env['action_dispatch.request.parameters']
-        notice[:params] = params if params
+        notice[:params] = request.params
+
+        rails_params = request.env['action_dispatch.request.parameters']
+        notice[:params].merge!(rails_params) if rails_params
       end
 
       ##
@@ -110,6 +112,15 @@ module Airbrake
           referer: request.referer,
           headers: http_headers
         )
+
+        notice[:environment][:body] =
+          if request.body
+            data = request.body.read(512)
+            request.body.rewind
+            data
+          end
+
+        notice[:environment]
       end
     end
   end

--- a/spec/unit/rack/notice_builder_spec.rb
+++ b/spec/unit/rack/notice_builder_spec.rb
@@ -1,9 +1,13 @@
 require 'spec_helper'
 
 RSpec.describe Airbrake::Rack::NoticeBuilder do
+  def env_for(url, opts = {})
+    Rack::MockRequest.env_for(url, opts)
+  end
+
   describe "#build_notice" do
-    it "doesn't overwrite session with nil" do
-      notice_builder = described_class.new('rack.session' => nil)
+    it "doesn't overwrite the session key with nil" do
+      notice_builder = described_class.new(env_for('/', 'rack.session' => nil))
       notice = notice_builder.build_notice(AirbrakeTestError.new)
 
       expect(notice[:session]).to eq({})
@@ -11,25 +15,38 @@ RSpec.describe Airbrake::Rack::NoticeBuilder do
 
     it "sets session if it is present" do
       session = { a: 1, b: 2 }
-      notice_builder = described_class.new('rack.session' => session)
+      notice_builder = described_class.new(env_for('/', 'rack.session' => session))
       notice = notice_builder.build_notice(AirbrakeTestError.new)
 
       expect(notice[:session]).to eq(session)
     end
 
-    it "doesn't overwrite params with nil" do
-      notice_builder = described_class.new('action_dispatch.request.parameters' => nil)
+    it "doesn't overwrite the params key with nil" do
+      notice_builder = described_class.new(env_for('/'))
       notice = notice_builder.build_notice(AirbrakeTestError.new)
 
       expect(notice[:session]).to eq({})
     end
 
-    it "sets params if they're present" do
+    it "sets form params if they're present" do
       params = { a: 1, b: 2 }
-      notice_builder = described_class.new('action_dispatch.request.parameters' => params)
+      input = StringIO.new
+
+      notice_builder = described_class.new(
+        'rack.request.form_hash' => params,
+        'rack.request.form_input' => input,
+        'rack.input' => input
+      )
       notice = notice_builder.build_notice(AirbrakeTestError.new)
 
       expect(notice[:params]).to eq(params)
+    end
+
+    it "sets query string params if they're present" do
+      notice_builder = described_class.new(env_for('/?bingo=bango&bongo=bish'))
+      notice = notice_builder.build_notice(AirbrakeTestError.new)
+
+      expect(notice[:params]).to eq('bingo' => 'bango', 'bongo' => 'bish')
     end
 
     it "adds CONTENT_TYPE, CONTENT_LENGTH and HTTP_* headers in the environment" do
@@ -38,7 +55,7 @@ RSpec.describe Airbrake::Rack::NoticeBuilder do
         "CONTENT_TYPE" => "text/html",
         "CONTENT_LENGTH" => 100500
       }
-      notice_builder = described_class.new(headers.dup)
+      notice_builder = described_class.new(env_for('/', headers.dup))
       notice = notice_builder.build_notice(AirbrakeTestError.new)
       expect(notice[:environment][:headers]).to eq(headers)
     end
@@ -49,8 +66,11 @@ RSpec.describe Airbrake::Rack::NoticeBuilder do
         "CONTENT_TYPE" => "text/html",
         "CONTENT_LENGTH" => 100500
       }
-      notice_builder = described_class.new(headers.merge("X-SOME-HEADER" => "value"))
+      notice_builder = described_class.new(
+        env_for('/', headers.merge("X-SOME-HEADER" => "value"))
+      )
       notice = notice_builder.build_notice(AirbrakeTestError.new)
+
       expect(notice[:environment][:headers]).to eq(headers)
     end
 
@@ -65,28 +85,72 @@ RSpec.describe Airbrake::Rack::NoticeBuilder do
         notice[:environment]["SOME_KEY"] = "SOME_VALUE"
         notice
       end
-      notice_builder = described_class.new(headers)
+      notice_builder = described_class.new(env_for('/', headers))
       notice = notice_builder.build_notice(AirbrakeTestError.new)
+
       expect(notice[:environment]["SOME_KEY"]).to eq("SOME_VALUE")
     end
 
-    it "runs user defined builders against notices" do
-      extended_class = described_class.dup
-      extended_class.add_builder do |notice, request|
-        notice[:params][:remoteIp] = request.env['REMOTE_IP']
+    context "when a custom builder is defined" do
+      before do
+        described_class.add_builder do |notice, request|
+          notice[:params][:remoteIp] = request.env['REMOTE_IP']
+        end
       end
-      notice_builder = extended_class.new('REMOTE_IP' => '127.0.0.1')
-      notice = notice_builder.build_notice(AirbrakeTestError.new)
-      expect(notice[:params][:remoteIp]).to eq("127.0.0.1")
+
+      after do
+        described_class.instance_variable_get(:@builders).pop
+      end
+
+      it "runs the builder against notices" do
+        notice_builder = described_class.new(env_for('/', 'REMOTE_IP' => '127.0.0.1'))
+        notice = notice_builder.build_notice(AirbrakeTestError.new)
+
+        expect(notice[:params][:remoteIp]).to eq("127.0.0.1")
+      end
     end
 
     context "when Airbrake is not configured" do
       it "returns nil" do
         allow(Airbrake).to receive(:build_notice).and_return(nil)
-        notice_builder = described_class.new('bingo' => 'bango')
+        notice_builder = described_class.new(env_for('/', 'bingo' => 'bango'))
 
         expect(notice_builder.build_notice('bongo')).to be_nil
         expect(Airbrake).to have_received(:build_notice)
+      end
+    end
+
+    context "when a request has a body" do
+      it "reads the body" do
+        body = StringIO.new('<bingo>bongo</bango>')
+        notice_builder = described_class.new(
+          env_for('/', 'rack.input' => body)
+        )
+        notice = notice_builder.build_notice(AirbrakeTestError.new)
+
+        expect(notice[:environment][:body]).to eq(body.string)
+      end
+
+      it "rewinds rack.input" do
+        body = StringIO.new('<bingo>bongo</bango>' * 512)
+        notice_builder = described_class.new(
+          env_for('/', 'rack.input' => body)
+        )
+
+        notice_builder.build_notice(AirbrakeTestError.new)
+
+        expect(body.pos).to be_zero
+      end
+
+      it "reads only first 512 bytes" do
+        len = 513
+        body = StringIO.new('a' * len)
+        notice_builder = described_class.new(
+          env_for('/', 'rack.input' => body)
+        )
+        notice = notice_builder.build_notice(AirbrakeTestError.new)
+
+        expect(notice[:environment][:body]).to eq(body.string[0...len - 1])
       end
     end
   end


### PR DESCRIPTION
Fixes #623 (Rack: send payload of XML requests on POST)