### PR TITLE
rack/middleware: don't install ActiveRecord hooks when it's absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Changelog
 
 ### master
 
+* Fixed `uninitialized constant Airbrake::Rack::Middleware::ActiveRecord` for
+  apps that don't use ActiveRecord
+  ([#899](https://github.com/airbrake/airbrake/pull/899))
+
 ### [v8.1.0][v8.1.0] (February 12, 2019)
 
 * Fixed warning coming from our middleware when using with Rails 6


### PR DESCRIPTION
Fixes https://github.com/airbrake/airbrake/pull/892#issuecomment-463267205.

Rails ships with the `-O` switch, which disables ActiveRecord. We hook into
ActiveRecord when Rails is present, so it causes breakage for such apps.

Now we are smarter and don't add any SQL hooks when ActiveRecord is not present.