### PR TITLE
Cleanup Rack & Rails integrations from notifier leftovers

### DIFF
--- a/lib/airbrake/rails/action_controller_notify_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_notify_subscriber.rb
@@ -5,10 +5,6 @@ module Airbrake
     #
     # @since v8.0.0
     class ActionControllerNotifySubscriber
-      def initialize(notifier)
-        @notifier = notifier
-      end
-
       def call(*args)
         routes = Airbrake::Rack::RequestStore[:routes]
         return if !routes || routes.none?
@@ -17,7 +13,7 @@ module Airbrake
         payload = event.payload
 
         routes.each do |route, method|
-          @notifier.notify_request(
+          Airbrake.notify_request(
             method: method,
             route: route,
             status_code: find_status_code(payload),

--- a/lib/airbrake/rails/active_record_subscriber.rb
+++ b/lib/airbrake/rails/active_record_subscriber.rb
@@ -4,17 +4,13 @@ module Airbrake
     #
     # @since v8.1.0
     class ActiveRecordSubscriber
-      def initialize(notifier)
-        @notifier = notifier
-      end
-
       def call(*args)
         routes = Airbrake::Rack::RequestStore[:routes]
         return if !routes || routes.none?
 
         event = ActiveSupport::Notifications::Event.new(*args)
         routes.each do |route, method|
-          @notifier.notify_query(
+          Airbrake.notify_query(
             route: route,
             method: method,
             query: event.payload[:sql],

--- a/spec/unit/rack/middleware_spec.rb
+++ b/spec/unit/rack/middleware_spec.rb
@@ -18,14 +18,6 @@ RSpec.describe Airbrake::Rack::Middleware do
     stub_request(:post, endpoint).to_return(status: 201, body: '{}')
   end
 
-  describe "#new" do
-    it "doesn't add filters if no notifiers are configured" do
-      expect do
-        expect(described_class.new(faulty_app, :unknown_notifier))
-      end.not_to raise_error
-    end
-  end
-
   describe "#call" do
     context "when app raises an exception" do
       it "rescues the exception, notifies Airbrake & re-raises it" do


### PR DESCRIPTION
The old system serves no purpose since `Airbrake` is a global wrapper used in
every integration.