### PR TITLE
Add Shoryuken support 

### DIFF
--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -17,8 +17,8 @@ prioritization of exceptions so that when errors occur, your team can quickly
 determine the root cause.
 
 Additionally, this gem includes integrations with such popular libraries and
-frameworks as Rails, Sinatra, Resque, Sidekiq, Delayed Job, Shoryuken, ActiveJob and many
-more.
+frameworks as Rails, Sinatra, Resque, Sidekiq, Delayed Job, Shoryuken,
+ActiveJob and many more.
 DESC
   s.author      = 'Airbrake Technologies, Inc.'
   s.email       = 'support@airbrake.io'

--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -17,7 +17,7 @@ prioritization of exceptions so that when errors occur, your team can quickly
 determine the root cause.
 
 Additionally, this gem includes integrations with such popular libraries and
-frameworks as Rails, Sinatra, Resque, Sidekiq, Delayed Job, ActiveJob and many
+frameworks as Rails, Sinatra, Resque, Sidekiq, Delayed Job, Shoryuken, ActiveJob and many
 more.
 DESC
   s.author      = 'Airbrake Technologies, Inc.'

--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -23,6 +23,7 @@ end
 require 'airbrake/rake/task_ext' if defined?(Rake::Task)
 require 'airbrake/resque/failure' if defined?(Resque)
 require 'airbrake/sidekiq/error_handler' if defined?(Sidekiq)
+require 'airbrake/shoryuken/error_handler' if defined?(Shoryuken)
 require 'airbrake/delayed_job/plugin' if defined?(Delayed)
 
 ##

--- a/lib/airbrake/shoryuken/error_handler.rb
+++ b/lib/airbrake/shoryuken/error_handler.rb
@@ -1,16 +1,20 @@
 module Airbrake
   module Shoryuken
+    ##
+    # Provides integration with Shoryuken.
     class ErrorHandler
-      def call(worker, queue, sqs_msg, body)
-        begin
-          yield
-        rescue => e
-          notify_airbrake(e, body.is_a?(Array) ? { batch: body } : body)
-          raise e
-        end
+      def call(_worker, _queue, _sqs_msg, body)
+        yield
+      rescue => e
+        notify_airbrake(e, notice_context(body))
+        raise e
       end
 
       private
+
+      def notice_context(body)
+        body.is_a?(Array) ? { batch: body } : { body: body }
+      end
 
       def notify_airbrake(exception, context)
         return unless (notice = Airbrake.build_notice(exception, context))

--- a/lib/airbrake/shoryuken/error_handler.rb
+++ b/lib/airbrake/shoryuken/error_handler.rb
@@ -1,0 +1,30 @@
+module Airbrake
+  module Shoryuken
+    class ErrorHandler
+      def call(worker, queue, sqs_msg, body)
+        begin
+          yield
+        rescue => e
+          notify_airbrake(e, body.is_a?(Array) ? { batch: body } : body)
+          raise e
+        end
+      end
+
+      private
+
+      def notify_airbrake(exception, context)
+        return unless (notice = Airbrake.build_notice(exception, context))
+
+        Airbrake.notify(notice)
+      end
+    end
+  end
+end
+
+if defined?(::Shoryuken)
+  Shoryuken.configure_server do |config|
+    config.server_middleware do |chain|
+      chain.add Airbrake::Shoryuken::ErrorHandler
+    end
+  end
+end

--- a/spec/unit/shoryuken/error_handler_spec.rb
+++ b/spec/unit/shoryuken/error_handler_spec.rb
@@ -16,8 +16,6 @@ RSpec.describe Airbrake::Shoryuken::ErrorHandler do
     'https://airbrake.io/api/v3/projects/113743/notices?key=fd04e13d806a90f96614ad8e529b2822'
   end
 
-  class FooWorker; end
-
   def wait_for_a_request_with_body(body)
     wait_for(a_request(:post, endpoint).with(body: body)).to have_been_made.once
   end

--- a/spec/unit/shoryuken/error_handler_spec.rb
+++ b/spec/unit/shoryuken/error_handler_spec.rb
@@ -5,7 +5,13 @@ RSpec.describe Airbrake::Shoryuken::ErrorHandler do
   let(:error) { AirbrakeTestError.new('shoryuken error') }
   let(:body) { { message: 'message' } }
   let(:queue) { 'foo_queue' }
-  let(:worker) { FooWorker.new }
+  let(:worker) do
+    Class.new do
+      def self.to_s
+        'FooWorker'
+      end
+    end.new
+  end
   let(:endpoint) do
     'https://airbrake.io/api/v3/projects/113743/notices?key=fd04e13d806a90f96614ad8e529b2822'
   end

--- a/spec/unit/shoryuken/error_handler_spec.rb
+++ b/spec/unit/shoryuken/error_handler_spec.rb
@@ -4,7 +4,6 @@ require 'airbrake/shoryuken/error_handler'
 RSpec.describe Airbrake::Shoryuken::ErrorHandler do
   let(:error) { AirbrakeTestError.new('shoryuken error') }
   let(:body) { { message: 'message' } }
-  let(:notice) { double 'notice' }
   let(:worker) { FooWorker.new }
   let(:endpoint) do
     'https://airbrake.io/api/v3/projects/113743/notices?key=fd04e13d806a90f96614ad8e529b2822'

--- a/spec/unit/shoryuken/error_handler_spec.rb
+++ b/spec/unit/shoryuken/error_handler_spec.rb
@@ -1,8 +1,53 @@
 require 'spec_helper'
+require 'airbrake/shoryuken/error_handler'
 
 module Airbrake
+  ##
+  # Provides tests for the Shoryuken integration.
   module Shoryuken
     RSpec.describe ErrorHandler do
+      let(:error) { AirbrakeTestError.new('shoryuken error') }
+      let(:body) { { message: 'message' } }
+      let(:notice) { double 'Notice' }
+
+      context "when there's an error" do
+        it 'notifies' do
+          expect(Airbrake).to receive(:build_notice).with(error, body: body).
+            and_return(notice)
+
+          expect(Airbrake).to receive(:notify).with(notice)
+
+          expect do
+            subject.call(nil, nil, nil, body) { raise error }
+          end.to raise_error(error)
+        end
+
+        context "and it's a batch" do
+          let(:body) { [{ message1: 'message1' }, { message2: 'message2' }] }
+
+          it 'notifies' do
+            expect(Airbrake).to receive(:build_notice).with(error, batch: body).
+              and_return(notice)
+
+            expect(Airbrake).to receive(:notify).with(notice)
+
+            expect do
+              subject.call(nil, nil, nil, body) { raise error }
+            end.to raise_error(error)
+          end
+        end
+      end
+
+      context "when there's no error" do
+        it 'does not notify ' do
+          expect(Airbrake).to_not receive(:build_notice)
+          expect(Airbrake).to_not receive(:notify)
+
+          expect do
+            expect { |b| subject.call(nil, nil, nil, body, &b) }.to yield_control
+          end.to_not raise_error
+        end
+      end
     end
   end
 end

--- a/spec/unit/shoryuken/error_handler_spec.rb
+++ b/spec/unit/shoryuken/error_handler_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+module Airbrake
+  module Shoryuken
+    RSpec.describe ErrorHandler do
+    end
+  end
+end


### PR DESCRIPTION
This PR ports [Honeybadger support for Shoryuken](https://github.com/honeybadger-io/honeybadger-ruby/pull/190) over to Airbrake. 

## TODO

- [x] Add tests
- [x] Notify [batches](https://github.com/phstc/shoryuken/wiki/Middleware#be-careful-with-batchable-workers)