### PR TITLE
rack/middleware: use ActionDispatch::Request when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Fix URL port reporting for Rails apps running through SSL
+  ([#803](https://github.com/airbrake/airbrake/pull/803))
+
 ### [v7.0.2][v7.0.2] (September 29, 2017)
 
 * Fixed Sidekiq error `no implicit conversion of String into Integer` when

--- a/lib/airbrake/rack/middleware.rb
+++ b/lib/airbrake/rack/middleware.rb
@@ -68,7 +68,15 @@ module Airbrake
         notice = @notifier.build_notice(exception)
         return unless notice
 
-        notice.stash[:rack_request] = ::Rack::Request.new(env)
+        # ActionDispatch::Request correctly captures server port when using SSL:
+        # See: https://github.com/airbrake/airbrake/issues/802
+        notice.stash[:rack_request] =
+          if defined?(ActionDispatch::Request)
+            ActionDispatch::Request.new(env)
+          else
+            ::Rack::Request.new(env)
+          end
+
         @notifier.notify(notice)
       end
 


### PR DESCRIPTION
Fixes #802 (Airbrake reporting ALL urls as secure with a port)

`ActionDipstach::Request` and `Rack::Request` are not the same. We should use
the former when it's available because it handles SSL port better.