### PR TITLE
rack/context_filter: don't freeze the versions hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Changelog
 
 ### master
 
+* Fixed `can't modify frozen Hash` error when using the Rack/Rails integration
+  along with `DependencyFilter` from airbrake-ruby
+  ([#847](https://github.com/airbrake/airbrake/pull/847))
+
 ### [v7.3.1][v7.3.1] (May 4, 2018)
 
 * Rack/Rails/Sinatra integrations started attaching their versions to

--- a/lib/airbrake/rack/context_filter.rb
+++ b/lib/airbrake/rack/context_filter.rb
@@ -18,7 +18,7 @@ module Airbrake
               'rack_version' => ::Rack.version,
               'rack_release' => ::Rack.release
             }
-          end.freeze
+          end
         @weight = 99
       end
 


### PR DESCRIPTION
There was a bug where the integration would attach a frozen hash, then
`DependencyFilter` from airbrake-ruby would try to add more data to the hash but
couldn't due to the `can't modify frozen Hash` error. We shoudn't freeze public
hashes.