### PR TITLE
circleci: commit Dockerfile for Ruby 2.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
           command: bundle exec rubocop --parallel
   "ruby-2.0":
     docker:
-      - image: kyrylo/ruby-2.0.0p648
+      - image: kyrylo/ruby-2.0.0p648-airbrake
     working_directory: /home/circleci/airbrake
     steps:
       - <<: *repo_restore_cache

--- a/.circleci/ruby-2.0.0p648-airbrake/Dockerfile
+++ b/.circleci/ruby-2.0.0p648-airbrake/Dockerfile
@@ -1,0 +1,84 @@
+FROM alpine
+
+RUN mkdir -p /usr/local/etc \
+      && { \
+        echo 'install: --no-document'; \
+          echo 'update: --no-document'; \
+      } >> /usr/local/etc/gemrc
+
+ENV RUBY_MAJOR 2.0
+ENV RUBY_VERSION 2.0.0-p648
+ENV RUBYGEMS_VERSION 1.8.23.2
+ENV BUNDLER_VERSION 1.16.6
+
+RUN set -ex \
+    && apk add --no-cache --virtual .ruby-builddeps \
+      autoconf \
+      bison \
+      bzip2 \
+      bzip2-dev \
+      ca-certificates \
+      coreutils \
+      curl \
+      gcc \
+      gdbm-dev \
+      glib-dev \
+      libc-dev \
+      libffi-dev \
+      libxml2-dev \
+      libxslt-dev \
+      linux-headers \
+      make \
+      ncurses-dev \
+      openssl-dev \
+      procps \
+      readline-dev \
+      ruby \
+      yaml-dev \
+      zlib-dev \
+    && curl -fSL -o ruby.tar.gz "http://cache.ruby-lang.org/pub/ruby/$RUBY_MAJOR/ruby-$RUBY_VERSION.tar.gz" \
+    && mkdir -p /usr/src \
+    && tar -xzf ruby.tar.gz -C /usr/src \
+    && rm ruby.tar.gz \
+    && cd /usr/src/ruby-$RUBY_VERSION \
+    && { echo '#define ENABLE_PATH_CHECK 0'; echo; cat file.c; } > file.c.new && mv file.c.new file.c \
+    && { echo '#include <asm/ioctl.h>'; echo; cat io.c; } > io.c.new && mv io.c.new io.c \
+    && autoconf \
+    && ac_cv_func_isnan=yes ac_cv_func_isinf=yes ./configure --disable-install-doc \
+    && make \
+    && make install \
+    && runDeps="$( \
+      scanelf --needed --nobanner --recursive /usr/local \
+      | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+      | sort -u \
+      | xargs -r apk info --installed \
+      | sort -u \
+      )" \
+    && apk add --virtual .ruby-rundeps $runDeps \
+      bzip2 \
+      ca-certificates \
+      curl \
+      libffi-dev \
+      openssl-dev \
+      yaml-dev \
+      procps \
+      zlib-dev \
+    && apk del .ruby-builddeps \
+    && gem update --system $RUBYGEMS_VERSION \
+    && rm -r /usr/src/ruby-$RUBY_VERSION
+
+RUN apk add --update --no-cache git nano build-base libxml2-dev libxslt-dev \
+  sqlite-dev tzdata && \
+  rm -rf /var/cache/apk/*
+
+RUN gem update --system
+
+RUN gem install bundler --version "$BUNDLER_VERSION" --force
+
+RUN bundle config build.nokogiri --use-system-libraries
+
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" BUNDLE_BIN="$GEM_HOME/bin" BUNDLE_SILENCE_ROOT_WARNING=1 BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" && chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+CMD [ "irb" ]


### PR DESCRIPTION
CircleCI doesn't host Ruby 2.0 anymore but we still support it. We've been
hosting the custom image for several months but DockerHub doesn't display the
Dockerfile used. I am committing it here so it's not lost.