### PR TITLE
gemspec: depend on airbrake-ruby `~> 3.0`

### DIFF
--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -31,7 +31,7 @@ DESC
 
   s.required_ruby_version = '>= 2.1'
 
-  s.add_dependency 'airbrake-ruby', '>= 3.0.0.rc.9'
+  s.add_dependency 'airbrake-ruby', '~> 3.0'
 
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rspec-wait', '~> 0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ Airbrake.configure do |c|
   c.logger = Logger.new('/dev/null')
   c.app_version = '1.2.3'
   c.workers = 5
+  c.route_stats = true
   c.route_stats_flush_period = 1
 end
 


### PR DESCRIPTION
This is when it gets real.