### PR TITLE
rake/tasks: improve feedback of 'airbrake:deploy'

### DIFF
--- a/lib/airbrake/rake/tasks.rb
+++ b/lib/airbrake/rake/tasks.rb
@@ -74,13 +74,18 @@ namespace :airbrake do
       end
     end
 
-    Airbrake.create_deploy(
+    deploy_params = {
       environment: ENV['ENVIRONMENT'],
       username: ENV['USERNAME'],
       revision: ENV['REVISION'],
       repository: ENV['REPOSITORY'],
       version: ENV['VERSION']
-    )
+    }
+    promise = Airbrake.create_deploy(deploy_params)
+    promise.then do
+      puts "The #{deploy_params[:environment]} environment was deployed."
+    end
+    promise.rescue { |error| abort(error) }
   end
 
   desc 'Install a Heroku deploy hook to notify Airbrake of deploys'


### PR DESCRIPTION
Depends on: https://github.com/airbrake/airbrake-ruby/pull/226

We can leverage promises to display user friendly messages and return
proper exit codes.