### PR TITLE
Release v4.3.9

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+Version 4.3.9 - 2017-04-06 13:39:44 +0300
+===============================================================================
+
+Kyrylo Silin (1):
+	Enable `secure` by default
+
 Version 4.3.8 - 2016-06-24 17:43:35 +0300
 ===============================================================================
 
@@ -1676,41 +1682,3 @@ Nick Quaranto (3):
       Fixing the capistrano hook bit in the readme
       Adding changeling:minor and changeling:patch to automate notifier releases
       Adding rake changeling:push
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/lib/airbrake/configuration.rb
+++ b/lib/airbrake/configuration.rb
@@ -156,7 +156,7 @@ module Airbrake
     alias_method :use_system_ssl_cert_chain?, :use_system_ssl_cert_chain
 
     def initialize
-      @secure                   = false
+      @secure                   = true
       @use_system_ssl_cert_chain= false
       @host                     = 'api.airbrake.io'
       @port                     = nil

--- a/lib/airbrake/version.rb
+++ b/lib/airbrake/version.rb
@@ -1,3 +1,3 @@
 module Airbrake
-  VERSION = "4.3.8".freeze
+  VERSION = "4.3.9".freeze
 end


### PR DESCRIPTION
This is an unscheduled support release. All v4 users *must* upgrade to
this version to be able to send errors OR configure the `secure` option:

```rb
Airbrake.configure do |config|
  config.secure = true
end
```

Due to some changes in our infrastructure, we don't accept HTTP payload anymore and our older
notifiers are configured to send errors via HTTP by default.