### PR TITLE
Stop following the RDoc convention

### DIFF
--- a/lib/airbrake/delayed_job.rb
+++ b/lib/airbrake/delayed_job.rb
@@ -1,6 +1,5 @@
 module Delayed
   module Plugins
-    ##
     # Provides integration with Delayed Job.
     # rubocop:disable Lint/RescueException
     class Airbrake < ::Delayed::Plugin
@@ -33,7 +32,6 @@ module Delayed
 end
 
 if RUBY_ENGINE == 'jruby' && defined?(Delayed::Backend::ActiveRecord::Job)
-  ##
   # Workaround against JRuby bug:
   # https://github.com/jruby/jruby/issues/3338
   # rubocop:disable Style/ClassAndModuleChildren

--- a/lib/airbrake/logger.rb
+++ b/lib/airbrake/logger.rb
@@ -2,7 +2,6 @@ require 'logger'
 require 'delegate'
 
 module Airbrake
-  ##
   # Decorator for +Logger+ from stdlib. Endows loggers the ability to both log
   # and report errors to Airbrake.
   #
@@ -13,14 +12,12 @@ module Airbrake
   #   # Just use the logger like you normally do.
   #   logger.fatal('oops')
   class AirbrakeLogger < SimpleDelegator
-    ##
     # @example
     #   # Assign a default Airbrake notifier
     #   logger.airbrake_notifier = Airbrake[:default]
     # @return [Airbrake::Notifier] notifier to be used to send notices
     attr_accessor :airbrake_notifier
 
-    ##
     # @return [Integer]
     attr_reader :airbrake_level
 
@@ -30,35 +27,30 @@ module Airbrake
       @airbrake_level = Logger::WARN
     end
 
-    ##
     # @see Logger#warn
     def warn(progname = nil, &block)
       notify_airbrake(Logger::WARN, progname)
       super
     end
 
-    ##
     # @see Logger#error
     def error(progname = nil, &block)
       notify_airbrake(Logger::ERROR, progname)
       super
     end
 
-    ##
     # @see Logger#fatal
     def fatal(progname = nil, &block)
       notify_airbrake(Logger::FATAL, progname)
       super
     end
 
-    ##
     # @see Logger#unknown
     def unknown(progname = nil, &block)
       notify_airbrake(Logger::UNKNOWN, progname)
       super
     end
 
-    ##
     # Sets airbrake severity level. Does not permit values below `Logger::WARN`.
     #
     # @example

--- a/lib/airbrake/rack/context_filter.rb
+++ b/lib/airbrake/rack/context_filter.rb
@@ -1,11 +1,9 @@
 module Airbrake
   module Rack
-    ##
     # Adds context (URL, User-Agent, framework version, controller and more).
     #
     # @since v5.7.0
     class ContextFilter
-      ##
       # @return [Integer]
       attr_reader :weight
 
@@ -21,7 +19,6 @@ module Airbrake
         @weight = 99
       end
 
-      ##
       # @see Airbrake::FilterChain#refine
       def call(notice)
         return unless (request = notice.stash[:rack_request])

--- a/lib/airbrake/rack/http_headers_filter.rb
+++ b/lib/airbrake/rack/http_headers_filter.rb
@@ -1,11 +1,9 @@
 module Airbrake
   module Rack
-    ##
     # Adds HTTP request parameters.
     #
     # @since v5.7.0
     class HttpHeadersFilter
-      ##
       # @return [Array<String>] the prefixes of the majority of HTTP headers in
       #   Rack (some prefixes match the header names for simplicity)
       HTTP_HEADER_PREFIXES = [
@@ -14,7 +12,6 @@ module Airbrake
         'CONTENT_LENGTH'.freeze
       ].freeze
 
-      ##
       # @return [Integer]
       attr_reader :weight
 
@@ -22,7 +19,6 @@ module Airbrake
         @weight = 98
       end
 
-      ##
       # @see Airbrake::FilterChain#refine
       def call(notice)
         return unless (request = notice.stash[:rack_request])

--- a/lib/airbrake/rack/http_params_filter.rb
+++ b/lib/airbrake/rack/http_params_filter.rb
@@ -1,11 +1,9 @@
 module Airbrake
   module Rack
-    ##
     # Adds HTTP request parameters.
     #
     # @since v5.7.0
     class HttpParamsFilter
-      ##
       # @return [Integer]
       attr_reader :weight
 
@@ -13,7 +11,6 @@ module Airbrake
         @weight = 97
       end
 
-      ##
       # @see Airbrake::FilterChain#refine
       def call(notice)
         return unless (request = notice.stash[:rack_request])

