### PR TITLE
Gemfile: update rubocop to v0.55.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,3 +69,7 @@ Bundler/OrderedGems:
 
 Naming/UncommunicativeMethodParamName:
   Enabled: false
+
+Style/SymbolArray:
+  Exclude:
+    - gemfiles/*.gemfile

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,3 +63,6 @@ Gemspec/RequiredRubyVersion:
 # Broken behaviour: https://github.com/bbatsov/rubocop/issues/5224
 Layout/EmptyLinesAroundArguments:
   Enabled: false
+
+Bundler/OrderedGems:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,3 +66,6 @@ Layout/EmptyLinesAroundArguments:
 
 Bundler/OrderedGems:
   Enabled: false
+
+Naming/UncommunicativeMethodParamName:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ gemspec
 
 # Rubocop supports only >=2.1.0
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.1.0')
-  gem 'rubocop', '= 0.51', require: false
+  gem 'rubocop', '= 0.55', require: false
 end

--- a/lib/generators/airbrake_generator.rb
+++ b/lib/generators/airbrake_generator.rb
@@ -6,7 +6,7 @@
 #
 class AirbrakeGenerator < Rails::Generators::Base
   # Adds current directory to source paths, so we can find the template file.
-  source_root File.expand_path('..', __FILE__)
+  source_root File.expand_path(__dir__)
 
   argument :project_id, required: false
   argument :project_key, required: false


### PR DESCRIPTION
* rubocop: disable the Bundle/OrderedGems cop
  This cop is nothing but a nitpick. Following its rules doesn't give anything but
headache, thus I'm disabling it.

* rubocop: disable the Naming/UncommunicativeMethodParamName cop
  This rule is a little annoying to follow. Although I understand that it
prevents you from bad variable names, sometimes they are useful (for example,
`h` or `th`).

* rubocop: ignore gemfiles for the Style/SymbolArray cop
  Those gemfiles are autogenerated and it is not recommended to edit them by hand.