### PR TITLE
generators/airbrake_initializer: ignore HTTP_AUTHORIZATION header

### DIFF
--- a/lib/generators/airbrake_initializer.rb.erb
+++ b/lib/generators/airbrake_initializer.rb.erb
@@ -53,7 +53,7 @@ Airbrake.configure do |c|
   # Airbrake. By default, all "password" attributes will have their contents
   # replaced.
   # https://github.com/airbrake/airbrake-ruby#blacklist_keys
-  c.blacklist_keys = [/password/i]
+  c.blacklist_keys = [/password/i, /authorization/i]
 
   # Alternatively, you can integrate with Rails' filter_parameters.
   # Read more: https://goo.gl/gqQ1xS


### PR DESCRIPTION
Fixes #671 (Do not log HTTP_AUTHORIZATION header by default)