### PR TITLE
gemspec: bump airbrake-ruby minimum version to v2.2.5

### DIFF
--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -31,7 +31,7 @@ DESC
 
   s.required_ruby_version = '>= 2.0'
 
-  s.add_dependency 'airbrake-ruby', '~> 2.2', '>= 2.2.3'
+  s.add_dependency 'airbrake-ruby', '~> 2.2', '>= 2.2.5'
 
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rspec-wait', '~> 0'


### PR DESCRIPTION
Release notes:
https://github.com/airbrake/airbrake-ruby/blob/master/CHANGELOG.md#v225-may-23-2017