### PR TITLE
rack/middleware(rails): support route status codes with exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Fixed route reporting for routes that raise
+  errors([#876](https://github.com/airbrake/airbrake/pull/876))
+
 ### [v8.0.0.rc.6][v8.0.0.rc.6] (November 12, 2018)
 
 * Updated Request API to support latest changes in Airbrake Ruby

--- a/lib/airbrake/rack/middleware.rb
+++ b/lib/airbrake/rack/middleware.rb
@@ -109,7 +109,7 @@ module Airbrake
             @notifier.notify_request(
               method: payload[:method],
               route: route,
-              status_code: payload[:status],
+              status_code: find_status_code(payload),
               start_time: event.time,
               end_time: Time.new
             )
@@ -138,6 +138,19 @@ module Airbrake
           routes.push(*engine.routes.routes.routes)
         end
         routes
+      end
+
+      def find_status_code(payload)
+        return payload[:status] if payload[:status]
+
+        if payload[:exception]
+          status = ActionDispatch::ExceptionWrapper.status_code_for_exception(
+            payload[:exception].first
+          )
+          return status
+        end
+
+        0
       end
     end
   end

--- a/spec/integration/rails/rails_spec.rb
+++ b/spec/integration/rails/rails_spec.rb
@@ -301,7 +301,9 @@ RSpec.describe "Rails integration specs" do
 
       wait_for_a_request_with_body(/"errors"/)
 
-      body = %r|{"routes":\[{"method":"GET","route":"\/crash\(\.:format\)"|
+      body = %r|
+        {"routes":\[{"method":"GET","route":"\/crash\(\.:format\)","status_code":500
+      |x
       wait_for(a_request(:put, routes_endpoint).with(body: body)).
         to have_been_made.once
     end


### PR DESCRIPTION
There was a bug where status code is reported as 0 for routes that raise
exceptions. Typically, the expected code should be 500. This is because the
Rails hook needs extra handling in this case. The approach is taken from

https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/log_subscriber.rb