### PR TITLE
Better handle detecting if ActiveRecord is actually loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Airbrake Changelog
 * Better fix for apps which don't use ActiveRecord. In some scenarios some pieces
   of ActiveRecord may still be loaded, e.g. the ActiveRecord errors, causing airbrake
   to still fail to startup.
+  ([#810](https://github.com/airbrake/airbrake/pull/810))
 
 ### [v7.1.0][v7.1.0] (October 20, 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Changelog
 
 ### master
 
+* Better fix for apps which don't use ActiveRecord. In some scenarios some pieces
+  of ActiveRecord may still be loaded, e.g. the ActiveRecord errors, causing airbrake
+  to still fail to startup.
+
 ### [v7.1.0][v7.1.0] (October 20, 2017)
 
 * Started depending on

--- a/lib/airbrake/rails.rb
+++ b/lib/airbrake/rails.rb
@@ -19,7 +19,7 @@ module Airbrake
             ActionDispatch::DebugExceptions,
             Airbrake::Rack::Middleware
           )
-        elsif defined?(::ActiveRecord) && defined?(::ActiveRecord::ConnectionAdapters)
+        elsif defined?(::ActiveRecord::ConnectionAdapters::ConnectionManagement)
           # Insert after ConnectionManagement to avoid DB connection leakage:
           # https://github.com/airbrake/airbrake/pull/568
           app.config.middleware.insert_after(

--- a/lib/airbrake/rails.rb
+++ b/lib/airbrake/rails.rb
@@ -19,7 +19,7 @@ module Airbrake
             ActionDispatch::DebugExceptions,
             Airbrake::Rack::Middleware
           )
-        elsif defined?(::ActiveRecord)
+        elsif defined?(::ActiveRecord) && defined?(::ActiveRecord::ConnectionAdapters)
           # Insert after ConnectionManagement to avoid DB connection leakage:
           # https://github.com/airbrake/airbrake/pull/568
           app.config.middleware.insert_after(


### PR DESCRIPTION
We have a product where we do not use ActiveRecord, however a gem is loading up active_record/errors.rb so it can handle errors for when a product does use AR.   This causes airbrake to incorrectly detect that activerecord is loaded and it blows up as the ConnectionAdapter code isn't actually loaded.  This extends the current check so that it better handles this scenario.

Related to #580 