--- a/lib/airbrake/rack/middleware.rb
+++ b/lib/airbrake/rack/middleware.rb
@@ -1,6 +1,5 @@
 module Airbrake
   module Rack
-    ##
     # Airbrake Rack middleware for Rails and Sinatra applications (or any other
     # Rack-compliant app). Any errors raised by the upstream application will be
     # delivered to Airbrake and re-raised.
@@ -8,7 +7,6 @@ module Airbrake
     # The middleware automatically sends information about the framework that
     # uses it (name and version).
     class Middleware
-      ##
       # @return [Array<Class>] the list of Rack filters that read Rack request
       #   information and append it to notices
       RACK_FILTERS = [
@@ -21,7 +19,6 @@ module Airbrake
         # Airbrake::Rack::RequestBodyFilter
       ].freeze
 
-      ##
       # An Array that holds notifier names, which are known to be associated
       # with particular Airbrake Rack middleware.
       # rubocop:disable Style/ClassVars
@@ -42,7 +39,6 @@ module Airbrake
         end
       end
 
-      ##
       # Rescues any exceptions, sends them to Airbrake and re-raises the
       # exception.
       # @param [Hash] env the Rack environment
@@ -80,7 +76,6 @@ module Airbrake
         @notifier.notify(notice)
       end
 
-      ##
       # Web framework middlewares often store rescued exceptions inside the
       # Rack env, but Rack doesn't have a standard key for it:
       #

--- a/lib/airbrake/rack/request_body_filter.rb
+++ b/lib/airbrake/rack/request_body_filter.rb
@@ -1,6 +1,5 @@
 module Airbrake
   module Rack
-    ##
     # A filter that appends Rack request body to the notice.
     #
     # @example
@@ -10,18 +9,15 @@ module Airbrake
     # @since v5.7.0
     # @note This filter is *not* used by default.
     class RequestBodyFilter
-      ##
       # @return [Integer]
       attr_reader :weight
 
-      ##
       # @param [Integer] length The maximum number of bytes to read
       def initialize(length = 4096)
         @length = length
         @weight = 95
       end
 
-      ##
       # @see Airbrake::FilterChain#refine
       def call(notice)
         return unless (request = notice.stash[:rack_request])

--- a/lib/airbrake/rack/session_filter.rb
+++ b/lib/airbrake/rack/session_filter.rb
@@ -1,11 +1,9 @@
 module Airbrake
   module Rack
-    ##
     # Adds HTTP session.
     #
     # @since v5.7.0
     class SessionFilter
-      ##
       # @return [Integer]
       attr_reader :weight
 
@@ -13,7 +11,6 @@ module Airbrake
         @weight = 96
       end
 
-      ##
       # @see Airbrake::FilterChain#refine
       def call(notice)
         return unless (request = notice.stash[:rack_request])

--- a/lib/airbrake/rack/user.rb
+++ b/lib/airbrake/rack/user.rb
@@ -1,6 +1,5 @@
 module Airbrake
   module Rack
-    ##
     # Represents an authenticated user, which can be converted to Airbrake's
     # payload format. Supports Warden and Omniauth authentication frameworks.
     class User

--- a/lib/airbrake/rails.rb
+++ b/lib/airbrake/rails.rb
@@ -1,6 +1,5 @@
 module Airbrake
   module Rails
-    ##
     # This railtie works for any Rails application that supports railties (Rails
     # 3.2+ apps). It makes Airbrake Ruby work with Rails and report errors
     # occurring in the application automatically.

--- a/lib/airbrake/rails/action_controller.rb
+++ b/lib/airbrake/rails/action_controller.rb
@@ -1,6 +1,5 @@
 module Airbrake
   module Rails
-    ##
     # Contains helper methods that can be used inside Rails controllers to send
     # notices to Airbrake. The main benefit of using them instead of the direct
     # API is that they automatically add information from the Rack environment
@@ -8,7 +7,6 @@ module Airbrake
     module ActionController
       private
 
-      ##
       # A helper method for sending notices to Airbrake *asynchronously*.
       # Attaches information from the Rack env.
       # @see Airbrake#notify, #notify_airbrake_sync
@@ -17,7 +15,6 @@ module Airbrake
         Airbrake[notifier_name].notify(notice, params)
       end
 
-      ##
       # A helper method for sending notices to Airbrake *synchronously*.
       # Attaches information from the Rack env.
       # @see Airbrake#notify_sync, #notify_airbrake
@@ -26,7 +23,6 @@ module Airbrake
         Airbrake[notifier_name].notify_sync(notice, params)
       end
 
-      ##
       # @param [Exception] exception
       # @return [Airbrake::Notice] the notice with information from the Rack env
       def build_notice(exception, params = {}, notifier_name = :default)

