### PR TITLE
Fix build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -74,7 +74,6 @@ test:
           1) rvm-exec 2.1.10 bundle exec appraisal rails-4.0 rake spec:integration:rails ;;
           2) rvm-exec 2.2.7 bundle exec appraisal rails-4.0 rake spec:integration:rails ;;
           3) rvm-exec 2.3.4 bundle exec appraisal rails-4.0 rake spec:integration:rails ;;
-          4) rvm-exec 2.4.1 bundle exec appraisal rails-4.0 rake spec:integration:rails ;;
           5)
             export JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF"
             rvm-exec jruby-9.1.8.0 bundle exec appraisal rails-4.0 rake spec:integration:rails
@@ -88,7 +87,6 @@ test:
           1) rvm-exec 2.1.10 bundle exec appraisal rails-4.1 rake spec:integration:rails ;;
           2) rvm-exec 2.2.7 bundle exec appraisal rails-4.1 rake spec:integration:rails ;;
           3) rvm-exec 2.3.4 bundle exec appraisal rails-4.1 rake spec:integration:rails ;;
-          4) rvm-exec 2.4.1 bundle exec appraisal rails-4.1 rake spec:integration:rails ;;
           5)
             export JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF"
             rvm-exec jruby-9.1.8.0 bundle exec appraisal rails-4.1 rake spec:integration:rails
@@ -115,19 +113,15 @@ test:
           2) rvm-exec 2.2.7 bundle exec appraisal rails-5.0 rake spec:integration:rails ;;
           3) rvm-exec 2.3.4 bundle exec appraisal rails-5.0 rake spec:integration:rails ;;
           4) rvm-exec 2.4.1 bundle exec appraisal rails-5.0 rake spec:integration:rails ;;
-          5)
-            export JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF"
-            rvm-exec jruby-9.1.8.0 bundle exec appraisal rails-5.0 rake spec:integration:rails
-            ;;
         esac
       :
         parallel: true
-    - ? |
-        case $CIRCLE_NODE_INDEX in
-          4) rvm-exec 2.4.1 bundle exec appraisal rails-edge rake spec:integration:rails ;;
-        esac
-      :
-        parallel: true
+    # - ? |
+    #     case $CIRCLE_NODE_INDEX in
+    #       4) rvm-exec 2.4.1 bundle exec appraisal rails-edge rake spec:integration:rails ;;
+    #     esac
+    #   :
+    #     parallel: true
     - ? |
         case $CIRCLE_NODE_INDEX in
           0) rvm-exec 2.0.0-p645 bundle exec appraisal sinatra rake spec:integration:sinatra ;;

--- a/lib/airbrake/delayed_job.rb
+++ b/lib/airbrake/delayed_job.rb
@@ -17,7 +17,7 @@ module Delayed
               params[:active_job] = job.payload_object.job_data
             end
 
-            Airbrake.notify(exception, params) do |notice|
+            ::Airbrake.notify(exception, params) do |notice|
               notice[:context][:component] = 'delayed_job'
               notice[:context][:action] = job.payload_object.class.name
             end

--- a/lib/airbrake/logger.rb
+++ b/lib/airbrake/logger.rb
@@ -20,10 +20,8 @@ module Airbrake
     attr_accessor :airbrake_notifier
 
     ##
-    # @example
-    #   logger.airbrake_level = Logger::FATAL
     # @return [Integer]
-    attr_accessor :airbrake_level
+    attr_reader :airbrake_level
 
     def initialize(logger)
       __setobj__(logger)

--- a/lib/airbrake/rails/action_controller.rb
+++ b/lib/airbrake/rails/action_controller.rb
@@ -13,7 +13,8 @@ module Airbrake
       # Attaches information from the Rack env.
       # @see Airbrake#notify, #notify_airbrake_sync
       def notify_airbrake(exception, params = {}, notifier_name = :default)
-        Airbrake[notifier_name].notify(exception, params)
+        return unless (notice = build_notice(exception, params, notifier_name))
+        Airbrake[notifier_name].notify(notice, params)
       end
 
       ##
@@ -21,7 +22,8 @@ module Airbrake
       # Attaches information from the Rack env.
       # @see Airbrake#notify_sync, #notify_airbrake
       def notify_airbrake_sync(exception, params = {}, notifier_name = :default)
-        Airbrake[notifier_name].notify_sync(exception, params)
+        return unless (notice = build_notice(exception, params, notifier_name))
+        Airbrake[notifier_name].notify_sync(notice, params)
       end
 
       ##

--- a/lib/airbrake/resque.rb
+++ b/lib/airbrake/resque.rb
@@ -7,7 +7,7 @@ module Resque
     # @see https://github.com/resque/resque/wiki/Failure-Backends
     class Airbrake < Base
       def save
-        Airbrake.notify_sync(exception, payload) do |notice|
+        ::Airbrake.notify_sync(exception, payload) do |notice|
           notice[:context][:component] = 'resque'
           notice[:context][:action] = payload['class'].to_s
         end


### PR DESCRIPTION
* logger: eliminate the warning about redefined methods
* rails/action_controller: use build_notice instead of the block form
    The problem is that the notice stash is populated after all filters were
run.
* delayed_job,resque: reference the top-level constant
* rails_spec: avoid mocking and modify @notifiers manually
* circle: don't run tests against unsupported frameworks/rubies