### PR TITLE
logger: require 'delegate'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Fixed Rails config generation on Ruby 2.1
+  ([#753](https://github.com/airbrake/airbrake/pull/753))
+
 ### [v6.1.1][v6.1.1] (May 23, 2017)
 
 * Fixed `airbrake:deploy` Rake task not reporting deploys

--- a/lib/airbrake/logger.rb
+++ b/lib/airbrake/logger.rb
@@ -1,4 +1,5 @@
 require 'logger'
+require 'delegate'
 
 module Airbrake
   ##


### PR DESCRIPTION
The `SimpleDelegator` is not required by older Rubies. I stumbled upon
this bug on Ruby 2.1.10 when generating Airbrake Rails config:

```
% rails g airbrake 1 2
...
Gem Load Error is: uninitialized constant Airbrake::SimpleDelegator
Backtrace for gem load error is:
/Users/kyrylo/.gem/ruby/2.1.10/gems/airbrake-6.1.1/lib/airbrake/logger.rb:14:in `<module:Airbrake>'
```