### PR TITLE
rack/middleware: move user extraction logic to its own filter

### DIFF
--- a/lib/airbrake/rack.rb
+++ b/lib/airbrake/rack.rb
@@ -1,4 +1,5 @@
 require 'airbrake/rack/user'
+require 'airbrake/rack/user_filter'
 require 'airbrake/rack/context_filter'
 require 'airbrake/rack/session_filter'
 require 'airbrake/rack/http_params_filter'

--- a/lib/airbrake/rack/context_filter.rb
+++ b/lib/airbrake/rack/context_filter.rb
@@ -35,13 +35,10 @@ module Airbrake
         add_framework_version(context)
 
         controller = request.env['action_controller.instance']
-        if controller
-          context[:component] = controller.controller_name
-          context[:action] = controller.action_name
-        end
+        return unless controller
 
-        user = Airbrake::Rack::User.extract(request.env)
-        notice[:context].merge!(user.as_json) if user
+        context[:component] = controller.controller_name
+        context[:action] = controller.action_name
       end
 
       private

--- a/lib/airbrake/rack/middleware.rb
+++ b/lib/airbrake/rack/middleware.rb
@@ -13,6 +13,7 @@ module Airbrake
       #   information and append it to notices
       RACK_FILTERS = [
         Airbrake::Rack::ContextFilter,
+        Airbrake::Rack::UserFilter,
         Airbrake::Rack::SessionFilter,
         Airbrake::Rack::HttpParamsFilter,
         Airbrake::Rack::HttpHeadersFilter,

--- a/lib/airbrake/rack/user_filter.rb
+++ b/lib/airbrake/rack/user_filter.rb
@@ -1,0 +1,23 @@
+module Airbrake
+  module Rack
+    # Adds current user information
+    #
+    # @since v8.0.x
+    class UserFilter
+      # @return [Integer]
+      attr_reader :weight
+
+      def initialize
+        @weight = 99
+      end
+
+      # @see Airbrake::FilterChain#refine
+      def call(notice)
+        return unless (request = notice.stash[:rack_request])
+
+        user = Airbrake::Rack::User.extract(request.env)
+        notice[:context].merge!(user.as_json) if user
+      end
+    end
+  end
+end

--- a/spec/unit/rack/context_filter_spec.rb
+++ b/spec/unit/rack/context_filter_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe Airbrake::Rack::ContextFilter do
     Rack::MockRequest.env_for(url, opts)
   end
 
-  subject { described_class.new }
-
   let(:notice) do
     Airbrake.build_notice('oops').tap do |notice|
       notice.stash[:rack_request] = Rack::Request.new(env_for(uri, opts))

--- a/spec/unit/rack/http_headers_filter_spec.rb
+++ b/spec/unit/rack/http_headers_filter_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe Airbrake::Rack::HttpHeadersFilter do
     Rack::MockRequest.env_for(url, opts)
   end
 
-  subject { described_class.new }
-
   let(:notice) do
     Airbrake.build_notice('oops').tap do |notice|
       notice.stash[:rack_request] = Rack::Request.new(env_for(uri, opts))

--- a/spec/unit/rack/http_params_filter_spec.rb
+++ b/spec/unit/rack/http_params_filter_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe Airbrake::Rack::HttpParamsFilter do
     Rack::MockRequest.env_for(url, opts)
   end
 
-  subject { described_class.new }
-
   let(:notice) do
     Airbrake.build_notice('oops').tap do |notice|
       notice.stash[:rack_request] = Rack::Request.new(env_for(uri, opts))

--- a/spec/unit/rack/request_body_filter_spec.rb
+++ b/spec/unit/rack/request_body_filter_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe Airbrake::Rack::RequestBodyFilter do
     Rack::MockRequest.env_for(url, opts)
   end
 
-  subject { described_class.new }
-
   let(:notice) do
     Airbrake.build_notice('oops').tap do |notice|
       notice.stash[:rack_request] = Rack::Request.new(env_for(uri, opts))

--- a/spec/unit/rack/session_filter_spec.rb
+++ b/spec/unit/rack/session_filter_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe Airbrake::Rack::SessionFilter do
     Rack::MockRequest.env_for(url, opts)
   end
 
-  subject { described_class.new }
-
   let(:notice) do
     Airbrake.build_notice('oops').tap do |notice|
       notice.stash[:rack_request] = Rack::Request.new(env_for(uri, opts))

--- a/spec/unit/rack/user_filter_spec.rb
+++ b/spec/unit/rack/user_filter_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe Airbrake::Rack::UserFilter do
+  def env_for(url, opts = {})
+    Rack::MockRequest.env_for(url, opts)
+  end
+
+  subject { described_class.new }
+  let(:uri) { '/' }
+  let(:opts) { {} }
+
+  let(:notice) do
+    Airbrake.build_notice('oops').tap do |notice|
+      notice.stash[:rack_request] = Rack::Request.new(env_for(uri, opts))
+    end
+  end
+
+  let(:user_payload) { { username: 'bingo' } }
+  let(:user) { Airbrake::Rack::User.new(double(user_payload)) }
+
+  it "delegates extraction of the current user information" do
+    expect(Airbrake::Rack::User).to receive(:extract).and_return(user)
+    subject.call(notice)
+    expect(notice[:context][:user]).to eq(user_payload)
+  end
+
+  context "when no current user is found" do
+    let(:user) { Airbrake::Rack::User.new(double) }
+
+    it "does not include the user key in the payload" do
+      expect(Airbrake::Rack::User).to receive(:extract).and_return(user)
+      subject.call(notice)
+      expect(notice[:context].keys).not_to include(:user)
+    end
+  end
+end

--- a/spec/unit/rack/user_filter_spec.rb
+++ b/spec/unit/rack/user_filter_spec.rb
@@ -5,13 +5,9 @@ RSpec.describe Airbrake::Rack::UserFilter do
     Rack::MockRequest.env_for(url, opts)
   end
 
-  subject { described_class.new }
-  let(:uri) { '/' }
-  let(:opts) { {} }
-
   let(:notice) do
     Airbrake.build_notice('oops').tap do |notice|
-      notice.stash[:rack_request] = Rack::Request.new(env_for(uri, opts))
+      notice.stash[:rack_request] = Rack::Request.new(env_for('/', {}))
     end
   end
 


### PR DESCRIPTION
In order to give more control over how to find the current user and what
information to include in the payload, allow defining a class for the
rack middleware to use when extracting the current user payload from
the rack request.