### PR TITLE
Fix Sidekiq action(context)

### DIFF
--- a/lib/airbrake/sidekiq.rb
+++ b/lib/airbrake/sidekiq.rb
@@ -26,7 +26,7 @@ module Airbrake
       #   job_class. When used directly, use worker's name
       def action(context)
         klass = context['class'] || context[:job] && context[:job]['class']
-        return klass unless context[:job] && context[:job]['args'].first
+        return klass unless context[:job] && context[:job]['args'].first.is_a?(Hash)
         return klass unless (job_class = context[:job]['args'].first['job_class'])
         job_class
       end


### PR DESCRIPTION
If ActiveJob is not used, you can for example have args that are `[1, 2, 3]`, which will not be caught by `return klass unless context[:job] && context[:job]['args'].first`.

This causes next line to fail with `no implicit conversion of String into Integer`.

Suggested fix: Only try to lookup 'job_class' if context[:job]['args'].first is a hash.

