### PR TITLE
Fix rubocop offences and warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ Metrics/MethodLength:
 Metrics/LineLength:
   Max: 90
 
-Style/DotPosition:
+Layout/DotPosition:
   EnforcedStyle: trailing
 
 # Details:
@@ -47,9 +47,9 @@ Metrics/BlockLength:
     - 'airbrake.gemspec'
     - 'lib/airbrake/rake/tasks.rb'
 
-Style/IndentHeredoc:
+Layout/IndentHeredoc:
   Enabled: false
 
-Style/FileName:
+Naming/FileName:
   Exclude:
     - 'Appraisals'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,20 +5,11 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
 
-Lint/HandleExceptions:
-  Enabled: true
-
 Metrics/MethodLength:
   Max: 25
 
-Style/SpaceInsideBrackets:
-  Enabled: true
-
 Metrics/LineLength:
   Max: 90
-
-Style/AccessorMethodName:
-  Enabled: true
 
 Style/DotPosition:
   EnforcedStyle: trailing
@@ -36,45 +27,15 @@ Style/StringLiterals:
 Style/HashSyntax:
   EnforcedStyle: ruby19
 
-Style/GuardClause:
-  Enabled: true
-
-Style/SpaceInsideHashLiteralBraces:
-  Enabled: true
-
 Style/NumericLiterals:
   Enabled: false
-
-Style/ParallelAssignment:
-  Enabled: true
-
-Style/SpaceAroundOperators:
-  Enabled: true
 
 Style/SignalException:
   EnforcedStyle: only_raise
 
-Style/RedundantSelf:
-  Enabled: true
-
-Style/SpaceInsideParens:
-  Enabled: true
-
 # TODO: enable this when Ruby 3.0 is out.
 Style/FrozenStringLiteralComment:
   Enabled: false
-
-Style/ConditionalAssignment:
-  Enabled: true
-
-Performance/StartWith:
-  Enabled: true
-
-Style/Alias:
-  Enabled: true
-
-Style/MultilineArrayBraceLayout:
-  Enabled: true
 
 Metrics/BlockLength:
   CountComments: false
@@ -90,6 +51,5 @@ Style/IndentHeredoc:
   Enabled: false
 
 Style/FileName:
-  Enabled: true
   Exclude:
     - 'Appraisals'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,11 +99,11 @@ AirbrakeTestError = Class.new(StandardError)
 
 # Print header with versions information. This simplifies debugging of build
 # failures on CircleCI.
-versions = <<EOS
+versions = <<BANNER
 #{'#' * 80}
 # RUBY_VERSION: #{RUBY_VERSION}
 # RUBY_ENGINE: #{RUBY_ENGINE}
-EOS
+BANNER
 versions << "# JRUBY_VERSION #{JRUBY_VERSION}\n" if defined?(JRUBY_VERSION)
 versions << "# Rails version: #{Rails.version}\n" if defined?(Rails)
 versions << "# Rack release: #{Rack.release}\n"


### PR DESCRIPTION
* rubocop: don't enable already enabled [by default] cops
* rubocop: fix "wrong namespace" warnings
    As seen in https://circleci.com/gh/airbrake/airbrake/1490#tests/containers/4
* rubocop: fix offences of the Naming/HeredocDelimiterNaming cop






