### PR TITLE
capistrano/capistrano2: port airbrake_env from airbrake v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Airbrake Changelog
 
 * Deprecated requiring `airbrake/capistrano/tasks` in favour of
   `airbrake/capistrano` ([#778](https://github.com/airbrake/airbrake/pull/778))
+* Port the `airbrake_env` variable to Capistrano 2 integration from airbrake v4
+  ([#784](https://github.com/airbrake/airbrake/pull/784))
 
 ### [v6.2.1][v6.2.1] (July 15, 2017)
 

--- a/lib/airbrake/capistrano/capistrano2.rb
+++ b/lib/airbrake/capistrano/capistrano2.rb
@@ -20,7 +20,7 @@ module Airbrake
 
                 bundle exec rake airbrake:deploy \
                   USERNAME=#{username} \
-                  ENVIRONMENT=#{fetch(:rails_env, 'production')} \
+                  ENVIRONMENT=#{fetch(:airbrake_env, fetch(:rails_env, 'production'))} \
                   REVISION=#{current_revision.strip} \
                   REPOSITORY=#{repository} \
                   VERSION=#{fetch(:app_version, nil)}


### PR DESCRIPTION
Fixes #777 (Capistrano v2 task no longer honors airbrake_env)