### PR TITLE
Added capistrano option that loads rails env when running rake

### DIFF
--- a/lib/airbrake/capistrano/capistrano2.rb
+++ b/lib/airbrake/capistrano/capistrano2.rb
@@ -18,7 +18,7 @@ module Airbrake
                 RACK_ENV=#{fetch(:rack_env, nil)} \
                 RAILS_ENV=#{fetch(:rails_env, nil)} \
 
-                bundle exec rake #{fetch(:airbrake_load_environment, nil)} airbrake:deploy \
+                bundle exec rake airbrake:deploy \
                   USERNAME=#{Shellwords.shellescape(ENV['USER'] || ENV['USERNAME'])} \
                   ENVIRONMENT=#{fetch(:airbrake_env, fetch(:rails_env, 'production'))} \
                   REVISION=#{current_revision.strip} \

--- a/lib/airbrake/capistrano/capistrano2.rb
+++ b/lib/airbrake/capistrano/capistrano2.rb
@@ -18,7 +18,7 @@ module Airbrake
                 RACK_ENV=#{fetch(:rack_env, nil)} \
                 RAILS_ENV=#{fetch(:rails_env, nil)} \
 
-                bundle exec rake airbrake:deploy \
+                bundle exec rake #{fetch(:airbreak_load_environment, nil)} airbrake:deploy \
                   USERNAME=#{Shellwords.shellescape(ENV['USER'] || ENV['USERNAME'])} \
                   ENVIRONMENT=#{fetch(:airbrake_env, fetch(:rails_env, 'production'))} \
                   REVISION=#{current_revision.strip} \

--- a/lib/airbrake/capistrano/capistrano2.rb
+++ b/lib/airbrake/capistrano/capistrano2.rb
@@ -18,7 +18,7 @@ module Airbrake
                 RACK_ENV=#{fetch(:rack_env, nil)} \
                 RAILS_ENV=#{fetch(:rails_env, nil)} \
 
-                bundle exec rake #{fetch(:airbreak_load_environment, nil)} airbrake:deploy \
+                bundle exec rake #{fetch(:airbrake_load_environment, nil)} airbrake:deploy \
                   USERNAME=#{Shellwords.shellescape(ENV['USER'] || ENV['USERNAME'])} \
                   ENVIRONMENT=#{fetch(:airbrake_env, fetch(:rails_env, 'production'))} \
                   REVISION=#{current_revision.strip} \

--- a/lib/airbrake/capistrano/capistrano3.rb
+++ b/lib/airbrake/capistrano/capistrano3.rb
@@ -5,7 +5,7 @@ namespace :airbrake do
     on role do
       within release_path do
         with rails_env: fetch(:rails_env, fetch(:stage)) do
-          environment = fetch(:airbreak_load_environment) ? :environment : nil
+          environment = fetch(:airbrake_load_environment) ? :environment : nil
           command = <<-CMD
             airbrake:deploy USERNAME=#{Shellwords.shellescape(local_user)} \
                             ENVIRONMENT=#{fetch(:airbrake_env, fetch(:rails_env, fetch(:stage)))} \

--- a/lib/airbrake/capistrano/capistrano3.rb
+++ b/lib/airbrake/capistrano/capistrano3.rb
@@ -5,14 +5,16 @@ namespace :airbrake do
     on role do
       within release_path do
         with rails_env: fetch(:rails_env, fetch(:stage)) do
-          execute :bundle, :exec, :rake, <<-CMD
+          environment = fetch(:airbreak_load_environment) ? :environment : nil
+          command = <<-CMD
             airbrake:deploy USERNAME=#{Shellwords.shellescape(local_user)} \
                             ENVIRONMENT=#{fetch(:airbrake_env, fetch(:rails_env, fetch(:stage)))} \
                             REVISION=#{fetch(:current_revision)} \
                             REPOSITORY=#{fetch(:repo_url)} \
                             VERSION=#{fetch(:app_version)}
             CMD
-
+          commands = [:bundle, :exec, :rake, environment, command].compact
+          execute(*commands)
           info 'Notified Airbrake of the deploy'
         end
       end


### PR DESCRIPTION
## Problem 

Can't reference rails application classes from within the airbrake initialiser.

## Solution

Add `airbrake_load_environment` option that causes the `environment` option to be passed in when `rake` is run.