### PR TITLE
rack/middleware: fix performance stat sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Fixed performance stats not being sent
+  ([#901](https://github.com/airbrake/airbrake/pull/901))
+
 ### [v8.1.1][v8.1.1] (February 14, 2019)
 
 * Fixed `uninitialized constant Airbrake::Rack::Middleware::ActiveRecord` for

--- a/lib/airbrake/rails/action_controller_route_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_route_subscriber.rb
@@ -5,7 +5,8 @@ module Airbrake
     #
     # @since v8.0.0
     class ActionControllerRouteSubscriber
-      def initialize
+      def initialize(routes)
+        @routes = routes
         @all_routes = nil
       end
 
@@ -17,8 +18,7 @@ module Airbrake
         event = ActiveSupport::Notifications::Event.new(*args)
         payload = event.payload
 
-        Thread.current[:airbrake_rails_route] = find_route(payload[:params])
-        Thread.current[:airbrake_rails_method] = payload[:method]
+        @routes[find_route(payload[:params])] = payload[:method]
       end
 
       private

--- a/lib/airbrake/rails/active_record_subscriber.rb
+++ b/lib/airbrake/rails/active_record_subscriber.rb
@@ -4,21 +4,24 @@ module Airbrake
     #
     # @since v8.1.0
     class ActiveRecordSubscriber
-      def initialize(notifier)
+      def initialize(notifier, routes)
         @notifier = notifier
+        @routes = routes
       end
 
       def call(*args)
         event = ActiveSupport::Notifications::Event.new(*args)
-        @notifier.notify(
-          Airbrake::Query.new(
-            route: Thread.current[:airbrake_rails_route],
-            method: Thread.current[:airbrake_rails_method],
-            query: event.payload[:sql],
-            start_time: event.time,
-            end_time: event.end
+        @routes.each do |route, method|
+          @notifier.notify(
+            Airbrake::Query.new(
+              route: route,
+              method: method,
+              query: event.payload[:sql],
+              start_time: event.time,
+              end_time: event.end
+            )
           )
-        )
+        end
       end
     end
   end


### PR DESCRIPTION
Using thread locals was not a reliable approach. While local testing was showing
that subscribers share information, in production it didn't really work. It
could be the order of subscribers, or something else (hard to tell).

This change removes the need for thread locals and uses a shared object.