### PR TITLE
Use airbrake v1.8.0 API for accessing notifiers

### DIFF
--- a/lib/airbrake/rack/middleware.rb
+++ b/lib/airbrake/rack/middleware.rb
@@ -37,7 +37,7 @@ module Airbrake
         @@known_notifiers << notifier_name
 
         RACK_FILTERS.each do |filter|
-          Airbrake.add_filter(filter.new, notifier_name)
+          Airbrake[notifier_name].add_filter(filter.new)
         end
       end
 
@@ -64,11 +64,11 @@ module Airbrake
       private
 
       def notify_airbrake(exception, env)
-        notice = Airbrake.build_notice(exception, {}, @notifier_name)
+        notice = Airbrake[@notifier_name].build_notice(exception)
         return unless notice
 
         notice.stash[:rack_request] = ::Rack::Request.new(env)
-        Airbrake.notify(notice, {}, @notifier_name)
+        Airbrake[@notifier_name].notify(notice)
       end
 
       ##

--- a/lib/airbrake/rails/action_controller.rb
+++ b/lib/airbrake/rails/action_controller.rb
@@ -12,25 +12,25 @@ module Airbrake
       # A helper method for sending notices to Airbrake *asynchronously*.
       # Attaches information from the Rack env.
       # @see Airbrake#notify, #notify_airbrake_sync
-      def notify_airbrake(exception, params = {}, notifier = :default)
+      def notify_airbrake(exception, params = {}, notifier_name = :default)
         return unless (notice = build_notice(exception, params, notifier))
-        Airbrake.notify(notice, params, notifier)
+        Airbrake[notifier_name].notify(notice, params)
       end
 
       ##
       # A helper method for sending notices to Airbrake *synchronously*.
       # Attaches information from the Rack env.
       # @see Airbrake#notify_sync, #notify_airbrake
-      def notify_airbrake_sync(exception, params = {}, notifier = :default)
+      def notify_airbrake_sync(exception, params = {}, notifier_name = :default)
         return unless (notice = build_notice(exception, params, notifier))
-        Airbrake.notify_sync(notice, params, notifier)
+        Airbrake[notifier_name].notify_sync(notice, params)
       end
 
       ##
       # @param [Exception] exception
       # @return [Airbrake::Notice] the notice with information from the Rack env
-      def build_notice(exception, params = {}, notifier = :default)
-        return unless (notice = Airbrake.build_notice(exception, params, notifier))
+      def build_notice(exception, params = {}, notifier_name = :default)
+        return unless (notice = Airbrake[notifier_name].build_notice(exception, params))
         notice.stash[:rack_request] = request
         notice
       end

--- a/spec/unit/rack/middleware_spec.rb
+++ b/spec/unit/rack/middleware_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Airbrake::Rack::Middleware do
           stub_request(:post, bingo_endpoint).to_return(status: 201, body: '{}')
         end
 
-        after { Airbrake.close(notifier_name) }
+        after { Airbrake[notifier_name].close }
 
         it "notifies via the specified notifier" do
           expect do
@@ -123,14 +123,14 @@ RSpec.describe Airbrake::Rack::Middleware do
 
   context "when Airbrake is not configured" do
     it "returns nil" do
-      allow(Airbrake).to receive(:build_notice).and_return(nil)
-      allow(Airbrake).to receive(:notify)
+      allow(Airbrake[:default]).to receive(:build_notice).and_return(nil)
+      allow(Airbrake[:default]).to receive(:notify)
 
       expect { described_class.new(faulty_app).call(env_for('/')) }.
         to raise_error(AirbrakeTestError)
 
-      expect(Airbrake).to have_received(:build_notice)
-      expect(Airbrake).not_to have_received(:notify)
+      expect(Airbrake[:default]).to have_received(:build_notice)
+      expect(Airbrake[:default]).not_to have_received(:notify)
     end
   end
 end


### PR DESCRIPTION
The API was introduced in:
https://github.com/airbrake/airbrake-ruby/pull/168/