### PR TITLE
Fix Rack integration overriding 'notice[:params]'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Airbrake Changelog
 * Started appending HTTP request info (method, headers & referer) from Rack to
   the `context` hash instead of the `environment` hash
   ([#703](https://github.com/airbrake/airbrake/pull/703))
+* Fixed Rack integration overriding `notice[:params]`
+  ([#716](https://github.com/airbrake/airbrake/pull/716))
 
 ### [v6.0.0][v6.0.0] (March 21, 2017)
 

--- a/lib/airbrake/rack/http_params_filter.rb
+++ b/lib/airbrake/rack/http_params_filter.rb
@@ -10,7 +10,7 @@ module Airbrake
       def call(notice)
         return unless (request = notice.stash[:rack_request])
 
-        notice[:params] = request.params
+        notice[:params].merge!(request.params)
 
         rails_params = request.env['action_dispatch.request.parameters']
         notice[:params].merge!(rails_params) if rails_params

--- a/spec/unit/rack/http_params_filter_spec.rb
+++ b/spec/unit/rack/http_params_filter_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe Airbrake::Rack::HttpParamsFilter do
       subject.call(notice)
       expect(notice[:params]).to eq(params)
     end
+
+    it "merges given params with existing params" do
+      notice[:params] = { bingo: :bango }
+      subject.call(notice)
+      expect(notice[:params]).to eq(bingo: :bango, a: 1, b: 2)
+    end
   end
 
   context "when query string params are present" do


### PR DESCRIPTION
Fixes #715 (HttpParamsFilter overrides custom params)