### PR TITLE
Run JRuby tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,35 @@
 language: ruby
+sudo: false
+
+rvm:
+  - jruby-9.1.8.0
+
+env:
+  global:
+    - JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF"
+
+cache:
+  bundler: true
+
+before_install: gem install bundler
+
+install:
+  - bundle install --jobs=15
+  - bundle exec appraisal install --jobs=15
+
+script:
+  - bundle exec appraisal rails-3.2 rake spec:integration:rails
+  - bundle exec appraisal rails-4.0 rake spec:integration:rails
+  - bundle exec appraisal rails-4.1 rake spec:integration:rails
+  - bundle exec appraisal rails-4.2 rake spec:integration:rails
+
+  # Sinatra specs fail on JRuby due to an unknwon Rack::Test issue:
+  # Example: https://travis-ci.org/airbrake/airbrake/builds/230467859
+  # - bundle exec appraisal sinatra rake spec:integration:sinatra
+
+  - bundle exec appraisal rack rake spec:integration:rack
+  - bundle exec rake spec:unit
+
+notifications:
+  slack:
+    secure: m2uvmZiXuUrpdyEcfsWA1lKe3rNaGmuxrBl++gLCiwyNM5SDX82pl71vc8yTeXsZQBsDyQDItjBq2T2QeEqQu584ABjnnu4tS/+uPpwQvZdfW/4yiOa218RGK/pXOm5DpK8S0ouEFCUkcH+C/92z7OeGaLFYCYb006uE26Acq2g=

--- a/circle.yml
+++ b/circle.yml
@@ -1,13 +1,9 @@
 machine:
-  java:
-    version: openjdk7
   ruby:
     version: 2.4.1
 
 dependencies:
   override:
-    - gem update --remote bundler
-    - gem update --system
     - bundle install
     - ? |
         case $CIRCLE_NODE_INDEX in
@@ -24,28 +20,12 @@ dependencies:
             rvm-exec 2.2.7 bundle exec appraisal install --jobs=15
             ;;
           3)
-            # Workaround for https://github.com/sickill/rainbow/issues/48
-            rvm-exec 2.3.4 gem update --remote bundler
-            rvm-exec 2.3.4 gem update --system
-
             rvm-exec 2.3.4 bundle install --jobs=15
             rvm-exec 2.3.4 bundle exec appraisal install --jobs=15
             ;;
           4)
             rvm-exec 2.4.1 bundle install --jobs=15
             rvm-exec 2.4.1 bundle exec appraisal install --jobs=15
-            ;;
-          5)
-            # The 'dev' switch makes JRuby start about 2.5 times faster.
-            # See: https://github.com/jruby/jruby/wiki/Improving-startup-time
-            export JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF"
-
-            # Workaround for https://github.com/sickill/rainbow/issues/48
-            rvm-exec jruby-9.1.8.0 gem update --remote bundler
-            rvm-exec jruby-9.1.8.0 gem update --system
-
-            rvm-exec jruby-9.1.8.0 bundle install --jobs=15
-            rvm-exec jruby-9.1.8.0 bundle exec appraisal install --jobs=15
             ;;
         esac
       :
@@ -61,10 +41,6 @@ test:
           2) rvm-exec 2.2.7 bundle exec appraisal rails-3.2 rake spec:integration:rails ;;
           3) rvm-exec 2.3.4 bundle exec appraisal rails-3.2 rake spec:integration:rails ;;
           4) rvm-exec 2.4.1 bundle exec appraisal rails-3.2 rake spec:integration:rails ;;
-          5)
-            export JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF"
-            rvm-exec jruby-9.1.8.0 bundle exec appraisal rails-3.2 rake spec:integration:rails
-            ;;
         esac
       :
         parallel: true
@@ -74,10 +50,6 @@ test:
           1) rvm-exec 2.1.10 bundle exec appraisal rails-4.0 rake spec:integration:rails ;;
           2) rvm-exec 2.2.7 bundle exec appraisal rails-4.0 rake spec:integration:rails ;;
           3) rvm-exec 2.3.4 bundle exec appraisal rails-4.0 rake spec:integration:rails ;;
-          5)
-            export JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF"
-            rvm-exec jruby-9.1.8.0 bundle exec appraisal rails-4.0 rake spec:integration:rails
-            ;;
         esac
       :
         parallel: true
@@ -87,10 +59,6 @@ test:
           1) rvm-exec 2.1.10 bundle exec appraisal rails-4.1 rake spec:integration:rails ;;
           2) rvm-exec 2.2.7 bundle exec appraisal rails-4.1 rake spec:integration:rails ;;
           3) rvm-exec 2.3.4 bundle exec appraisal rails-4.1 rake spec:integration:rails ;;
-          5)
-            export JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF"
-            rvm-exec jruby-9.1.8.0 bundle exec appraisal rails-4.1 rake spec:integration:rails
-            ;;
         esac
       :
         parallel: true
@@ -101,10 +69,6 @@ test:
           2) rvm-exec 2.2.7 bundle exec appraisal rails-4.2 rake spec:integration:rails ;;
           3) rvm-exec 2.3.4 bundle exec appraisal rails-4.2 rake spec:integration:rails ;;
           4) rvm-exec 2.4.1 bundle exec appraisal rails-4.2 rake spec:integration:rails ;;
-          5)
-            export JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF"
-            rvm-exec jruby-9.1.8.0 bundle exec appraisal rails-4.2 rake spec:integration:rails
-            ;;
         esac
       :
         parallel: true
