### PR TITLE
spec: don't pass key for notice stubs

### DIFF
--- a/spec/integration/rails/rake_spec.rb
+++ b/spec/integration/rails/rake_spec.rb
@@ -1,9 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe "Rake integration" do
-  let(:endpoint) do
-    'https://airbrake.io/api/v3/projects/113743/notices?key=fd04e13d806a90f96614ad8e529b2822'
-  end
+  let(:endpoint) { 'https://airbrake.io/api/v3/projects/113743/notices' }
 
   def wait_for_a_request_with_body(body)
     wait_for(a_request(:post, endpoint).with(body: body)).to have_been_made.once

--- a/spec/integration/shared_examples/rack_examples.rb
+++ b/spec/integration/shared_examples/rack_examples.rb
@@ -3,9 +3,7 @@ RSpec.shared_examples 'rack examples' do
 
   after { Warden.test_reset! }
 
-  let(:endpoint) do
-    'https://airbrake.io/api/v3/projects/113743/notices?key=fd04e13d806a90f96614ad8e529b2822'
-  end
+  let(:endpoint) { 'https://airbrake.io/api/v3/projects/113743/notices' }
 
   def wait_for_a_request_with_body(body)
     wait_for(a_request(:post, endpoint).with(body: body)).to have_been_made.once

--- a/spec/integration/sinatra/sinatra_spec.rb
+++ b/spec/integration/sinatra/sinatra_spec.rb
@@ -20,13 +20,8 @@ RSpec.describe "Sinatra integration specs" do
   end
 
   context "when multiple apps are mounted" do
-    let(:endpoint1) do
-      'https://airbrake.io/api/v3/projects/113743/notices?key=fd04e13d806a90f96614ad8e529b2822'
-    end
-
-    let(:endpoint2) do
-      'https://airbrake.io/api/v3/projects/99123/notices?key=ad04e13d806a90f96614ad8e529b2821'
-    end
+    let(:endpoint1) { 'https://airbrake.io/api/v3/projects/113743/notices' }
+    let(:endpoint2) { 'https://airbrake.io/api/v3/projects/99123/notices' }
 
     def env_for(url, opts = {})
       Rack::MockRequest.env_for(url, opts)

--- a/spec/unit/logger_spec.rb
+++ b/spec/unit/logger_spec.rb
@@ -3,10 +3,7 @@ require 'spec_helper'
 RSpec.describe Airbrake::AirbrakeLogger do
   let(:project_id) { 113743 }
   let(:project_key) { 'fd04e13d806a90f96614ad8e529b2822' }
-
-  let(:endpoint) do
-    "https://airbrake.io/api/v3/projects/#{project_id}/notices?key=#{project_key}"
-  end
+  let(:endpoint) { "https://airbrake.io/api/v3/projects/#{project_id}/notices" }
 
   let(:airbrake) do
     Airbrake::Notifier.new(project_id: project_id, project_key: project_key)

--- a/spec/unit/rack/middleware_spec.rb
+++ b/spec/unit/rack/middleware_spec.rb
@@ -1,18 +1,9 @@
 require 'spec_helper'
 
 RSpec.describe Airbrake::Rack::Middleware do
-  let(:app) do
-    proc { |env| [200, env, 'Bingo bango content'] }
-  end
-
-  let(:faulty_app) do
-    proc { raise AirbrakeTestError }
-  end
-
-  let(:endpoint) do
-    'https://airbrake.io/api/v3/projects/113743/notices?key=fd04e13d806a90f96614ad8e529b2822'
-  end
-
+  let(:app) { proc { |env| [200, env, 'Bingo bango content'] } }
+  let(:faulty_app) { proc { raise AirbrakeTestError } }
+  let(:endpoint) { 'https://airbrake.io/api/v3/projects/113743/notices' }
   let(:middleware) { described_class.new(app) }
 
   def env_for(url, opts = {})
