### PR TITLE
rack/user: return early if Warden is present and no user found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Airbrake Changelog
 
 * Read up to 4096 bytes from Rack request's body (increased from 512)
   ([#627](https://github.com/airbrake/airbrake/pull/627))
+* Fixed unwanted authentication when calling `current_user`, when Warden is
+  present ([#643](https://github.com/airbrake/airbrake/pull/643))
 
 ### [v5.6.1][v5.6.1] (October 24, 2016)
 

--- a/lib/airbrake/rack/user.rb
+++ b/lib/airbrake/rack/user.rb
@@ -11,9 +11,11 @@ module Airbrake
       def self.extract(rack_env)
         # Warden support (including Devise).
         if (warden = rack_env['warden'])
-          if (user = warden.user(run_callbacks: false))
-            return new(user) if user
-          end
+          user = warden.user(run_callbacks: false)
+          # Early return to prevent unwanted possible authentication via
+          # calling the `current_user` method later.
+          # See: https://github.com/airbrake/airbrake/issues/641
+          return user ? new(user) : nil
         end
 
         # Fallback mode (OmniAuth support included). Works only for Rails.

--- a/spec/integration/rails/rails_spec.rb
+++ b/spec/integration/rails/rails_spec.rb
@@ -202,6 +202,10 @@ RSpec.describe "Rails integration specs" do
 
   describe "notice payload when a user is authenticated without Warden" do
     context "when the current_user method is defined" do
+      before do
+        allow(Warden::Proxy).to receive(:new) { nil }
+      end
+
       it "contains the user information" do
         user = OpenStruct.new(id: 1, email: 'qa@example.com', username: 'qa-dept')
         allow_any_instance_of(DummyController).to receive(:current_user) { user }


### PR DESCRIPTION
Fixes #641 (notify_airbrake persists user login during 422 error)
Replaces #642 (Prevent users from signing in during notify_airbrake)
