### PR TITLE
rack/middleware: do not raise if no notifiers exist

### DIFF
--- a/spec/unit/rack/middleware_spec.rb
+++ b/spec/unit/rack/middleware_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe Airbrake::Rack::Middleware do
     stub_request(:post, endpoint).to_return(status: 201, body: '{}')
   end
 
+  describe "#new" do
+    it "doesn't add filters if no notifiers are configured" do
+      expect do
+        expect(described_class.new(faulty_app, :unknown_notifier))
+      end.not_to raise_error
+    end
+  end
+
   describe "#call" do
     context "when app raises an exception" do
       context "and when the notifier name is specified" do


### PR DESCRIPTION
Fixes #691 (undefined method `add_filter' for
nil:NilClass (NoMethodError) - when Airbrake is not configured)