### PR TITLE
Do not track development env by default

### DIFF
--- a/lib/generators/airbrake_initializer.rb.erb
+++ b/lib/generators/airbrake_initializer.rb.erb
@@ -47,7 +47,7 @@ Airbrake.configure do |c|
   # unwanted environments such as :test.
   # NOTE: This option *does not* work if you don't set the 'environment' option.
   # https://github.com/airbrake/airbrake-ruby#ignore_environments
-  c.ignore_environments = %w(test)
+  c.ignore_environments = %w(test development)
 
   # A list of parameters that should be filtered out of what is sent to
   # Airbrake. By default, all "password" attributes will have their contents


### PR DESCRIPTION
It's just a suggestion.

Most of people/companies/projects I've worked always ignore dev env.

The reason is quite simple: None one is interested in see errors from someone else computer, eg: bad DB config, fix typo, and these sort of things