### PR TITLE
gemspec: test sidekiq only on Ruby >= 2.2.2

### DIFF
--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -45,6 +45,9 @@ DESC
   s.add_development_dependency 'nokogiri', '= 1.6.8.1'
 
   s.add_development_dependency 'rack-test', '~> 0'
-  s.add_development_dependency 'sidekiq', '~> 5'
   s.add_development_dependency 'rubocop', '~> 0.47'
+
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
+    s.add_development_dependency 'sidekiq', '~> 5'
+  end
 end

--- a/spec/unit/sidekiq_spec.rb
+++ b/spec/unit/sidekiq_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2')
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
   require 'sidekiq'
   require 'sidekiq/cli'
   require 'airbrake/sidekiq'


### PR DESCRIPTION
Sidekiq v5.0.4 has a Ruby version restriction now:
https://github.com/mperham/sidekiq/commit/7b66865a7c2b9bc6325697f63c2cbaea5a06019d