### PR TITLE
notice_builder: support class definitions for builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ Airbrake Changelog
 
 * **IMPORTANT:** support for Ruby 1.9.2, 1.9.3 & JRuby (1.9-mode) is dropped
   ([#646](https://github.com/airbrake/airbrake/pull/646))
-* Read up to 4096 bytes from Rack request's body (increased from 512)
-  ([#627](https://github.com/airbrake/airbrake/pull/627))
 * Fixed unwanted authentication when calling `current_user`, when Warden is
   present ([#643](https://github.com/airbrake/airbrake/pull/643))
+* Stopped collecting HTTP request bodies by default, which started happening
+  since [v5.6.1](#v561-october-24-2016). Due to security concerns we now make
+  this behaviour optional. Users who need this information can use a new
+  predefined builder called `Airbrake::Rack::RequestBodyBuilder`
+  ([#650](https://github.com/airbrake/airbrake/pull/650))
 
 ### [v5.6.1][v5.6.1] (October 24, 2016)
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,17 @@ end
 
 `request` here is a normal Rack request.
 
+The library comes with optional predefined builders listed below.
+
+##### RequestBodyBuilder
+
+`RequestBodyBuilder` appends Rack request body to the notice. It accepts a
+`length` argument, which tells the builder how many bytes to read from the body.
+
+```ruby
+Airbrake.add_rack_builder(Airbrake::Rack::RequestBodyBuilder.new(512))
+```
+
 #### Configuring individual notifier for each subproject
 
 If your app consists of multiple components and you want to log errors from each

--- a/lib/airbrake/rack/context_builder.rb
+++ b/lib/airbrake/rack/context_builder.rb
@@ -1,0 +1,42 @@
+module Airbrake
+  module Rack
+    ##
+    # Adds context (URL, User-Agent, framework version, controller and more).
+    #
+    # @since v5.7.0
+    class ContextBuilder
+      def initialize
+        @framework_version =
+          if defined?(::Rails)
+            "Rails/#{::Rails.version}"
+          elsif defined?(::Sinatra)
+            "Sinatra/#{Sinatra::VERSION}"
+          else
+            "Rack.version/#{::Rack.version} Rack.release/#{::Rack.release}"
+          end.freeze
+      end
+
+      def call(notice, request)
+        context = notice[:context]
+
+        context[:url] = request.url
+        context[:userAgent] = request.user_agent
+
+        if context.key?(:version)
+          context[:version] += " #{@framework_version}"
+        else
+          context[:version] = @framework_version
+        end
+
+        controller = request.env['action_controller.instance']
+        if controller
+          context[:component] = controller.controller_name
+          context[:action] = controller.action_name
+        end
+
+        user = Airbrake::Rack::User.extract(request.env)
+        notice[:context].merge!(user.as_json) if user
+      end
+    end
+  end
+end

--- a/lib/airbrake/rack/http_headers_builder.rb
+++ b/lib/airbrake/rack/http_headers_builder.rb
@@ -1,0 +1,36 @@
+module Airbrake
+  module Rack
+    ##
+    # Adds HTTP request parameters.
+    #
+    # @since v5.7.0
+    class HttpHeadersBuilder
+      ##
+      # @return [Array<String>] the prefixes of the majority of HTTP headers in
+      #   Rack (some prefixes match the header names for simplicity)
+      HTTP_HEADER_PREFIXES = [
+        'HTTP_'.freeze,
+        'CONTENT_TYPE'.freeze,
+        'CONTENT_LENGTH'.freeze
+      ].freeze
+
+      def call(notice, request)
+        http_headers = request.env.map.with_object({}) do |(key, value), headers|
+          if HTTP_HEADER_PREFIXES.any? { |prefix| key.to_s.start_with?(prefix) }
+            headers[key] = value
+          end
+
+          headers
+        end
+
+        notice[:environment].merge!(
+          httpMethod: request.request_method,
+          referer: request.referer,
+          headers: http_headers
+        )
+
+        notice[:environment]
+      end
+    end
+  end
+end

--- a/lib/airbrake/rack/http_params_builder.rb
+++ b/lib/airbrake/rack/http_params_builder.rb
@@ -1,0 +1,16 @@
+module Airbrake
+  module Rack
+    ##
+    # Adds HTTP request parameters.
+    #
+    # @since v5.7.0
+    class HttpParamsBuilder
+      def call(notice, request)
+        notice[:params] = request.params
+
+        rails_params = request.env['action_dispatch.request.parameters']
+        notice[:params].merge!(rails_params) if rails_params
+      end
+    end
+  end
+end

--- a/lib/airbrake/rack/notice_builder.rb
+++ b/lib/airbrake/rack/notice_builder.rb
@@ -10,22 +10,7 @@ module Airbrake
         ##
         # @return [Array<Proc>] the list of notice builders
         attr_reader :builders
-
-        ##
-        # Adds user defined builders to the chain.
-        def add_builder(&block)
-          @builders << block
-        end
       end
-
-      ##
-      # @return [Array<String>] the prefixes of the majority of HTTP headers in
-      #   Rack (some prefixes match the header names for simplicity)
-      HTTP_HEADER_PREFIXES = [
-        'HTTP_'.freeze,
-        'CONTENT_TYPE'.freeze,
-        'CONTENT_LENGTH'.freeze
-      ].freeze
 
       ##
       # @param [Hash{String=>Object}] rack_env The Rack environment
@@ -45,80 +30,6 @@ module Airbrake
 
         NoticeBuilder.builders.each { |builder| builder.call(notice, @request) }
         notice
-      end
-
-      ##
-      # Adds context (URL, User-Agent, framework version, controller and more).
-      add_builder do |notice, request|
-        context = notice[:context]
-
-        context[:url] = request.url
-        context[:userAgent] = request.user_agent
-
-        framework_version =
-          if defined?(::Rails)
-            "Rails/#{::Rails.version}"
-          elsif defined?(::Sinatra)
-            "Sinatra/#{Sinatra::VERSION}"
-          else
-            "Rack.version/#{::Rack.version} Rack.release/#{::Rack.release}"
-          end.freeze
-
-        if context.key?(:version)
-          context[:version] += " #{framework_version}"
-        else
-          context[:version] = framework_version
-        end
-
-        controller = request.env['action_controller.instance']
-        if controller
-          context[:component] = controller.controller_name
-          context[:action] = controller.action_name
-        end
-
-        user = Airbrake::Rack::User.extract(request.env)
-        notice[:context].merge!(user.as_json) if user
-      end
-
-      ##
-      # Adds session.
-      add_builder do |notice, request|
-        session = request.session
-        notice[:session] = session if session
-      end
-
-      ##
-      # Adds HTTP request parameters.
-      add_builder do |notice, request|
-        notice[:params] = request.params
-
-        rails_params = request.env['action_dispatch.request.parameters']
-        notice[:params].merge!(rails_params) if rails_params
-      end
-
-      ##
-      # Adds HTTP referer, method and headers to the environment.
-      add_builder do |notice, request|
-        http_headers = request.env.map.with_object({}) do |(key, value), headers|
-          if HTTP_HEADER_PREFIXES.any? { |prefix| key.to_s.start_with?(prefix) }
-            headers[key] = value
-          end
-
-          headers
-        end
-
-        notice[:environment].merge!(
-          httpMethod: request.request_method,
-          referer: request.referer,
-          headers: http_headers
-        )
-
-        if request.body
-          notice[:environment][:body] = request.body.read(4096)
-          request.body.rewind
-        end
-
-        notice[:environment]
       end
     end
   end

--- a/lib/airbrake/rack/request_body_builder.rb
+++ b/lib/airbrake/rack/request_body_builder.rb
@@ -1,0 +1,29 @@
+module Airbrake
+  module Rack
+    ##
+    # A builder that appends Rack request body to the notice.
+    #
+    # @example
+    #   # Read and append up to 512 bytes from Rack request's body.
+    #   Airbrake.add_rack_builder(Airbrake::Rack::RequestBodyBuilder.new(512))
+    #
+    # @since v5.7.0
+    # @note This builder is *not* included by default.
+    class RequestBodyBuilder
+      ##
+      # @param [Integer] length The maximum number of bytes to read
+      def initialize(length = 4096)
+        @length = length
+      end
+
+      ##
+      # @see Airbrake.add_rack_builder
+      def call(notice, request)
+        return unless request.body
+
+        notice[:environment][:body] = request.body.read(@length)
+        request.body.rewind
+      end
+    end
+  end
+end

--- a/lib/airbrake/rack/session_builder.rb
+++ b/lib/airbrake/rack/session_builder.rb
@@ -1,0 +1,14 @@
+module Airbrake
+  module Rack
+    ##
+    # Adds HTTP session.
+    #
+    # @since v5.7.0
+    class SessionBuilder
+      def call(notice, request)
+        session = request.session
+        notice[:session] = session if session
+      end
+    end
+  end
+end


### PR DESCRIPTION
Also:

  * add optional default builder - `RequestBodyBuilder` (appends request
    body)
  * refactor other builders, so they also use classes