### PR TITLE
Simplify manual inclusion of integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,10 +336,11 @@ end
 
 ### Resque
 
-Since Airbrake v5 the gem provides its own failure backend. The old way of
-integrating Resque doesn't work. If you upgrade to Airbrake v5, just make sure
-that you require `airbrake/resque/failure` instead of
-`resque/failure/airbrake`. The rest remains the same.
+Simply `require` the Resque integration:
+
+```ruby
+require 'airbrake/resque'
+```
 
 #### Integrating with Rails applications
 
@@ -348,17 +349,17 @@ new initializer in `config/initializers/resque.rb` with the following content:
 
 ```ruby
 # config/initializers/resque.rb
-require 'airbrake/resque/failure'
+require 'airbrake/resque'
 Resque::Failure.backend = Resque::Failure::Airbrake
 ```
 
-That's all configuration.
+Now you're all set.
 
 #### General integration
 
 Any Ruby app using Resque can be integrated with Airbrake. If you can require
 the Airbrake gem *after* Resque, then there's no need to require
-`airbrake/resque/failure` anymore:
+`airbrake/resque` anymore:
 
 ```ruby
 require 'resque'

--- a/README.md
+++ b/README.md
@@ -373,10 +373,10 @@ multiple backends, then continue reading the needed configuration steps in
 
 ### DelayedJob
 
-Simply `require` our plugin and you're done:
+Simply `require` our integration and you're done:
 
 ```ruby
-require 'airbrake/delayed_job/plugin'
+require 'airbrake/delayed_job'
 ```
 
 If you required DelayedJob before Airbrake, then you don't even have to `require`

--- a/README.md
+++ b/README.md
@@ -384,10 +384,10 @@ anything manually and it should just work out-of-box.
 
 ### Shoryuken
 
-Simply `require` our error handler and you're done:
+Simply `require` our integration and you're done:
 
 ```ruby
-require 'airbrake/shoryuken/error_handler'
+require 'airbrake/shoryuken'
 ```
 
 If you required Shoryuken before Airbrake, then you don't even have to `require`

--- a/README.md
+++ b/README.md
@@ -309,10 +309,10 @@ use Airbrake::Rack::Middleware, :app2
 ### Sidekiq
 
 We support Sidekiq v2, v3 and v4. The configurations steps for them are
-identical. Simply `require` our error handler and you're done:
+identical. Simply `require` our integration and you're done:
 
 ```ruby
-require 'airbrake/sidekiq/error_handler'
+require 'airbrake/sidekiq'
 ```
 
 If you required Sidekiq before Airbrake, then you don't even have to `require`

--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -14,7 +14,7 @@ if defined?(Rack)
   require 'airbrake/rails/railtie' if defined?(Rails)
 end
 
-require 'airbrake/rake/task_ext' if defined?(Rake::Task)
+require 'airbrake/rake' if defined?(Rake::Task)
 require 'airbrake/resque' if defined?(Resque)
 require 'airbrake/sidekiq' if defined?(Sidekiq)
 require 'airbrake/shoryuken' if defined?(Shoryuken)

--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -15,7 +15,7 @@ if defined?(Rack)
 end
 
 require 'airbrake/rake/task_ext' if defined?(Rake::Task)
-require 'airbrake/resque/failure' if defined?(Resque)
+require 'airbrake/resque' if defined?(Resque)
 require 'airbrake/sidekiq' if defined?(Sidekiq)
 require 'airbrake/shoryuken' if defined?(Shoryuken)
 require 'airbrake/delayed_job' if defined?(Delayed)

--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -17,7 +17,7 @@ end
 require 'airbrake/rake/task_ext' if defined?(Rake::Task)
 require 'airbrake/resque/failure' if defined?(Resque)
 require 'airbrake/sidekiq/error_handler' if defined?(Sidekiq)
-require 'airbrake/shoryuken/error_handler' if defined?(Shoryuken)
+require 'airbrake/shoryuken' if defined?(Shoryuken)
 require 'airbrake/delayed_job' if defined?(Delayed)
 
 require 'airbrake/logger/airbrake_logger'

--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -18,7 +18,7 @@ require 'airbrake/rake/task_ext' if defined?(Rake::Task)
 require 'airbrake/resque/failure' if defined?(Resque)
 require 'airbrake/sidekiq/error_handler' if defined?(Sidekiq)
 require 'airbrake/shoryuken/error_handler' if defined?(Shoryuken)
-require 'airbrake/delayed_job/plugin' if defined?(Delayed)
+require 'airbrake/delayed_job' if defined?(Delayed)
 
 require 'airbrake/logger/airbrake_logger'
 

--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -16,7 +16,7 @@ end
 
 require 'airbrake/rake/task_ext' if defined?(Rake::Task)
 require 'airbrake/resque/failure' if defined?(Resque)
-require 'airbrake/sidekiq/error_handler' if defined?(Sidekiq)
+require 'airbrake/sidekiq' if defined?(Sidekiq)
 require 'airbrake/shoryuken' if defined?(Shoryuken)
 require 'airbrake/delayed_job' if defined?(Delayed)
 

--- a/lib/airbrake/delayed_job.rb
+++ b/lib/airbrake/delayed_job.rb
@@ -1,0 +1,1 @@
+require 'airbrake/delayed_job/plugin'

--- a/lib/airbrake/rake.rb
+++ b/lib/airbrake/rake.rb
@@ -1,0 +1,1 @@
+require 'airbrake/rake/task_ext'

--- a/lib/airbrake/resque.rb
+++ b/lib/airbrake/resque.rb
@@ -1,0 +1,1 @@
+require 'airbrake/resque/failure'

--- a/lib/airbrake/shoryuken.rb
+++ b/lib/airbrake/shoryuken.rb
@@ -1,0 +1,1 @@
+require 'airbrake/shoryuken/error_handler'

--- a/lib/airbrake/sidekiq.rb
+++ b/lib/airbrake/sidekiq.rb
@@ -1,0 +1,1 @@
+require 'airbrake/sidekiq/error_handler'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,7 +65,7 @@ if ENV['APPRAISAL_INITIALIZED']
 
     require 'resque'
     require 'resque_spec'
-    require 'airbrake/resque/failure'
+    require 'airbrake/resque'
     Resque::Failure.backend = Resque::Failure::Airbrake
 
     require 'delayed_job'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,7 +70,7 @@ if ENV['APPRAISAL_INITIALIZED']
 
     require 'delayed_job'
     require 'delayed_job_active_record'
-    require 'airbrake/delayed_job/plugin'
+    require 'airbrake/delayed_job'
     Delayed::Worker.delay_jobs = false
 
     require 'airbrake/rails/railtie'

--- a/spec/unit/sidekiq/error_handler_spec.rb
+++ b/spec/unit/sidekiq/error_handler_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0')
   require 'sidekiq'
   require 'sidekiq/cli'
-  require 'airbrake/sidekiq/error_handler'
+  require 'airbrake/sidekiq'
 
   RSpec.describe "airbrake/sidekiq/error_handler" do
     let(:endpoint) do


### PR DESCRIPTION
This way we hide unnecessary implementation details, so users can reference an integration by its name.