### PR TITLE
Remove support for Ruby 1.9.2 & 1.9.3

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -23,10 +23,7 @@ appraise 'rails-4.0' do
 
   gem 'delayed_job_active_record', '~> 4.1.0'
 
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
-    # Newer 'mime-types' doesn't support Ruby 1.9.3 anymore.
-    gem 'mime-types', '~> 2.6'
-  end
+  gem 'mime-types', '~> 3.1'
 end
 
 appraise 'rails-4.1' do
@@ -41,10 +38,7 @@ appraise 'rails-4.1' do
 
   gem 'delayed_job_active_record', '~> 4.1.0'
 
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
-    # Newer 'mime-types' doesn't support Ruby 1.9.3 anymore.
-    gem 'mime-types', '~> 2.6'
-  end
+  gem 'mime-types', '~> 3.1'
 end
 
 appraise 'rails-4.2' do
@@ -59,10 +53,7 @@ appraise 'rails-4.2' do
 
   gem 'delayed_job_active_record', '~> 4.1.0'
 
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
-    # Newer 'mime-types' doesn't support Ruby 1.9.3 anymore.
-    gem 'mime-types', '~> 2.6'
-  end
+  gem 'mime-types', '~> 3.1'
 end
 
 # Rails 5+ supports only modern Rubies (2.2.2+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Airbrake Changelog
 
 ### master
 
+* **IMPORTANT:** support for Ruby 1.9.2, 1.9.3 & JRuby (1.9-mode) is dropped
+  ([#646](https://github.com/airbrake/airbrake/pull/646))
 * Read up to 4096 bytes from Rack request's body (increased from 512)
   ([#627](https://github.com/airbrake/airbrake/pull/627))
 * Fixed unwanted authentication when calling `current_user`, when Warden is

--- a/README.md
+++ b/README.md
@@ -458,8 +458,8 @@ Then, invoke it like shown in the example for Rails.
 Supported Rubies
 ----------------
 
-* CRuby >= 1.9.2
-* JRuby >= 1.9-mode
+* CRuby >= 2.0.0
+* JRuby >= 9k
 * Rubinius >= 2.2.10
 
 Contact

--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -29,6 +29,8 @@ DESC
   s.files        = ['lib/airbrake.rb', *Dir.glob('lib/**/*')]
   s.test_files   = Dir.glob('spec/**/*')
 
+  s.required_ruby_version = '>= 2.0'
+
   s.add_dependency 'airbrake-ruby', '~> 1.6'
 
   s.add_development_dependency 'rspec', '~> 3'
@@ -37,12 +39,9 @@ DESC
   s.add_development_dependency 'pry', '~> 0'
   s.add_development_dependency 'appraisal', '~> 2'
   s.add_development_dependency 'rack', '~> 1'
+  s.add_development_dependency 'webmock', '~> 2'
 
-  # We still support Ruby 1.9.2+, but webmock 2.2.0+ doesn't.
-  s.add_development_dependency 'webmock', '= 2.2.0'
-
-  # We still support Ruby 1.9.2+, 1.9.3+, 2.0.0+, but
-  # nokogiri 1.7.0+ doesn't.
+  # We still support Ruby 2.0.0+, but nokogiri 1.7.0+ doesn't.
   s.add_development_dependency 'nokogiri', '= 1.6.8.1'
 
   s.add_development_dependency 'rack-test', '~> 0'

--- a/circle.yml
+++ b/circle.yml
@@ -12,8 +12,6 @@ dependencies:
     - ? |
         case $CIRCLE_NODE_INDEX in
           0)
-            rvm-exec 1.9.3-p551 bundle install --jobs=15 --path=vendor
-            rvm-exec 1.9.3-p551 bundle exec appraisal install --jobs=15
             ;;
           1)
             rvm-exec 2.0.0-p645 bundle install --jobs=15 --path=vendor
@@ -48,14 +46,6 @@ test:
         set -e
         case $CIRCLE_NODE_INDEX in
           0)
-            rvm-exec 1.9.3-p551 bundle exec appraisal rails-3.2 rake spec:integration:rails
-            rvm-exec 1.9.3-p551 bundle exec appraisal rails-4.0 rake spec:integration:rails
-            rvm-exec 1.9.3-p551 bundle exec appraisal rails-4.1 rake spec:integration:rails
-            rvm-exec 1.9.3-p551 bundle exec appraisal rails-4.2 rake spec:integration:rails
-
-            rvm-exec 1.9.3-p551 bundle exec appraisal sinatra rake spec:integration:sinatra
-
-            rvm-exec 1.9.3-p551 bundle exec appraisal rack rake spec:integration:rack
             ;;
           1)
             rvm-exec 2.0.0-p645 bundle exec appraisal rails-3.2 rake spec:integration:rails
@@ -98,7 +88,6 @@ test:
         set -e
         case $CIRCLE_NODE_INDEX in
           0)
-            rvm-exec 1.9.3-p551 bundle exec rake spec:unit
             ;;
           1)
             rvm-exec 2.0.0-p645 bundle exec rake spec:unit

--- a/spec/integration/rails/rails_spec.rb
+++ b/spec/integration/rails/rails_spec.rb
@@ -179,24 +179,21 @@ RSpec.describe "Rails integration specs" do
     end
   end
 
-  # Delayed Job doesn't support Ruby 1.9.2
-  if Gem::Version.new(RUBY_VERSION) > Gem::Version.new('1.9.2')
-    describe "DelayedJob jobs" do
-      it "reports exceptions occurring in DelayedJob jobs" do
-        get '/delayed_job'
-        sleep 2
+  describe "DelayedJob jobs" do
+    it "reports exceptions occurring in DelayedJob jobs" do
+      get '/delayed_job'
+      sleep 2
 
-        wait_for_a_request_with_body(
-          %r("message":"delayed_job\serror".*"params":{.*
+      wait_for_a_request_with_body(
+        %r("message":"delayed_job\serror".*"params":{.*
            "handler":"---\s!ruby/struct:BangoJob\\nbingo:\s
                      bingo\\nbongo:\sbongo\\n".*})x
-        )
+      )
 
-        # Two requests are performed during this example. We care only about one.
-        # Sleep guarantees that we let the unimportant request occur here and not
-        # elsewhere.
-        sleep 2
-      end
+      # Two requests are performed during this example. We care only about one.
+      # Sleep guarantees that we let the unimportant request occur here and not
+      # elsewhere.
+      sleep 2
     end
   end
 


### PR DESCRIPTION
* Remove support for 1.9.2 (official support ended on 2014-07-31)
* Remove support for 1.9.3 (official support ended on 2015-02-23)
* Remove support for JRuby 1.7.X (quote from JRuby: "The primary goal of
  1.7 point releases is to fill out any missing compatibility issues
  with Ruby 1.9.3)