### PR TITLE
rake/tasks: don't load initializer when Airbrake is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Airbrake Changelog
   `airbrake/shoryuken` ([#719](https://github.com/airbrake/airbrake/pull/719))
 * Deprecated requiring `airbrake/sidekiq/error_handler` in favour of
   `airbrake/sidekiq` ([#719](https://github.com/airbrake/airbrake/pull/719))
+* Fixed `airbrake:deploy` task raising `AirbrakeError` when Rails `:environment`
+  is already required by some other task
+  ([#721](https://github.com/airbrake/airbrake/pull/721))
 
 ### [v6.0.0][v6.0.0] (March 21, 2017)
 

--- a/lib/airbrake/rake/tasks.rb
+++ b/lib/airbrake/rake/tasks.rb
@@ -68,7 +68,7 @@ namespace :airbrake do
       # Avoid loading the environment to speed up the deploy task and try guess
       # the initializer file location.
       if initializer.exist?
-        load initializer
+        load(initializer) unless Airbrake[:default]
       else
         Rake::Task[:environment].invoke
       end


### PR DESCRIPTION
Fixes #714 (do not load airbrake initializer when environment is already
loaded and require it)