### PR TITLE
Refactor some integrations to stop using deprecated API

### DIFF
--- a/lib/airbrake/resque/failure.rb
+++ b/lib/airbrake/resque/failure.rb
@@ -7,12 +7,11 @@ module Resque
     # @see https://github.com/resque/resque/wiki/Failure-Backends
     class Airbrake < Base
       def save
-        params = payload.merge(
-          component: 'resque',
-          action: payload['class'].to_s
-        )
+        notice = ::Airbrake.build_notice(exception, payload)
+        notice[:context][:component] = 'resque'
+        notice[:context][:action] = payload['class'].to_s
 
-        ::Airbrake.notify_sync(exception, params)
+        ::Airbrake.notify_sync(notice)
       end
     end
   end

--- a/lib/airbrake/sidekiq/error_handler.rb
+++ b/lib/airbrake/sidekiq/error_handler.rb
@@ -15,8 +15,11 @@ module Airbrake
       private
 
       def notify_airbrake(exception, context)
-        params = context.merge(component: 'sidekiq', action: context['class'])
-        Airbrake.notify(exception, params)
+        notice = Airbrake.build_notice(exception, context)
+        notice[:context][:component] = 'sidekiq'
+        notice[:context][:action] = context['class']
+
+        Airbrake.notify(notice)
       end
     end
   end


### PR DESCRIPTION
Setting `component/action` like that was deprecated in
https://github.com/airbrake/airbrake-ruby/pull/151