### PR TITLE
[FEATURE] Add Ignorable Classes with retry attempts before ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,17 @@ has exhausted its retries you can add the `RetryableJobsFilter`:
 Airbrake.add_filter(Airbrake::Sidekiq::RetryableJobsFilter.new)
 ```
 
+To ignore certain classes `x` times use the `IgnorableClassFilter`
+
+```ruby
+Airbrake.add_filter(
+  Airbrake::Sidekiq::IgnorableClassFilter.new(
+    ignorable_classes: ['SomeIgnorableClass'],
+    retry_attempts_before_airbrake: x
+  )
+)
+```
+
 ### ActiveJob
 
 No additional configuration is needed. Simply ensure that you have configured

--- a/lib/airbrake/sidekiq.rb
+++ b/lib/airbrake/sidekiq.rb
@@ -1,5 +1,5 @@
 require 'airbrake/sidekiq/retryable_jobs_filter'
-require 'airbrake/sidekiq/ignorable_class_filter'
+require 'airbrake/sidekiq/ignorable_error_class_filter'
 
 module Airbrake
   module Sidekiq

--- a/lib/airbrake/sidekiq.rb
+++ b/lib/airbrake/sidekiq.rb
@@ -1,4 +1,5 @@
 require 'airbrake/sidekiq/retryable_jobs_filter'
+require 'airbrake/sidekiq/ignorable_class_filter'
 
 module Airbrake
   module Sidekiq

--- a/lib/airbrake/sidekiq/ignorable_class_filter.rb
+++ b/lib/airbrake/sidekiq/ignorable_class_filter.rb
@@ -1,0 +1,48 @@
+module Airbrake
+  module Sidekiq
+    # Filter that ignores classes a minimum number of times before sending to airbrake
+    class IgnorableClassFilter
+      if Gem::Version.new(::Sidekiq::VERSION) < Gem::Version.new('5.0.0')
+        require 'sidekiq/middleware/server/retry_jobs'
+        DEFAULT_MAX_RETRY_ATTEMPTS = \
+          ::Sidekiq::Middleware::Server::RetryJobs::DEFAULT_MAX_RETRY_ATTEMPTS
+      else
+        require 'sidekiq/job_retry'
+        DEFAULT_MAX_RETRY_ATTEMPTS = ::Sidekiq::JobRetry::DEFAULT_MAX_RETRY_ATTEMPTS
+      end
+
+      attr_accessor :retry_attempts_before_airbrake
+      attr_accessor :ignorable_classes
+
+      def initialize(retry_attempts_before_airbrake: nil, ignorable_classes: nil)
+        @retry_attempts_before_airbrake = [retry_attempts_before_airbrake.to_i, DEFAULT_MAX_RETRY_ATTEMPTS].min
+        @ignorable_classes = Array(ignorable_classes)
+      end
+
+      def call(notice)
+        job = notice[:params][:job]
+
+        notice.ignore! if ignorable?(job)
+      end
+
+      private
+
+      def ignorable?(job)
+        # DO NOT IGNORE if not a job or does not have a retry
+        return false unless job && job['retry']
+
+        # IGNORE if an ignorable class and retry attempts less than RETRY_ATTEMPTS_BEFORE_AIRBRAKE
+        if @ignorable_classes.include?(job['class'])
+          if job['retry_count'] > @retry_attempts_before_airbrake
+            return false
+          else
+            return true
+          end
+        end
+
+        # DO NOT IGNORE all the others
+        return false
+      end
+    end
+  end
+end

--- a/lib/airbrake/sidekiq/ignorable_class_filter.rb
+++ b/lib/airbrake/sidekiq/ignorable_class_filter.rb
@@ -35,7 +35,7 @@ module Airbrake
         # IGNORE if an ignorable class and
         # retry attempts less than RETRY_ATTEMPTS_BEFORE_AIRBRAKE
         return true if @ignorable_classes.include?(job['class']) &&
-                         job['retry_count'] <= @retry_attempts_before_airbrake
+                       job['retry_count'] <= @retry_attempts_before_airbrake
 
         # DO NOT IGNORE all the others
         false

--- a/lib/airbrake/sidekiq/ignorable_class_filter.rb
+++ b/lib/airbrake/sidekiq/ignorable_class_filter.rb
@@ -15,7 +15,8 @@ module Airbrake
       attr_accessor :ignorable_classes
 
       def initialize(retry_attempts_before_airbrake: nil, ignorable_classes: nil)
-        @retry_attempts_before_airbrake = [retry_attempts_before_airbrake.to_i, DEFAULT_MAX_RETRY_ATTEMPTS].min
+        @retry_attempts_before_airbrake = \
+          [retry_attempts_before_airbrake.to_i, DEFAULT_MAX_RETRY_ATTEMPTS].min
         @ignorable_classes = Array(ignorable_classes)
       end
 
@@ -31,17 +32,13 @@ module Airbrake
         # DO NOT IGNORE if not a job or does not have a retry
         return false unless job && job['retry']
 
-        # IGNORE if an ignorable class and retry attempts less than RETRY_ATTEMPTS_BEFORE_AIRBRAKE
-        if @ignorable_classes.include?(job['class'])
-          if job['retry_count'] > @retry_attempts_before_airbrake
-            return false
-          else
-            return true
-          end
-        end
+        # IGNORE if an ignorable class and
+        # retry attempts less than RETRY_ATTEMPTS_BEFORE_AIRBRAKE
+        return true if @ignorable_classes.include?(job['class']) &&
+                         job['retry_count'] <= @retry_attempts_before_airbrake
 
         # DO NOT IGNORE all the others
-        return false
+        false
       end
     end
   end

--- a/lib/airbrake/sidekiq/ignorable_error_class_filter.rb
+++ b/lib/airbrake/sidekiq/ignorable_error_class_filter.rb
@@ -1,7 +1,7 @@
 module Airbrake
   module Sidekiq
     # Filter that ignores classes a minimum number of times before sending to airbrake
-    class IgnorableClassFilter
+    class IgnorableErrorClassFilter
       if Gem::Version.new(::Sidekiq::VERSION) < Gem::Version.new('5.0.0')
         require 'sidekiq/middleware/server/retry_jobs'
         DEFAULT_MAX_RETRY_ATTEMPTS = \
@@ -34,7 +34,7 @@ module Airbrake
 
         # IGNORE if an ignorable class and
         # retry attempts less than RETRY_ATTEMPTS_BEFORE_AIRBRAKE
-        return true if @ignorable_classes.include?(job['class']) &&
+        return true if @ignorable_classes.include?(job['error_class']) &&
                        job['retry_count'] <= @retry_attempts_before_airbrake
 
         # DO NOT IGNORE all the others

--- a/spec/unit/sidekiq/ignorable_classes_filter_spec.rb
+++ b/spec/unit/sidekiq/ignorable_classes_filter_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+require 'sidekiq'
+require 'sidekiq/cli'
+require 'airbrake/sidekiq'
+
+RSpec.describe "airbrake/sidekiq/ignorable_class_filter" do
+  subject(:filter) do
+    Airbrake::Sidekiq::IgnorableClassFilter.new(
+      retry_attempts_before_airbrake: retry_attempts_before_airbrake,
+      ignorable_classes: ignorable_classes
+    )
+  end
+
+  let(:retry_attempts_before_airbrake) { 2 }
+  let(:ignorable_classes) do
+    ["OneIgnorableClass"]
+  end
+
+  def build_notice(job = nil)
+    Airbrake::Notice.new(Airbrake::Config.new, StandardError.new, job: job)
+  end
+
+  it "does not ignore notices that are not from jobs" do
+    notice = build_notice
+    filter.call(notice)
+    expect(build_notice).to_not be_ignored
+  end
+
+  it "does not ignore notices from jobs that have retries disabled" do
+    notice = build_notice('retry' => false)
+    filter.call(notice)
+    expect(build_notice).to_not be_ignored
+  end
+
+  it "ignore notices from jobs that is an ignorable class" do
+    notice = build_notice('retry' => true, 'retry_count' => 0, 'class' => 'OneIgnorableClass')
+    filter.call(notice)
+    expect(notice).to be_ignored
+  end
+
+  it "does not ignore notices from jobs that is an ignorable class with higher retry count" do
+    notice = build_notice(
+      'retry' => true,
+      'retry_count' => retry_attempts_before_airbrake + 1,
+      'class' => 'OneIgnorableClass'
+    )
+    filter.call(notice)
+    expect(build_notice).to_not be_ignored
+  end
+end

--- a/spec/unit/sidekiq/ignorable_classes_filter_spec.rb
+++ b/spec/unit/sidekiq/ignorable_classes_filter_spec.rb
@@ -1,55 +1,57 @@
 require 'spec_helper'
 
-require 'sidekiq'
-require 'sidekiq/cli'
-require 'airbrake/sidekiq'
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
+  require 'sidekiq'
+  require 'sidekiq/cli'
+  require 'airbrake/sidekiq'
 
-RSpec.describe "airbrake/sidekiq/ignorable_class_filter" do
-  subject(:filter) do
-    Airbrake::Sidekiq::IgnorableClassFilter.new(
-      retry_attempts_before_airbrake: retry_attempts_before_airbrake,
-      ignorable_classes: ignorable_classes
-    )
-  end
+  RSpec.describe "airbrake/sidekiq/ignorable_class_filter" do
+    subject(:filter) do
+      Airbrake::Sidekiq::IgnorableClassFilter.new(
+        retry_attempts_before_airbrake: retry_attempts_before_airbrake,
+        ignorable_classes: ignorable_classes
+      )
+    end
 
-  let(:retry_attempts_before_airbrake) { 2 }
-  let(:ignorable_classes) do
-    ["OneIgnorableClass"]
-  end
+    let(:retry_attempts_before_airbrake) { 2 }
+    let(:ignorable_classes) do
+      ["OneIgnorableClass"]
+    end
 
-  def build_notice(job = nil)
-    Airbrake::Notice.new(Airbrake::Config.new, StandardError.new, job: job)
-  end
+    def build_notice(job = nil)
+      Airbrake::Notice.new(Airbrake::Config.new, StandardError.new, job: job)
+    end
 
-  it "does not ignore notices that are not from jobs" do
-    notice = build_notice
-    filter.call(notice)
-    expect(build_notice).to_not be_ignored
-  end
+    it "does not ignore notices that are not from jobs" do
+      notice = build_notice
+      filter.call(notice)
+      expect(build_notice).to_not be_ignored
+    end
 
-  it "does not ignore notices from jobs that have retries disabled" do
-    notice = build_notice('retry' => false)
-    filter.call(notice)
-    expect(build_notice).to_not be_ignored
-  end
+    it "does not ignore notices from jobs that have retries disabled" do
+      notice = build_notice('retry' => false)
+      filter.call(notice)
+      expect(build_notice).to_not be_ignored
+    end
 
-  it "ignore notices from jobs that is an ignorable class" do
-    notice = build_notice(
-      'retry' => true,
-      'retry_count' => 0,
-      'class' => 'OneIgnorableClass'
-    )
-    filter.call(notice)
-    expect(notice).to be_ignored
-  end
+    it "ignore notices from jobs that is an ignorable class" do
+      notice = build_notice(
+        'retry' => true,
+        'retry_count' => 0,
+        'class' => 'OneIgnorableClass'
+      )
+      filter.call(notice)
+      expect(notice).to be_ignored
+    end
 
-  it "does not ignore notices from ignorable class with higher retry count" do
-    notice = build_notice(
-      'retry' => true,
-      'retry_count' => retry_attempts_before_airbrake + 1,
-      'class' => 'OneIgnorableClass'
-    )
-    filter.call(notice)
-    expect(build_notice).to_not be_ignored
+    it "does not ignore notices from ignorable class with higher retry count" do
+      notice = build_notice(
+        'retry' => true,
+        'retry_count' => retry_attempts_before_airbrake + 1,
+        'class' => 'OneIgnorableClass'
+      )
+      filter.call(notice)
+      expect(build_notice).to_not be_ignored
+    end
   end
 end

--- a/spec/unit/sidekiq/ignorable_classes_filter_spec.rb
+++ b/spec/unit/sidekiq/ignorable_classes_filter_spec.rb
@@ -34,12 +34,16 @@ RSpec.describe "airbrake/sidekiq/ignorable_class_filter" do
   end
 
   it "ignore notices from jobs that is an ignorable class" do
-    notice = build_notice('retry' => true, 'retry_count' => 0, 'class' => 'OneIgnorableClass')
+    notice = build_notice(
+      'retry' => true,
+      'retry_count' => 0,
+      'class' => 'OneIgnorableClass'
+    )
     filter.call(notice)
     expect(notice).to be_ignored
   end
 
-  it "does not ignore notices from jobs that is an ignorable class with higher retry count" do
+  it "does not ignore notices from ignorable class with higher retry count" do
     notice = build_notice(
       'retry' => true,
       'retry_count' => retry_attempts_before_airbrake + 1,

--- a/spec/unit/sidekiq/ignorable_classes_filter_spec.rb
+++ b/spec/unit/sidekiq/ignorable_classes_filter_spec.rb
@@ -5,9 +5,9 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
   require 'sidekiq/cli'
   require 'airbrake/sidekiq'
 
-  RSpec.describe "airbrake/sidekiq/ignorable_class_filter" do
+  RSpec.describe "airbrake/sidekiq/ignorable_error_class_filter" do
     subject(:filter) do
-      Airbrake::Sidekiq::IgnorableClassFilter.new(
+      Airbrake::Sidekiq::IgnorableErrorClassFilter.new(
         retry_attempts_before_airbrake: retry_attempts_before_airbrake,
         ignorable_classes: ignorable_classes
       )
@@ -15,7 +15,7 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
 
     let(:retry_attempts_before_airbrake) { 2 }
     let(:ignorable_classes) do
-      ["OneIgnorableClass"]
+      ["OneIgnorableErrorClass"]
     end
 
     def build_notice(job = nil)
@@ -38,7 +38,7 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
       notice = build_notice(
         'retry' => true,
         'retry_count' => 0,
-        'class' => 'OneIgnorableClass'
+        'error_class' => 'OneIgnorableErrorClass'
       )
       filter.call(notice)
       expect(notice).to be_ignored
@@ -48,7 +48,7 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
       notice = build_notice(
         'retry' => true,
         'retry_count' => retry_attempts_before_airbrake + 1,
-        'class' => 'OneIgnorableClass'
+        'error_class' => 'OneIgnorableErrorClass'
       )
       filter.call(notice)
       expect(build_notice).to_not be_ignored


### PR DESCRIPTION
We had a specific use case (which we hope is somewhat common) where we wanted to ignore sending airbrakes for certain jobs until it tries a certain number of time. 

This PR (sidekiq filter) allows you do exactly this.

Hope it is useful!