@@ -39,14 +30,8 @@ RSpec.describe Airbrake::Rack::Middleware do
     context "when app raises an exception" do
       context "and when the notifier name is specified" do
         let(:notifier_name) { :rack_middleware_initialize }
-
-        let(:bingo_endpoint) do
-          'https://airbrake.io/api/v3/projects/92123/notices?key=ad04e13d806a90f96614ad8e529b2821'
-        end
-
-        let(:expected_body) do
-          /"errors":\[{"type":"AirbrakeTestError"/
-        end
+        let(:bingo_endpoint) { 'https://airbrake.io/api/v3/projects/92123/notices' }
+        let(:expected_body) { /"errors":\[{"type":"AirbrakeTestError"/ }
 
         before do
           Airbrake.configure(notifier_name) do |c|

--- a/spec/unit/rack/user_spec.rb
+++ b/spec/unit/rack/user_spec.rb
@@ -1,9 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Airbrake::Rack::User do
-  let(:endpoint) do
-    'https://airbrake.io/api/v3/projects/113743/notices?key=fd04e13d806a90f96614ad8e529b2822'
-  end
+  let(:endpoint) { 'https://airbrake.io/api/v3/projects/113743/notices' }
 
   let(:user) do
     OpenStruct.new(

--- a/spec/unit/rake/tasks_spec.rb
+++ b/spec/unit/rake/tasks_spec.rb
@@ -1,9 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe "airbrake/rake/tasks" do
-  let(:endpoint) do
-    'https://airbrake.io/api/v4/projects/113743/deploys?key=fd04e13d806a90f96614ad8e529b2822'
-  end
+  let(:endpoint) { 'https://airbrake.io/api/v4/projects/113743/deploys' }
 
   def wait_for_a_request_with_body(body)
     wait_for(a_request(:post, endpoint).with(body: body)).to have_been_made.once
@@ -37,9 +35,7 @@ RSpec.describe "airbrake/rake/tasks" do
     end
 
     context "when Airbrake is not configured" do
-      let(:deploy_endpoint) do
-        'https://airbrake.io/api/v3/projects/113743/notices?key=fd04e13d806a90f96614ad8e529b2822'
-      end
+      let(:deploy_endpoint) { 'https://airbrake.io/api/v3/projects/113743/notices' }
 
       before do
         stub_request(:post, deploy_endpoint)

--- a/spec/unit/shoryuken_spec.rb
+++ b/spec/unit/shoryuken_spec.rb
@@ -14,9 +14,7 @@ RSpec.describe Airbrake::Shoryuken::ErrorHandler do
     end.new
   end
 
-  let(:endpoint) do
-    'https://airbrake.io/api/v3/projects/113743/notices?key=fd04e13d806a90f96614ad8e529b2822'
-  end
+  let(:endpoint) { 'https://airbrake.io/api/v3/projects/113743/notices' }
 
   def wait_for_a_request_with_body(body)
     wait_for(a_request(:post, endpoint).with(body: body)).to have_been_made.once

--- a/spec/unit/sidekiq_spec.rb
+++ b/spec/unit/sidekiq_spec.rb
@@ -6,9 +6,7 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
   require 'airbrake/sidekiq'
 
   RSpec.describe "airbrake/sidekiq/error_handler" do
-    let(:endpoint) do
-      'https://airbrake.io/api/v3/projects/113743/notices?key=fd04e13d806a90f96614ad8e529b2822'
-    end
+    let(:endpoint) { 'https://airbrake.io/api/v3/projects/113743/notices' }
 
     def wait_for_a_request_with_body(body)
       wait_for(a_request(:post, endpoint).with(body: body)).to have_been_made.once


### PR DESCRIPTION
In the most recent airbrake-ruby project key is passed through the Authorization
header, not a query parameter. [1]

[1]: https://github.com/airbrake/airbrake-ruby/commit/5d258a28993ca2b2649e02abd93dfa944f207063