### PR TITLE
Appraisals: fix delayed_job_active_record

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -98,7 +98,7 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
     # to test our Resque integration.
     gem 'resque_spec', github: 'airbrake/resque_spec'
 
-    gem 'delayed_job_active_record', github: 'collectiveidea/delayed_job_active_record'
+    gem 'delayed_job_active_record', github: 'airbrake/delayed_job_active_record', branch: 'rails-edge-fix'
     gem 'delayed_job', github: 'collectiveidea/delayed_job'
   end
 end

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -11,7 +11,7 @@ gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.20", :platforms => :jruby
 gem "sqlite3", "~> 1.3.11", :platforms => [:mri, :rbx]
 gem "resque", "~> 1.6"
 gem "resque_spec", :github => "airbrake/resque_spec"
-gem "delayed_job_active_record", :github => "collectiveidea/delayed_job_active_record"
+gem "delayed_job_active_record", :github => "airbrake/delayed_job_active_record", :branch => "rails-edge-fix"
 gem "delayed_job", :github => "collectiveidea/delayed_job"
 
 gemspec :path => "../"


### PR DESCRIPTION
Fixes (https://circleci.com/gh/airbrake/airbrake/985):

```
Directly inheriting from ActiveRecord::Migration is not
supported. Please specify the Rails release the migration was written
for: (StandardError)
```

The gem seems to be abandoned, so we depend on a fork here to make sure
our tests pass on rails-edge.

This is what fixed the error:
https://github.com/airbrake/delayed_job_active_record/commit/56c2b52e42a201fc0923b94ce56b28e65bd69db5