### PR TITLE
logger: respect level of the logger that we wrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Fixed Logger integration not respecting level of the logger that is being
+  wrapped ([#903](https://github.com/airbrake/airbrake/pull/903))
+
 ### [v8.1.2][v8.1.2] (February 14, 2019)
 
 * Fixed performance stats not being sent

--- a/lib/airbrake/logger.rb
+++ b/lib/airbrake/logger.rb
@@ -24,7 +24,7 @@ module Airbrake
     def initialize(logger)
       __setobj__(logger)
       @airbrake_notifier = Airbrake[:default]
-      @airbrake_level = Logger::WARN
+      self.level = logger.level
     end
 
     # @see Logger#warn
@@ -48,6 +48,12 @@ module Airbrake
     # @see Logger#unknown
     def unknown(progname = nil, &block)
       notify_airbrake(Logger::UNKNOWN, progname)
+      super
+    end
+
+    # @see Logger#level=
+    def level=(value)
+      self.airbrake_level = value < Logger::WARN ? Logger::WARN : value
       super
     end
 

--- a/spec/unit/logger_spec.rb
+++ b/spec/unit/logger_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Airbrake::AirbrakeLogger do
   let(:endpoint) { "https://api.airbrake.io/api/v3/projects/#{project_id}/notices" }
 
   let(:airbrake) do
-    Airbrake::Notifier.new(project_id: project_id, project_key: project_key)
+    Airbrake::NoticeNotifier.new(
+      Airbrake::Config.new(project_id: project_id, project_key: project_key)
+    )
   end
 
   let(:logger) { Logger.new('/dev/null') }
@@ -23,7 +25,7 @@ RSpec.describe Airbrake::AirbrakeLogger do
 
   describe "#airbrake_notifier" do
     it "has the default notifier installed by default" do
-      expect(subject.airbrake_notifier).to be_an(Airbrake::Notifier)
+      expect(subject.airbrake_notifier).to be_an(Airbrake::NoticeNotifier)
     end
 
     it "installs Airbrake notifier" do
@@ -113,6 +115,23 @@ RSpec.describe Airbrake::AirbrakeLogger do
           subject.airbrake_level = Logger::DEBUG
         end.to raise_error(/severity level \d is not allowed/)
       end
+    end
+  end
+
+  describe "#level=" do
+    it "sets logger level" do
+      subject.level = Logger::FATAL
+      expect(subject.level).to eq(Logger::FATAL)
+    end
+
+    it "sets airbrake level" do
+      subject.level = Logger::FATAL
+      expect(subject.airbrake_level).to eq(Logger::FATAL)
+    end
+
+    it "normalizes airbrake logger level when provided level is below WARN" do
+      subject.level = Logger::DEBUG
+      expect(subject.airbrake_level).to eq(Logger::WARN)
     end
   end
 end


### PR DESCRIPTION
There was a bug where provided logger has severity ERROR but `airbrake_level`
would still be WARN (because it was hardcoded). Because of this WARN messages
would be sent to Airbrake, even though nothing would be logged.

Additionally, if you change level of the wrapped logger, airbrake_level would
get out of sync.