### PR TITLE
rack/notice_builder: read up to 4096 bytes from Rack request's body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Read up to 4096 bytes from Rack request's body (increased from 512)
+  ([#627](https://github.com/airbrake/airbrake/pull/627))
+
 ### [v5.6.1][v5.6.1] (October 24, 2016)
 
 * Fixed Rails bug with regard to the `current_user` method signature having

--- a/lib/airbrake/rack/notice_builder.rb
+++ b/lib/airbrake/rack/notice_builder.rb
@@ -113,12 +113,10 @@ module Airbrake
           headers: http_headers
         )
 
-        notice[:environment][:body] =
-          if request.body
-            data = request.body.read(512)
-            request.body.rewind
-            data
-          end
+        if request.body
+          notice[:environment][:body] = request.body.read(4096)
+          request.body.rewind
+        end
 
         notice[:environment]
       end

--- a/spec/unit/rack/notice_builder_spec.rb
+++ b/spec/unit/rack/notice_builder_spec.rb
@@ -142,8 +142,8 @@ RSpec.describe Airbrake::Rack::NoticeBuilder do
         expect(body.pos).to be_zero
       end
 
-      it "reads only first 512 bytes" do
-        len = 513
+      it "reads only first 4096 bytes" do
+        len = 4097
         body = StringIO.new('a' * len)
         notice_builder = described_class.new(
           env_for('/', 'rack.input' => body)


### PR DESCRIPTION
Fixes #626 (Log full HTTP post data)

We can't really read the whole body because it will significantly
increase our average notice size. But we're trying to find the right
balance here and read more.