### PR TITLE
gemspec: lock rack-test to v0.7.0

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -113,7 +113,6 @@ end
 
 appraise 'sinatra' do
   gem 'sinatra', '~> 1.4.7'
-  gem 'rack-test', '~> 0.6.3'
   gem 'warden', '~> 1.2.6'
 end
 

--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -46,7 +46,8 @@ DESC
   # We still support Ruby 2.0.0+, but nokogiri 1.7.0+ doesn't.
   s.add_development_dependency 'nokogiri', '= 1.6.8.1'
 
-  s.add_development_dependency 'rack-test', '~> 0'
+  s.add_development_dependency 'rack-test', '= 0.6.3'
+  s.add_development_dependency 'redis', '= 3.3.3'
 
   # Fixes build failure with public_suffix v3
   # https://circleci.com/gh/airbrake/airbrake-ruby/889

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+machine:
+  ruby:
+    version: 2.4.2
+
 dependencies:
   override:
     - ? |

--- a/gemfiles/rack.gemfile
+++ b/gemfiles/rack.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "rubocop", "~> 0.51", require: false
 gem "warden", "~> 1.2.6"
 
 gemspec path: "../"

--- a/gemfiles/rails_3.2.gemfile
+++ b/gemfiles/rails_3.2.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "rubocop", "~> 0.51", require: false
 gem "rails", "~> 3.2.22"
 gem "warden", "~> 1.2.3"
 gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.18", platforms: :jruby
@@ -9,5 +10,6 @@ gem "sqlite3", "~> 1.3.11", platforms: [:mri, :rbx]
 gem "resque", "~> 1.25.2"
 gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job_active_record", "~> 4.1.0"
+gem "rack-test", "~> 0.6"
 
 gemspec path: "../"

--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "rubocop", "~> 0.51", require: false
 gem "rails", "~> 4.0.13"
 gem "warden", "~> 1.2.3"
 gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.18", platforms: :jruby

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "rubocop", "~> 0.51", require: false
 gem "rails", "~> 4.1.13"
 gem "warden", "~> 1.2.3"
 gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.18", platforms: :jruby

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "rubocop", "~> 0.51", require: false
 gem "rails", "~> 4.2.4"
 gem "warden", "~> 1.2.3"
 gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.18", platforms: :jruby

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "rubocop", "~> 0.51", require: false
 gem "rails", "~> 5.0.0"
 gem "warden", "~> 1.2.6"
 gem "rack", "~> 2.0"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "rubocop", "~> 0.51", require: false
 gem "rails", "~> 5.1.0"
 gem "warden", "~> 1.2.6"
 gem "rack", "~> 2.0"

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "rubocop", "~> 0.51", require: false
 gem "rails", github: "rails/rails"
 gem "arel", github: "rails/arel"
 gem "rack", "~> 2.0"

--- a/gemfiles/sinatra.gemfile
+++ b/gemfiles/sinatra.gemfile
@@ -2,8 +2,9 @@
 
 source "https://rubygems.org"
 
+gem "rubocop", "~> 0.51", require: false
 gem "sinatra", "~> 1.4.7"
-gem "rack-test", "~> 0.6.3"
+gem "rack-test", "~> 0.6"
 gem "warden", "~> 1.2.6"
 
 gemspec path: "../"


### PR DESCRIPTION
Rack test v0.8.0+ added a required_ruby_version of >= 2.2.2 but we still need to
support old Rubies.