### PR TITLE
logger: improve support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Fixed Logger integration error and refactored the way it works. It's no longer
+  required automatically ([#681](https://github.com/airbrake/airbrake/pull/681))
+
 ### [v5.8.0.rc.2][v5.8.0.rc.2] (February 27, 2017)
 
 * Fixed Rails controller helper methods throwing `NameError`

--- a/README.md
+++ b/README.md
@@ -417,8 +417,8 @@ end
 
 If you want to convert your log messages to Airbrake errors, you can use our
 integration with Ruby's `Logger` class from stdlib. All you need to do is to
-make sure that the integration is required (if the Airbrake is loaded after
-`Logger`, then it is already integrated):
+manually `require` the integration somewhere in your code (after Logger is
+loaded):
 
 ```ruby
 require 'airbrake/logger/logger_ext'
@@ -437,16 +437,15 @@ The Logger class will attempt to utilize the default Airbrake notifier to send
 messages. It's possible to set the notifier explicitly:
 
 ```ruby
-# New method.
-# We assign the default notifier here.
-logger.airbrake_notifier = Airbrake[:default]
+# Assign a custom notifier.
+logger.airbrake_notifier = Airbrake[:nondefault_notifier]
 ```
 
 #### Airbrake severity level
 
-In order to reduce the noise from the Logger integration (or maximize) it's
-possible to configure Airbrake severity level. For example, if only want to send
-fatal messages from Logger, then configure your logger as follows:
+In order to reduce the noise from the Logger integration it's possible to
+configure Airbrake severity level. For example, if only want to send fatal
+messages from Logger, then configure your logger as follows:
 
 ```ruby
 # New method.
@@ -455,7 +454,9 @@ logger.airbrake_severity_level = Logger::FATAL
 ```
 
 By default, `airbrake_severity_level` is set to `Logger::WARN`, which means it
-sends warnings, errors and fatal error messages to Airbrake.
+sends warnings, errors and fatal error messages to Airbrake. Due to security
+considerations `Logger::WARN` is the lowest permitted severity (so you don't
+flood your project with debug messages).
 
 ### Plain Ruby scripts
 

--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -25,7 +25,9 @@ require 'airbrake/resque/failure' if defined?(Resque)
 require 'airbrake/sidekiq/error_handler' if defined?(Sidekiq)
 require 'airbrake/shoryuken/error_handler' if defined?(Shoryuken)
 require 'airbrake/delayed_job/plugin' if defined?(Delayed)
-require 'airbrake/logger/logger_ext' if defined?(Logger)
+
+# Potentially dangerous to require automatically:
+# require 'airbrake/logger/logger_ext' if defined?(Logger)
 
 ##
 # This module reopens the original Airbrake module from airbrake-ruby and adds


### PR DESCRIPTION
* I'm still a bit wary to enable this integration by default because I
  don't know what to expect from this. One of our
  users also has some concerns:
  https://github.com/airbrake/airbrake/pull/674#issuecomment-282953767

  Thus, I want to keep this as an optional integration for now. If this
  proves to be useful and harmless, I'm ready to enable it by default

* The code here is a bit funky now due to the fact that there was a bug
  in the initialize method. Loggers initialized before Airbrake is
  included (Rails initializes at least 4 loggers before Airbrake is
  loaded) don't have a notifier set.

* Severity cannot be set to DEBUG or INFO to avoid massive spam. When that happens our own airbrake-ruby spams the dashboard with requests continuously, which leads to DDoS'ing our service. We can technically stop logging every response in airbrake-ruby, but this is still very dangerous because any other library that we do not control can do the same without even realising it.