### PR TITLE
capistrano/capistrano2: fix NameError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Airbrake Changelog
 
 * Fix error message for `rake airbrake:test` when current environment is ignored
   ([#796](https://github.com/airbrake/airbrake/pull/796))
+* Fix `undefined local variable or method 'username'` for the Capistrano 2
+  integration ([#797](https://github.com/airbrake/airbrake/pull/797))
 
 ### [v7.0.0][v7.0.0] (September 21, 2017)
 

--- a/lib/airbrake/capistrano/capistrano2.rb
+++ b/lib/airbrake/capistrano/capistrano2.rb
@@ -2,6 +2,7 @@ module Airbrake
   ##
   # The Capistrano v2 integration.
   module Capistrano
+    # rubocop:disable Metrics/AbcSize
     def self.load_into(config)
       config.load do
         after 'deploy',            'airbrake:deploy'
@@ -19,7 +20,7 @@ module Airbrake
                 RAILS_ENV=#{fetch(:rails_env, nil)} \
 
                 bundle exec rake airbrake:deploy \
-                  USERNAME=#{username} \
+                  USERNAME=#{Shellwords.shellescape(ENV['USER'] || ENV['USERNAME'])} \
                   ENVIRONMENT=#{fetch(:airbrake_env, fetch(:rails_env, 'production'))} \
                   REVISION=#{current_revision.strip} \
                   REPOSITORY=#{repository} \
@@ -31,11 +32,7 @@ module Airbrake
         end
       end
     end
-
-    def self.username
-      Shellwords.shellescape(ENV['USER'] || ENV['USERNAME'])
-    end
-    private_class_method :username
+    # rubocop:enable Metrics:AbcSize
   end
 end
 


### PR DESCRIPTION
Fixes https://github.com/airbrake/airbrake/issues/795.

Apparently the username method is not accessible from that scope. The only
reason it was a method is to reduce AbcSize complexity, but now it seems to be
safer to ignore that metrics.