### PR TITLE
airbrake/rack: set weight for all filters

### DIFF
--- a/lib/airbrake/rack/context_filter.rb
+++ b/lib/airbrake/rack/context_filter.rb
@@ -5,6 +5,10 @@ module Airbrake
     #
     # @since v5.7.0
     class ContextFilter
+      ##
+      # @return [Integer]
+      attr_reader :weight
+
       def initialize
         @framework_version =
           if defined?(::Rails) && ::Rails.respond_to?(:version)
@@ -14,6 +18,7 @@ module Airbrake
           else
             "Rack.version/#{::Rack.version} Rack.release/#{::Rack.release}"
           end.freeze
+        @weight = 99
       end
 
       ##

--- a/lib/airbrake/rack/http_headers_filter.rb
+++ b/lib/airbrake/rack/http_headers_filter.rb
@@ -15,6 +15,14 @@ module Airbrake
       ].freeze
 
       ##
+      # @return [Integer]
+      attr_reader :weight
+
+      def initialize
+        @weight = 98
+      end
+
+      ##
       # @see {Airbrake::FilterChain#refine}
       def call(notice)
         return unless (request = notice.stash[:rack_request])

--- a/lib/airbrake/rack/http_params_filter.rb
+++ b/lib/airbrake/rack/http_params_filter.rb
@@ -6,6 +6,14 @@ module Airbrake
     # @since v5.7.0
     class HttpParamsFilter
       ##
+      # @return [Integer]
+      attr_reader :weight
+
+      def initialize
+        @weight = 97
+      end
+
+      ##
       # @see {Airbrake::FilterChain#refine}
       def call(notice)
         return unless (request = notice.stash[:rack_request])

--- a/lib/airbrake/rack/request_body_filter.rb
+++ b/lib/airbrake/rack/request_body_filter.rb
@@ -11,9 +11,14 @@ module Airbrake
     # @note This filter is *not* used by default.
     class RequestBodyFilter
       ##
+      # @return [Integer]
+      attr_reader :weight
+
+      ##
       # @param [Integer] length The maximum number of bytes to read
       def initialize(length = 4096)
         @length = length
+        @weight = 95
       end
 
       ##

--- a/lib/airbrake/rack/session_filter.rb
+++ b/lib/airbrake/rack/session_filter.rb
@@ -6,6 +6,14 @@ module Airbrake
     # @since v5.7.0
     class SessionFilter
       ##
+      # @return [Integer]
+      attr_reader :weight
+
+      def initialize
+        @weight = 96
+      end
+
+      ##
       # @see {Airbrake::FilterChain#refine}
       def call(notice)
         return unless (request = notice.stash[:rack_request])


### PR DESCRIPTION
This weight ensures that we load these filters after `airbrake-ruby`
filters, but not after user defined filters.