### PR TITLE
rails/active_job,rake: don't overwrite 'params'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Fixed overwriting `notice[:params]` in the Rake and ActiveJob integrations
+  ([#859](https://github.com/airbrake/airbrake/pull/859))
+
 ### [v7.3.4][v7.3.4] (June 14, 2018)
 
 * Fixed SystemStackError in the Sneakers integration

--- a/lib/airbrake/rails/active_job.rb
+++ b/lib/airbrake/rails/active_job.rb
@@ -16,7 +16,7 @@ module Airbrake
         Airbrake.notify(exception) do |notice|
           notice[:context][:component] = 'active_job'
           notice[:context][:action] = job.class.name
-          notice[:params] = job.serialize
+          notice[:params].merge!(job.serialize)
         end
 
         raise exception

--- a/lib/airbrake/rake.rb
+++ b/lib/airbrake/rake.rb
@@ -27,11 +27,11 @@ module Rake
       Airbrake.notify_sync(exception) do |notice|
         notice[:context][:component] = 'rake'
         notice[:context][:action] = name
-        notice[:params] = {
+        notice[:params].merge!(
           rake_task: task_info,
           execute_args: args,
           argv: ARGV.join(' ')
-        }
+        )
       end
     end
 


### PR DESCRIPTION
We shouldn't overwrite 'params' because it breaks filters, such as
`ContextFilter`, making `Airbrake.merge_context` unusable for these
integrations.