### PR TITLE
rails/action_controller: fix NameError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Fixed Rails controller helper methods throwing `NameError`
+  ([#669](https://github.com/airbrake/airbrake/pull/669))
+
 [v5.8.0.rc.1][v5.8.0.rc.1] (February 27, 2017)
 
 * **IMPORTANT:** added Shoryuken integration

--- a/lib/airbrake/rails/action_controller.rb
+++ b/lib/airbrake/rails/action_controller.rb
@@ -13,7 +13,7 @@ module Airbrake
       # Attaches information from the Rack env.
       # @see Airbrake#notify, #notify_airbrake_sync
       def notify_airbrake(exception, params = {}, notifier_name = :default)
-        return unless (notice = build_notice(exception, params, notifier))
+        return unless (notice = build_notice(exception, params, notifier_name))
         Airbrake[notifier_name].notify(notice, params)
       end
 
@@ -22,7 +22,7 @@ module Airbrake
       # Attaches information from the Rack env.
       # @see Airbrake#notify_sync, #notify_airbrake
       def notify_airbrake_sync(exception, params = {}, notifier_name = :default)
-        return unless (notice = build_notice(exception, params, notifier))
+        return unless (notice = build_notice(exception, params, notifier_name))
         Airbrake[notifier_name].notify_sync(notice, params)
       end
 


### PR DESCRIPTION
Horrible oversight and Rubocop didn't save me here :(
Luckily, this is not in any of the stable releases.