### PR TITLE
Update initializer erb to conform to rubocop style guide

### DIFF
--- a/lib/generators/airbrake_initializer.rb.erb
+++ b/lib/generators/airbrake_initializer.rb.erb
@@ -47,7 +47,7 @@ Airbrake.configure do |c|
   # unwanted environments such as :test.
   # NOTE: This option *does not* work if you don't set the 'environment' option.
   # https://github.com/airbrake/airbrake-ruby#ignore_environments
-  c.ignore_environments = %w(test)
+  c.ignore_environments = %w[test]
 
   # A list of parameters that should be filtered out of what is sent to
   # Airbrake. By default, all "password" attributes will have their contents


### PR DESCRIPTION
per https://github.com/rubocop-hq/ruby-style-guide#percent-literal-braces, `%w` arrays should be delimited by `[]` instead of `()`