@@ -129,10 +93,6 @@ test:
           2) rvm-exec 2.2.7 bundle exec appraisal sinatra rake spec:integration:sinatra ;;
           3) rvm-exec 2.3.4 bundle exec appraisal sinatra rake spec:integration:sinatra ;;
           4) rvm-exec 2.4.1 bundle exec appraisal sinatra rake spec:integration:sinatra ;;
-          5)
-            export JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF"
-            rvm-exec jruby-9.1.8.0 bundle exec appraisal sinatra rake spec:integration:sinatra
-            ;;
         esac
       :
         parallel: true
@@ -143,10 +103,6 @@ test:
           2) rvm-exec 2.2.7 bundle exec appraisal rack rake spec:integration:rack ;;
           3) rvm-exec 2.3.4 bundle exec appraisal rack rake spec:integration:rack ;;
           4) rvm-exec 2.4.1 bundle exec appraisal rack rake spec:integration:rack ;;
-          5)
-            export JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF"
-            rvm-exec jruby-9.1.8.0 bundle exec appraisal rack rake spec:integration:rack
-            ;;
         esac
       :
         parallel: true
@@ -157,10 +113,6 @@ test:
           2) rvm-exec 2.2.7 bundle exec rake spec:unit ;;
           3) rvm-exec 2.3.4 bundle exec rake spec:unit ;;
           4) rvm-exec 2.4.1 bundle exec rake spec:unit ;;
-          5)
-            export JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF"
-            rvm-exec jruby-9.1.8.0 bundle exec rake spec:unit
-            ;;
         esac
       :
         parallel: true

--- a/gemfiles/rack.gemfile
+++ b/gemfiles/rack.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "warden", "~> 1.2.6"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_3.2.gemfile
+++ b/gemfiles/rails_3.2.gemfile
@@ -4,10 +4,10 @@ source "https://rubygems.org"
 
 gem "rails", "~> 3.2.22"
 gem "warden", "~> 1.2.3"
-gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.18", :platforms => :jruby
-gem "sqlite3", "~> 1.3.11", :platforms => [:mri, :rbx]
+gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.18", platforms: :jruby
+gem "sqlite3", "~> 1.3.11", platforms: [:mri, :rbx]
 gem "resque", "~> 1.25.2"
-gem "resque_spec", :github => "airbrake/resque_spec"
+gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job_active_record", "~> 4.1.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -4,11 +4,11 @@ source "https://rubygems.org"
 
 gem "rails", "~> 4.0.13"
 gem "warden", "~> 1.2.3"
-gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.18", :platforms => :jruby
-gem "sqlite3", "~> 1.3.11", :platforms => [:mri, :rbx]
+gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.18", platforms: :jruby
+gem "sqlite3", "~> 1.3.11", platforms: [:mri, :rbx]
 gem "resque", "~> 1.25.2"
-gem "resque_spec", :github => "airbrake/resque_spec"
+gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job_active_record", "~> 4.1.0"
 gem "mime-types", "~> 3.1"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -4,11 +4,11 @@ source "https://rubygems.org"
 
 gem "rails", "~> 4.1.13"
 gem "warden", "~> 1.2.3"
-gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.18", :platforms => :jruby
-gem "sqlite3", "~> 1.3.11", :platforms => [:mri, :rbx]
+gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.18", platforms: :jruby
+gem "sqlite3", "~> 1.3.11", platforms: [:mri, :rbx]
 gem "resque", "~> 1.25.2"
-gem "resque_spec", :github => "airbrake/resque_spec"
+gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job_active_record", "~> 4.1.0"
 gem "mime-types", "~> 3.1"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -4,11 +4,11 @@ source "https://rubygems.org"
 
 gem "rails", "~> 4.2.4"
 gem "warden", "~> 1.2.3"
-gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.18", :platforms => :jruby
-gem "sqlite3", "~> 1.3.11", :platforms => [:mri, :rbx]
+gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.18", platforms: :jruby
+gem "sqlite3", "~> 1.3.11", platforms: [:mri, :rbx]
 gem "resque", "~> 1.25.2"
-gem "resque_spec", :github => "airbrake/resque_spec"
+gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job_active_record", "~> 4.1.0"
 gem "mime-types", "~> 3.1"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -5,11 +5,11 @@ source "https://rubygems.org"
 gem "rails", "~> 5.0.0"
 gem "warden", "~> 1.2.6"
 gem "rack", "~> 2.0"
-gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.20", :platforms => :jruby
-gem "sqlite3", "~> 1.3.11", :platforms => [:mri, :rbx]
+gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.20", platforms: :jruby
+gem "sqlite3", "~> 1.3.11", platforms: [:mri, :rbx]
 gem "resque", "~> 1.26"
-gem "resque_spec", :github => "airbrake/resque_spec"
+gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job_active_record", "~> 4.1.1"
 gem "mime-types", "~> 3.1"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/sinatra.gemfile
+++ b/gemfiles/sinatra.gemfile
@@ -6,4 +6,4 @@ gem "sinatra", "~> 1.4.7"
 gem "rack-test", "~> 0.6.3"
 gem "warden", "~> 1.2.6"
 
-gemspec :path => "../"
+gemspec path: "../"


### PR DESCRIPTION
JRuby makes our builds last more than 13 minutes. Circle waits on every
container to finish their current task before proceeding to the next
one. JRuby is always slow to boot, so other containers are idling while
JRuby works. By moving JRuby builds to Travis we can test JRuby and MRI
in parallel.