### PR TITLE
rails: insert our middleware before Executor on Rails 5

### DIFF
--- a/lib/airbrake/rails.rb
+++ b/lib/airbrake/rails.rb
@@ -12,11 +12,10 @@ module Airbrake
         # DebugExceptions, so we don't notify Airbrake about local requests.
 
         if ::Rails.version.start_with?('5.')
-          # Avoid the warning about deprecated strings.
-          # Insert after DebugExceptions, since ConnectionManagement doesn't
-          # exist in Rails 5 anymore.
-          app.config.middleware.insert_after(
-            ActionDispatch::DebugExceptions,
+          # Avoid the warning about deprecated strings. Insert before Executor,
+          # since ConnectionManagement doesn't exist in Rails 5 anymore.
+          app.config.middleware.insert_before(
+            ActionDispatch::Executor,
             Airbrake::Rack::Middleware
           )
         elsif defined?(ActiveRecord)


### PR DESCRIPTION
Replaces https://github.com/airbrake/airbrake/pull/781

Description by @lowang:

> move Airbrake to beginning of the stack - since in Rails 5,
> ActionDispatch::Executor is handling db connections now, Airbrake
> needs to wrap it to catch ActiveRecord::ConnectionTimeoutError