--- a/lib/airbrake/rails/active_job.rb
+++ b/lib/airbrake/rails/active_job.rb
@@ -1,11 +1,9 @@
 module Airbrake
   module Rails
-    ##
     # Enables support for exceptions occurring in ActiveJob jobs.
     module ActiveJob
       extend ActiveSupport::Concern
 
-      ##
       # @return [Array<Regexp>] the list of known adapters
       ADAPTERS = [/Resque/, /Sidekiq/, /DelayedJob/].freeze
 

--- a/lib/airbrake/rails/active_record.rb
+++ b/lib/airbrake/rails/active_record.rb
@@ -1,6 +1,5 @@
 module Airbrake
   module Rails
-    ##
     # Rails <4.2 has a bug with regard to swallowing exceptions in the
     # +after_commit+ and the +after_rollback+ hooks: it doesn't bubble up
     # exceptions from there.
@@ -12,7 +11,6 @@ module Airbrake
     # @see https://goo.gl/348lor Rails 4.2+ implementation (fixed)
     # @see https://goo.gl/ddFNg7 Rails <4.2 implementation (bugged)
     module ActiveRecord
-      ##
       # Patches default +run_callbacks+ with our version, which is capable of
       # notifying about exceptions.
       #

--- a/lib/airbrake/rake.rb
+++ b/lib/airbrake/rake.rb
@@ -4,13 +4,11 @@
 Rake::TaskManager.record_task_metadata = true
 
 module Rake
-  ##
   # Redefine +Rake::Task#execute+, so it can report errors to Airbrake.
   class Task
     # Store the original method to use it later.
     alias execute_without_airbrake execute
 
-    ##
     # A wrapper around the original +#execute+, that catches all errors and
     # notifies Airbrake.
     #

--- a/lib/airbrake/resque.rb
+++ b/lib/airbrake/resque.rb
@@ -1,6 +1,5 @@
 module Resque
   module Failure
-    ##
     # Provides Resque integration with Airbrake.
     #
     # @since v5.0.0
@@ -15,7 +14,6 @@ module Resque
 
       private
 
-      ##
       # @return [String] job's name. When ActiveJob is present, retrieve
       #   job_class. When used directly, use worker's name
       def action(payload)

--- a/lib/airbrake/shoryuken.rb
+++ b/lib/airbrake/shoryuken.rb
@@ -1,6 +1,5 @@
 module Airbrake
   module Shoryuken
-    ##
     # Provides integration with Shoryuken.
     class ErrorHandler
       # rubocop:disable Lint/RescueException

--- a/lib/airbrake/sidekiq.rb
+++ b/lib/airbrake/sidekiq.rb
@@ -2,7 +2,6 @@ require 'airbrake/sidekiq/retryable_jobs_filter'
 
 module Airbrake
   module Sidekiq
-    ##
     # Provides integration with Sidekiq v2+.
     class ErrorHandler
       # rubocop:disable Lint/RescueException
@@ -23,7 +22,6 @@ module Airbrake
         end
       end
 
-      ##
       # @return [String] job's name. When ActiveJob is present, retrieve
       #   job_class. When used directly, use worker's name
       def action(context)

--- a/lib/airbrake/sidekiq/retryable_jobs_filter.rb
+++ b/lib/airbrake/sidekiq/retryable_jobs_filter.rb
@@ -1,6 +1,5 @@
 module Airbrake
   module Sidekiq
-    ##
     # Filter that can ignore notices from jobs that failed but will be retried
     # by Sidekiq
     # @since v7.3.0

--- a/lib/airbrake/sneakers.rb
+++ b/lib/airbrake/sneakers.rb
@@ -1,6 +1,5 @@
 module Airbrake
   module Sneakers
-    ##
     # Provides integration with Sneakers.
     #
     # @see https://github.com/jondot/sneakers

--- a/lib/airbrake/version.rb
+++ b/lib/airbrake/version.rb
@@ -1,4 +1,3 @@
-##
 # We use Semantic Versioning v2.0.0
 # More information: http://semver.org/
 module Airbrake

--- a/lib/generators/airbrake_generator.rb
+++ b/lib/generators/airbrake_generator.rb
@@ -1,4 +1,3 @@
-##
 # Creates the Airbrake initializer file for Rails apps.
 #
 # @example Invokation from terminal
@@ -11,7 +10,6 @@ class AirbrakeGenerator < Rails::Generators::Base
   argument :project_id, required: false
   argument :project_key, required: false
 
-  ##
   # Makes the NAME option optional, which allows to subclass from Base, so we
   # can pass arguments to the ERB template.
   #


### PR DESCRIPTION
YARD sometimes doesn't understand `##`, since it's actually RDoc's format. We
use YARD in this project so we should try to follow its conventions instead.