### PR TITLE
gemspec: update airbrake-ruby to '~> 2.0'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Airbrake Changelog
 * Started always closing the default notifier to stop losing exceptions
   occurring in Rake & Resque integrations
   ([#695](https://github.com/airbrake/airbrake/pull/695))
+* Started depending on
+  [airbrake-ruby-2.0.0](https://github.com/airbrake/airbrake-ruby/releases/tag/v2.0.0)
+  ([#699](https://github.com/airbrake/airbrake/pull/699))
 
 ### [v5.8.1][v5.8.1] (March 2, 2017)
 

--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -31,7 +31,7 @@ DESC
 
   s.required_ruby_version = '>= 2.0'
 
-  s.add_dependency 'airbrake-ruby', '~> 1.8'
+  s.add_dependency 'airbrake-ruby', '~> 2.0'
 
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rspec-wait', '~> 0'


### PR DESCRIPTION
Release https://github.com/airbrake/airbrake-ruby/pull/185