### PR TITLE
sneakers: fix SystemStackError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Fixed SystemStackError in the Sneakers integration
+  ([#852](https://github.com/airbrake/airbrake/pull/852))
+
 ### [v7.3.3][v7.3.3] (May 11, 2018)
 
 * Fixed Resque failure when the first item in payload args is not a hash

--- a/lib/airbrake/sneakers.rb
+++ b/lib/airbrake/sneakers.rb
@@ -5,11 +5,27 @@ module Airbrake
     # @see https://github.com/jondot/sneakers
     # @since v7.2.0
     class ErrorReporter
+      # @return [Array<Symbol>] ignored keys values of which raise
+      #   SystemStackError when `as_json` is called on them
+      # @see https://github.com/airbrake/airbrake/issues/850
+      IGNORED_KEYS = %i[delivery_tag consumer channel].freeze
+
       def call(exception, worker = nil, **context)
-        Airbrake.notify(exception, context) do |notice|
+        Airbrake.notify(exception, filter_context(context)) do |notice|
           notice[:context][:component] = 'sneakers'
           notice[:context][:action] = worker.class.to_s
         end
+      end
+
+      private
+
+      def filter_context(context)
+        return context unless context[:delivery_info]
+        h = context.dup
+        h[:delivery_info] = context[:delivery_info].reject do |k, _v|
+          IGNORED_KEYS.include?(k)
+        end
+        h
       end
     end
   end


### PR DESCRIPTION
Fixes #850
("Stack level is too deep" on 7.3.3 when calling from Sneakers (7.2.0) worker
with Rails 5.2.0)

`as_json` causes problems on certain objects that Sneakers manages. We can't do
anything but ignore them.