### PR TITLE
gemspec: lock airbrake-ruby to ('~> 2.2', '>= 2.2.1')

### DIFF
--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -31,7 +31,7 @@ DESC
 
   s.required_ruby_version = '>= 2.0'
 
-  s.add_dependency 'airbrake-ruby', '~> 2.2'
+  s.add_dependency 'airbrake-ruby', '~> 2.2', '>= 2.2.1'
 
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rspec-wait', '~> 0'


### PR DESCRIPTION
https://github.com/airbrake/airbrake-ruby/pull/207