### PR TITLE
Delete deprecated require paths for some integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Changelog
 
 ### master
 
+* Deleted deprecated require paths for Capistrano, DelayedJob, Logger, Rails,
+  Rake, Resque, Shoryuken & Sidekiq integrations
+  ([#792](https://github.com/airbrake/airbrake/pull/792))
+
 ### [v6.3.0][v6.3.0] (September 20, 2017)
 
 * Deprecated requiring `airbrake/capistrano/tasks` in favour of

--- a/lib/airbrake/capistrano/tasks.rb
+++ b/lib/airbrake/capistrano/tasks.rb
@@ -1,5 +1,0 @@
-require 'airbrake/capistrano'
-
-warn "DEPRECATION WARNING: Requiring 'airbrake/capistrano/tasks' is " \
-     "deprecated and will be removed in the next MAJOR release. Require " \
-     "'airbrake/capistrano' instead."

--- a/lib/airbrake/delayed_job/plugin.rb
+++ b/lib/airbrake/delayed_job/plugin.rb
@@ -1,5 +1,0 @@
-require 'airbrake/delayed_job'
-
-warn "DEPRECATION WARNING: Requiring 'airbrake/delayed_job/plugin' is " \
-     "deprecated and will be removed in the next MAJOR release. Require " \
-     "'airbrake/delayed_job' instead."

--- a/lib/airbrake/logger/airbrake_logger.rb
+++ b/lib/airbrake/logger/airbrake_logger.rb
@@ -1,5 +1,0 @@
-require 'airbrake/logger'
-
-warn "DEPRECATION WARNING: Requiring 'airbrake/logger/airbrake_logger' is " \
-     "deprecated and will be removed in the next MAJOR release. Require " \
-     "'airbrake/logger' instead."

--- a/lib/airbrake/rails/railtie.rb
+++ b/lib/airbrake/rails/railtie.rb
@@ -1,5 +1,0 @@
-require 'airbrake/rails'
-
-warn "DEPRECATION WARNING: Requiring 'airbrake/rails/railtie' is " \
-     "deprecated and will be removed in the next MAJOR release. Require " \
-     "'airbrake/rails' instead."

--- a/lib/airbrake/rake/task_ext.rb
+++ b/lib/airbrake/rake/task_ext.rb
@@ -1,5 +1,0 @@
-require 'airbrake/rake'
-
-warn "DEPRECATION WARNING: Requiring 'airbrake/rake/task_ext' is " \
-     "deprecated and will be removed in the next MAJOR release. Require " \
-     "'airbrake/rake' instead."

--- a/lib/airbrake/resque/failure.rb
+++ b/lib/airbrake/resque/failure.rb
@@ -1,5 +1,0 @@
-require 'airbrake/resque'
-
-warn "DEPRECATION WARNING: Requiring 'airbrake/resque/failure' is " \
-     "deprecated and will be removed in the next MAJOR release. Require " \
-     "'airbrake/resque' instead."

--- a/lib/airbrake/shoryuken/error_handler.rb
+++ b/lib/airbrake/shoryuken/error_handler.rb
@@ -1,5 +1,0 @@
-require 'airbrake/shoryuken'
-
-warn "DEPRECATION WARNING: Requiring 'airbrake/shoryuken/error_handler' is " \
-     "deprecated and will be removed in the next MAJOR release. Require " \
-     "'airbrake/shoryuken' instead."

--- a/lib/airbrake/sidekiq/error_handler.rb
+++ b/lib/airbrake/sidekiq/error_handler.rb
@@ -1,5 +1,0 @@
-require 'airbrake/sidekiq'
-
-warn "DEPRECATION WARNING: Requiring 'airbrake/sidekiq/error_handler' is " \
-     "deprecated and will be removed in the next MAJOR release. Require " \
-     "'airbrake/sidekiq' instead."


### PR DESCRIPTION
These were deprecated 5 months ago, so it's high time to get rid of them.