### PR TITLE
active_job: deduplicate notices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Airbrake Changelog
 * Fixed `NameError: uninitialized constant
   Airbrake::Rails::ActiveRecord::ConnectionAdapters`
   ([#780](https://github.com/airbrake/airbrake/pull/780))
+* Fixed duplicate errors for ActiveJob integration
+  ([#789](https://github.com/airbrake/airbrake/pull/789))
 
 ### [v6.2.1][v6.2.1] (July 15, 2017)
 

--- a/README.md
+++ b/README.md
@@ -323,18 +323,7 @@ anything manually and it should just work out-of-box.
 ### ActiveJob
 
 No additional configuration is needed. Simply ensure that you have configured
-your Airbrake notifier.
-
-If you see duplicate error entries in your dashboard, you can avoid them by
-ignoring the ActiveJob wrapper. Just add a filter like this one:
-
-```ruby
-Airbrake.add_filter do |notice|
-  if notice[:context][:action] == 'ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper'
-    notice.ignore!
-  end
-end
-```
+your Airbrake notifier with your queue adapter.
 
 ### Resque
 

--- a/lib/airbrake/delayed_job.rb
+++ b/lib/airbrake/delayed_job.rb
@@ -15,11 +15,12 @@ module Delayed
             # If DelayedJob is used through ActiveJob, it contains extra info.
             if job.payload_object.respond_to?(:job_data)
               params[:active_job] = job.payload_object.job_data
+              job_class = job.payload_object.job_data['job_class']
             end
 
             ::Airbrake.notify(exception, params) do |notice|
               notice[:context][:component] = 'delayed_job'
-              notice[:context][:action] = job.payload_object.class.name
+              notice[:context][:action] = job_class || job.payload_object.class.name
             end
 
             raise exception

--- a/lib/airbrake/resque.rb
+++ b/lib/airbrake/resque.rb
@@ -9,8 +9,20 @@ module Resque
       def save
         ::Airbrake.notify_sync(exception, payload) do |notice|
           notice[:context][:component] = 'resque'
-          notice[:context][:action] = payload['class'].to_s
+          notice[:context][:action] = action(payload)
         end
+      end
+
+      private
+
+      ##
+      # @return [String] job's name. When ActiveJob is present, retrieve
+      #   job_class. When used directly, use worker's name
+      def action(payload)
+        klass = payload['class'].to_s
+        return klass unless payload['args'] && payload['args'].first
+        return klass unless (job_class = payload['args'].first['job_class'])
+        job_class
       end
     end
   end

--- a/lib/airbrake/sidekiq.rb
+++ b/lib/airbrake/sidekiq.rb
@@ -17,8 +17,18 @@ module Airbrake
       def notify_airbrake(exception, context)
         Airbrake.notify(exception, context) do |notice|
           notice[:context][:component] = 'sidekiq'
-          notice[:context][:action] = context['class']
+          notice[:context][:action] = action(context)
         end
+      end
+
+      ##
+      # @return [String] job's name. When ActiveJob is present, retrieve
+      #   job_class. When used directly, use worker's name
+      def action(context)
+        klass = context['class'] || context[:job] && context[:job]['class']
+        return klass unless context[:job] && context[:job]['args'].first
+        return klass unless (job_class = context[:job]['args'].first['job_class'])
+        job_class
       end
     end
   end

--- a/spec/integration/rails/rails_spec.rb
+++ b/spec/integration/rails/rails_spec.rb
@@ -147,7 +147,6 @@ RSpec.describe "Rails integration specs" do
         end
 
         it "doesn't report errors" do
-          allow(Airbrake).to receive(:build_notice).and_return(nil)
           allow(Airbrake).to receive(:notify)
 
           # Make sure we don't call `build_notice` more than 1 time. Rack
@@ -165,9 +164,6 @@ RSpec.describe "Rails integration specs" do
             a_request(:post, endpoint).
             with(body: /"message":"active_job error"/)
           ).not_to have_been_made
-
-          expect(Airbrake).to have_received(:build_notice)
-          expect(Airbrake).not_to have_received(:notify)
         end
       end
     end


### PR DESCRIPTION
Fixes #608 (ActiveJob using DelayedJob notifies Airbrake twice)

Due to deduplication changes we also have to fix `action` for each integration
because the old code would report an adapter as `action`.