### PR TITLE
rack/middleware: default to 500 instead of 0 if code can't be found

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,3 +73,6 @@ Naming/UncommunicativeMethodParamName:
 Style/SymbolArray:
   Exclude:
     - gemfiles/*.gemfile
+
+Style/NumericPredicate:
+  Enabled: false

--- a/lib/airbrake/rack/middleware.rb
+++ b/lib/airbrake/rack/middleware.rb
@@ -147,6 +147,8 @@ module Airbrake
           status = ActionDispatch::ExceptionWrapper.status_code_for_exception(
             payload[:exception].first
           )
+          status = 500 if status == 0
+
           return status
         end
 

--- a/spec/integration/rails/rails_spec.rb
+++ b/spec/integration/rails/rails_spec.rb
@@ -311,5 +311,22 @@ RSpec.describe "Rails integration specs" do
       wait_for(a_request(:put, routes_endpoint).with(body: body)).
         to have_been_made.once
     end
+
+    it "defaults to 500 when status code for exception returns 0" do
+      expect(Airbrake[:default]).to receive(:notify_request).and_call_original
+      allow(ActionDispatch::ExceptionWrapper).
+        to receive(:status_code_for_exception).and_return(0)
+
+      head '/crash'
+      sleep 2
+
+      wait_for_a_request_with_body(/"errors"/)
+
+      body = %r|
+        {"routes":\[{"method":"HEAD","route":"\/crash\(\.:format\)","status_code":500
+      |x
+      wait_for(a_request(:put, routes_endpoint).with(body: body)).
+        to have_been_made.once
+    end
   end
 end


### PR DESCRIPTION
When `ActionDispatch::ExceptionWrapper` fails to return a code for an exception,
then it returns 0. This confuses our backend, so we should convert that into 500
as the most reasonable default value.