### PR TITLE
rake: check for NilNotifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Fixed `airbrake:deploy` Rake task not reporting deploys
+  ([#746](https://github.com/airbrake/airbrake/pull/746))
+
 ### [v6.1.0][v6.1.0] (May 11, 2017)
 
 * Started depending on

--- a/lib/airbrake/rake/tasks.rb
+++ b/lib/airbrake/rake/tasks.rb
@@ -67,8 +67,8 @@ namespace :airbrake do
 
       # Avoid loading the environment to speed up the deploy task and try guess
       # the initializer file location.
-      if initializer.exist?
-        load(initializer) unless Airbrake[:default]
+      if initializer.exist? && Airbrake[:default].is_a?(Airbrake::NilNotifier)
+        load(initializer)
       else
         Rake::Task[:environment].invoke
       end


### PR DESCRIPTION
Fixes #745 (Capistrano Deployment Notification stopped working in v6.1.0 Update)

`Airbrake::NilNotifier` was introduced in airbrake-ruby v2.1.0. This
check wasn't updated accordingly.