### PR TITLE
only use Rails.version if it is defined

### DIFF
--- a/lib/airbrake/rack/context_filter.rb
+++ b/lib/airbrake/rack/context_filter.rb
@@ -7,7 +7,7 @@ module Airbrake
     class ContextFilter
       def initialize
         @framework_version =
-          if defined?(::Rails)
+          if defined?(::Rails) and ::Rails.respond_to?(:version)
             "Rails/#{::Rails.version}"
           elsif defined?(::Sinatra)
             "Sinatra/#{Sinatra::VERSION}"

--- a/lib/airbrake/rack/context_filter.rb
+++ b/lib/airbrake/rack/context_filter.rb
@@ -7,7 +7,7 @@ module Airbrake
     class ContextFilter
       def initialize
         @framework_version =
-          if defined?(::Rails) and ::Rails.respond_to?(:version)
+          if defined?(::Rails) && ::Rails.respond_to?(:version)
             "Rails/#{::Rails.version}"
           elsif defined?(::Sinatra)
             "Sinatra/#{Sinatra::VERSION}"


### PR DESCRIPTION
This is an interesting situation.

I am writing a Grape API application using only Rack, however, I am using ActionMailer to send some emails in Sidekiq. Something inside one of the Action* gems is defining the module `Rails`, but it's not fully loaded, as I am not using Rails. So when Airbrake gets to the point where it wants to use the context filter, it fails because `version` is not defined in the `Rails` module.

This code just checks to see if version is a defined attribute or method of the module `Rails`.