### PR TITLE
Prevent users from signing in during notify_airbrake

### DIFF
--- a/lib/airbrake/rack/user.rb
+++ b/lib/airbrake/rack/user.rb
@@ -22,7 +22,11 @@ module Airbrake
       end
 
       def self.try_user_signed_in(rack_env)
+                puts " see me 1321321321 " * 100
+
         controller = rack_env['action_controller.instance']
+                puts " see me 65464654654 " * 100
+
         return unless controller.respond_to?(:user_signed_in?)
         puts " see me 9879879387 " * 100
         return unless [-1, 0].include?(controller.method(:user_signed_in?).arity)

--- a/lib/airbrake/rack/user.rb
+++ b/lib/airbrake/rack/user.rb
@@ -35,7 +35,7 @@ module Airbrake
         return unless [-1, 0].include?(controller.method(:current_user).arity)
         controller.current_user
       end
-      private_class_method :try_current_user 
+      private_class_method :try_current_user
 
       def initialize(user)
         @user = user

--- a/lib/airbrake/rack/user.rb
+++ b/lib/airbrake/rack/user.rb
@@ -21,7 +21,7 @@ module Airbrake
         new(user) if user
       end
 
-      def self.try_user_signed_in
+      def self.try_user_signed_in(rack_env)
         controller = rack_env['action_controller.instance']
         return unless controller.respond_to?(:user_signed_in)
         return unless [-1, 0].include?(controller.method(:user_signed_in).arity)
@@ -29,7 +29,7 @@ module Airbrake
       end
       
       def self.try_current_user(rack_env)
-        return unless self.try_user_signed_in
+        return unless self.try_user_signed_in(rack_env)
         controller = rack_env['action_controller.instance']
         return unless controller.respond_to?(:current_user)
         return unless [-1, 0].include?(controller.method(:current_user).arity)

--- a/lib/airbrake/rack/user.rb
+++ b/lib/airbrake/rack/user.rb
@@ -24,6 +24,7 @@ module Airbrake
       def self.try_user_signed_in(rack_env)
         controller = rack_env['action_controller.instance']
         return unless controller.respond_to?(:user_signed_in?)
+        puts " see me 9879879387 " * 100
         return unless [-1, 0].include?(controller.method(:user_signed_in?).arity)
         controller.user_signed_in?
       end

--- a/lib/airbrake/rack/user.rb
+++ b/lib/airbrake/rack/user.rb
@@ -21,13 +21,21 @@ module Airbrake
         new(user) if user
       end
 
+      def self.try_user_signed_in
+        controller = rack_env['action_controller.instance']
+        return unless controller.respond_to?(:user_signed_in)
+        return unless [-1, 0].include?(controller.method(:user_signed_in).arity)
+        controller.user_signed_in
+      end
+      
       def self.try_current_user(rack_env)
+        return unless self.try_user_signed_in
         controller = rack_env['action_controller.instance']
         return unless controller.respond_to?(:current_user)
         return unless [-1, 0].include?(controller.method(:current_user).arity)
         controller.current_user
       end
-      private_class_method :try_current_user
+      private_class_method :try_current_user, :try_user_signed_in
 
       def initialize(user)
         @user = user

--- a/lib/airbrake/rack/user.rb
+++ b/lib/airbrake/rack/user.rb
@@ -23,9 +23,9 @@ module Airbrake
 
       def self.try_user_signed_in(rack_env)
         controller = rack_env['action_controller.instance']
-        return unless controller.respond_to?(:user_signed_in)
-        return unless [-1, 0].include?(controller.method(:user_signed_in).arity)
-        controller.user_signed_in
+        return unless controller.respond_to?(:user_signed_in?)
+        return unless [-1, 0].include?(controller.method(:user_signed_in?).arity)
+        controller.user_signed_in?
       end
       
       def self.try_current_user(rack_env)
@@ -35,7 +35,7 @@ module Airbrake
         return unless [-1, 0].include?(controller.method(:current_user).arity)
         controller.current_user
       end
-      private_class_method :try_current_user, :try_user_signed_in
+      private_class_method :try_current_user 
 
       def initialize(user)
         @user = user

--- a/lib/airbrake/rack/user.rb
+++ b/lib/airbrake/rack/user.rb
@@ -21,7 +21,7 @@ module Airbrake
         new(user) if user
       end
 
-      def self.try_user_signed_in(rack_env)
+      def self.try_warden_authenticated?(rack_env)
         controller = rack_env['action_controller.instance']
         return unless controller.respond_to?(:warden)
         return unless [-1, 0].include?(controller.method(:warden).arity)
@@ -29,11 +29,7 @@ module Airbrake
       end
       
       def self.try_current_user(rack_env)
-        puts " see me 65464654654 " * 100
-
-        return unless self.try_user_signed_in(rack_env)
-        puts " see me 9879879387 " * 100
-
+        return unless self.try_warden_authenticated?(rack_env)
         controller = rack_env['action_controller.instance']
         return unless controller.respond_to?(:current_user)
         return unless [-1, 0].include?(controller.method(:current_user).arity)

--- a/lib/airbrake/rack/user.rb
+++ b/lib/airbrake/rack/user.rb
@@ -22,19 +22,18 @@ module Airbrake
       end
 
       def self.try_user_signed_in(rack_env)
-                puts " see me 1321321321 " * 100
-
         controller = rack_env['action_controller.instance']
-                puts " see me 65464654654 " * 100
-
-        return unless controller.respond_to?(:user_signed_in?)
-        puts " see me 9879879387 " * 100
-        return unless [-1, 0].include?(controller.method(:user_signed_in?).arity)
-        controller.user_signed_in?
+        return unless controller.respond_to?(:warden)
+        return unless [-1, 0].include?(controller.method(:warden).arity)
+        controller.warden.authenticated?(scope: :user)
       end
       
       def self.try_current_user(rack_env)
+        puts " see me 65464654654 " * 100
+
         return unless self.try_user_signed_in(rack_env)
+        puts " see me 9879879387 " * 100
+
         controller = rack_env['action_controller.instance']
         return unless controller.respond_to?(:current_user)
         return unless [-1, 0].include?(controller.method(:current_user).arity)


### PR DESCRIPTION
### What GitHub issue(s) does this address?
Fixes #641  

### What problem does your PR solve?
If a developer calls `notify_airbrake` during a user log-in request, `notify_airbrake` will attempt to authenticate and sign in the user. This is because `notify_airbrake` calls Devise's `current_user` which attempts to sign the user in. This is not the intended behavior of `notify_airbrake`.

### What does your code solution do?
I've added a check that first calls `warden.authenticated?` to see if the user is signed in. If the user is signed in, we then call `current_user`.  
 
### Are there any special changes in the code that we should be aware of?
None.

### Anything else we should know?
For more info on how Devise and Warden are authenticating the user when calling `current_user`, view these files below:

https://github.com/plataformatec/devise/blob/v3.4.1/lib/devise/controllers/helpers.rb#L119
https://github.com/hassox/warden/blob/master/lib/warden/proxy.rb#L103
https://github.com/hassox/warden/blob/master/lib/warden/proxy.rb#L316