### PR TITLE
Add a filter that ignore retryable Sidekiq jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,14 @@ require 'airbrake/sidekiq'
 If you required Sidekiq before Airbrake, then you don't even have to `require`
 anything manually and it should just work out-of-box.
 
+By default, Airbrake notifies of all errors, including reoccurring errors during a
+retry attempt. To filter out these errors and only get notified when Sidekiq has
+exhausted its retries you can add the `RetryableJobsFilter`:
+
+```ruby
+Airbrake.add_filter(Airbrake::Sidekiq::RetryableJobsFilter.new)
+```
+
 ### ActiveJob
 
 No additional configuration is needed. Simply ensure that you have configured

--- a/lib/airbrake/sidekiq.rb
+++ b/lib/airbrake/sidekiq.rb
@@ -1,3 +1,5 @@
+require 'airbrake/sidekiq/retryable_jobs_filter'
+
 module Airbrake
   module Sidekiq
     ##

--- a/spec/unit/sidekiq/retryable_jobs_filter_spec.rb
+++ b/spec/unit/sidekiq/retryable_jobs_filter_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
+  require 'sidekiq'
+  require 'sidekiq/cli'
+  require 'airbrake/sidekiq'
+
+  RSpec.describe "airbrake/sidekiq/retryable_jobs_filter" do
+    subject(:filter) { Airbrake::Sidekiq::RetryableJobsFilter.new }
+    def build_notice(job = nil)
+      Airbrake::Notice.new(Airbrake::Config.new, StandardError.new, job: job)
+    end
+
+    it "does not ignore notices that are not from jobs" do
+      notice = build_notice
+      filter.call(notice)
+      expect(build_notice).to_not be_ignored
+    end
+
+    it "does not ignore notices from jobs that have retries disabled" do
+      notice = build_notice('retry' => false)
+      filter.call(notice)
+      expect(build_notice).to_not be_ignored
+    end
+
+    it "ignore notices from jobs that will be retried" do
+      notice = build_notice('retry' => true, 'retry_count' => 0)
+      filter.call(notice)
+      expect(notice).to be_ignored
+    end
+
+    it "does not ignore notices from jobs that will not be retried" do
+      notice = build_notice('retry' => 5, 'retry_count' => 5)
+      filter.call(notice)
+      expect(build_notice).to_not be_ignored
+    end
+  end
+end


### PR DESCRIPTION
With this filter, errors from jobs tha will be retried will be ignored and only collected when Sidekiq exhausts its retries attempts

Closes #830