### PR TITLE
circleci: fix JRuby build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,9 +150,9 @@ jobs:
       - <<: *rails52
       - <<: *sinatra
       - <<: *rack
-  "jruby-9.1.16":
+  "jruby-9.2.0.0":
     docker:
-      - image: circleci/jruby:9.1.16.0
+      - image: circleci/jruby:9.2.0.0
     working_directory: ~/airbrake
     steps:
       - <<: *repo_restore_cache
@@ -190,6 +190,6 @@ workflows:
       - "ruby-2.5":
           requires:
             - lint
-      - "jruby-9.1.16":
+      - "jruby-9.2.0.0":
           requires:
             - lint


### PR DESCRIPTION
It looks like with the new JRuby release the old CircleCI image is not available
anymore.