### PR TITLE
Append userAddr to context

### DIFF
--- a/lib/airbrake/rack/context_filter.rb
+++ b/lib/airbrake/rack/context_filter.rb
@@ -29,6 +29,7 @@ module Airbrake
         context = notice[:context]
 
         context[:url] = request.url
+        context[:userAddr] = request.ip
         context[:userAgent] = request.user_agent
 
         add_framework_version(context)

--- a/spec/unit/rack/context_filter_spec.rb
+++ b/spec/unit/rack/context_filter_spec.rb
@@ -44,6 +44,28 @@ RSpec.describe Airbrake::Rack::ContextFilter do
     end
   end
 
+  context "when visitor address is present" do
+    let(:opts) do
+      { 'REMOTE_ADDR' => '1.2.3.4' }
+    end
+
+    it "adds userAddr to the context" do
+      subject.call(notice)
+      expect(notice[:context][:userAddr]).to eq('1.2.3.4')
+    end
+  end
+
+  context "when visitor is behind a proxy or load balancer" do
+    let(:opts) do
+      { 'HTTP_X_FORWARDED_FOR' => '8.8.8.8, 9.9.9.9' }
+    end
+
+    it "adds userAddr to the context" do
+      subject.call(notice)
+      expect(notice[:context][:userAddr]).to eq('9.9.9.9')
+    end
+  end
+
   context "when controller is present" do
     let(:controller) do
       double.tap do |ctrl|


### PR DESCRIPTION
Checked with Airbrake today and learned that user addresses were not being included in notices. This is particularly confusing on Heroku, as only AWS addresses are reported.

This adds `userAddr` to notices and relies on Rack's well-tested `#ip` method. https://github.com/rack/rack/blob/c1437097dcdf92d53a692ca8135a3391791fbca3/lib/rack/request.rb#L256-L265