### PR TITLE
airbrake: close default Airbrake notifier on exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Changelog
 
 ### master
 
+* Started always closing the default notifier to stop losing exceptions
+  occurring in Rake & Resque integrations
+  ([#695](https://github.com/airbrake/airbrake/pull/695))
+
 ### [v5.8.1][v5.8.1] (March 2, 2017)
 
 * Fixed `NoMethodError` when initializing the Rack integration without a

--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -77,4 +77,5 @@ end
 # Notify of unhandled exceptions, if there were any, but ignore SystemExit.
 at_exit do
   Airbrake.notify_sync($ERROR_INFO) if $ERROR_INFO
+  Airbrake.close
 end


### PR DESCRIPTION
Fixes #695 (Airbrake.notify method is not safe in the rake tasks.)