### PR TITLE
Don't call methods of @user if parameters are required

### DIFF
--- a/lib/airbrake/rack/user.rb
+++ b/lib/airbrake/rack/user.rb
@@ -50,7 +50,11 @@ module Airbrake
       private
 
       def try_to_get(key)
-        String(@user.__send__(key)) if @user.respond_to?(key)
+        return unless @user.respond_to?(key)
+        # try methods with no arguments or with variable number of arguments,
+        # where none of them are required
+        return unless @user.method(key).arity.between?(-1, 0)
+        String(@user.__send__(key))
       end
 
       def full_name

--- a/spec/unit/rack/user_spec.rb
+++ b/spec/unit/rack/user_spec.rb
@@ -189,5 +189,34 @@ RSpec.describe Airbrake::Rack::User do
         expect(user_data).to be_empty
       end
     end
+
+    context "when Rack user's field expects a parameter" do
+      let(:user_data) do
+        described_class.new(
+          Class.new do
+            def name(required_param)
+              "my name is #{required_param}"
+            end
+
+            def id(required_param, *optional_params)
+              "id is #{required_param} #{optional_params.inspect}"
+            end
+
+            def username(*optional_params)
+              "username is #{optional_params.inspect}"
+            end
+          end.new
+        ).as_json
+      end
+
+      it "does not call the method if it has required parameters" do
+        expect(user_data[:user]).not_to include(:id)
+        expect(user_data[:user]).not_to include(:name)
+      end
+
+      it "calls the method if it has a variable number of optional parameters" do
+        expect(user_data[:user]).to include(:username)
+      end
+    end
   end
 end


### PR DESCRIPTION
If attribute methods are overwritten to have parameters
e.g.
```
class User < ApplicationRecord
  def name(formating)
  end
end
```
Airbrake will fail with error `ArgumentError (wrong number of arguments (given 0, expected 1))`
and no error message will be sent to Airbrake