### PR TITLE
fix reference to ActiveRecord

### DIFF
--- a/lib/airbrake/rails.rb
+++ b/lib/airbrake/rails.rb
@@ -19,11 +19,11 @@ module Airbrake
             ActionDispatch::DebugExceptions,
             Airbrake::Rack::Middleware
           )
-        elsif defined?(ActiveRecord)
+        elsif defined?(::ActiveRecord)
           # Insert after ConnectionManagement to avoid DB connection leakage:
           # https://github.com/airbrake/airbrake/pull/568
           app.config.middleware.insert_after(
-            ActiveRecord::ConnectionAdapters::ConnectionManagement,
+            ::ActiveRecord::ConnectionAdapters::ConnectionManagement,
             'Airbrake::Rack::Middleware'
           )
         else


### PR DESCRIPTION
Sometimes I get the error `NameError:  uninitialized constant Airbrake::Rails::ActiveRecord::ConnectionAdapters`

I believe this is happening because `lib/airbrake/rails/active_record.rb` has been required  and thus the constant `Airbrake::Rails::ActiveRecord` is being referenced instead of `::ActiveRecord`

My guess is that the order the `initalizer`'s are run is not necessarily the order in which they are defined in the file and `initializer('airbrake.active_record')` which requires `airbrake/rails/active_record.rb` is being run before `initializer('airbrake.middleware')`.

By referencing back to the root scope, '::', it fixes the error.

* Rails 4.2
* Airbrake 6.2.1
* Airbrake-ruby 2.3.2