### PR TITLE
Appraisals: point rails-edge to the 5-2-stable branch

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -92,7 +92,7 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
   end
 
   appraise 'rails-edge' do
-    gem 'rails', github: 'rails/rails'
+    gem 'rails', github: 'rails/rails', branch: '5-2-stable'
     gem 'arel', github: 'rails/arel'
     gem 'rack', '~> 2.0'
     gem 'warden', '~> 1.2.6'

--- a/gemfiles/rails_3.2.gemfile
+++ b/gemfiles/rails_3.2.gemfile
@@ -10,6 +10,5 @@ gem "sqlite3", "~> 1.3.11", platforms: [:mri, :rbx]
 gem "resque", "~> 1.25.2"
 gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job_active_record", "~> 4.1.0"
-gem "rack-test", "~> 0.6"
 
 gemspec path: "../"

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rubocop", "~> 0.51", require: false
-gem "rails", github: "rails/rails"
+gem "rails", github: "rails/rails", branch: "5-2-stable"
 gem "arel", github: "rails/arel"
 gem "rack", "~> 2.0"
 gem "warden", "~> 1.2.6"

--- a/gemfiles/sinatra.gemfile
+++ b/gemfiles/sinatra.gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 gem "rubocop", "~> 0.51", require: false
 gem "sinatra", "~> 1.4.7"
-gem "rack-test", "~> 0.6"
 gem "warden", "~> 1.2.6"
 
 gemspec path: "../"


### PR DESCRIPTION
For some reason it was resolving to 6.0.0.alpha, and as of now I can't find
where it is being mentioned in the latest repo. Either way, it's too early to
think about it because even v5.2.0 hasn't been released yet.