### PR TITLE
rack/middleware: factor out hook installation code outside class

### DIFF
--- a/lib/airbrake/rack/context_filter.rb
+++ b/lib/airbrake/rack/context_filter.rb
@@ -8,17 +8,6 @@ module Airbrake
       attr_reader :weight
 
       def initialize
-        @framework_version =
-          if defined?(::Rails) && ::Rails.respond_to?(:version)
-            { 'rails' => ::Rails.version }
-          elsif defined?(::Sinatra)
-            { 'sinatra' => Sinatra::VERSION }
-          else
-            {
-              'rack_version' => ::Rack.version,
-              'rack_release' => ::Rack.release
-            }
-          end
         @weight = 99
       end
 
@@ -45,10 +34,24 @@ module Airbrake
 
       def add_framework_version(context)
         if context.key?(:versions)
-          context[:versions].merge!(@framework_version)
+          context[:versions].merge!(framework_version)
         else
-          context[:versions] = @framework_version
+          context[:versions] = framework_version
         end
+      end
+
+      def framework_version
+        @framework_version ||=
+          if defined?(::Rails) && ::Rails.respond_to?(:version)
+            { 'rails' => ::Rails.version }
+          elsif defined?(::Sinatra)
+            { 'sinatra' => Sinatra::VERSION }
+          else
+            {
+              'rack_version' => ::Rack.version,
+              'rack_release' => ::Rack.release
+            }
+          end
       end
     end
   end

--- a/lib/airbrake/rails.rb
+++ b/lib/airbrake/rails.rb
@@ -52,6 +52,11 @@ module Airbrake
           # interesting request data. Appends that information to notices.
           require 'airbrake/rails/action_controller'
           include Airbrake::Rails::ActionController
+
+          # Cache route information for the duration of the request.
+          require 'airbrake/rails/action_controller_route_subscriber'
+          # Send route stats.
+          require 'airbrake/rails/action_controller_notify_subscriber'
         end
       end
 
@@ -61,6 +66,9 @@ module Airbrake
           # Applicable only to the versions of Rails lower than 4.2.
           require 'airbrake/rails/active_record'
           include Airbrake::Rails::ActiveRecord
+
+          # Send SQL queries.
+          require 'airbrake/rails/active_record_subscriber'
         end
       end
 

--- a/lib/airbrake/rails/action_controller_notify_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_notify_subscriber.rb
@@ -42,3 +42,8 @@ module Airbrake
     end
   end
 end
+
+ActiveSupport::Notifications.subscribe(
+  'process_action.action_controller',
+  Airbrake::Rails::ActionControllerNotifySubscriber.new
+)

--- a/lib/airbrake/rails/action_controller_route_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_route_subscriber.rb
@@ -46,3 +46,8 @@ module Airbrake
     end
   end
 end
+
+ActiveSupport::Notifications.subscribe(
+  'start_processing.action_controller',
+  Airbrake::Rails::ActionControllerRouteSubscriber.new
+)

--- a/lib/airbrake/rails/active_record_subscriber.rb
+++ b/lib/airbrake/rails/active_record_subscriber.rb
@@ -36,3 +36,13 @@ module Airbrake
     end
   end
 end
+
+Airbrake.add_performance_filter(
+  Airbrake::Filters::SqlFilter.new(
+    ActiveRecord::Base.connection_config[:adapter]
+  )
+)
+
+ActiveSupport::Notifications.subscribe(
+  'sql.active_record', Airbrake::Rails::ActiveRecordSubscriber.new
+)


### PR DESCRIPTION
It was necessary to keep the hooks inside the middleware to support multiple
notifiers. Since we don't support this feautre anymore, we are feeling more
relaxed and can simplify the middleware. It was a horrible hack anyway, since we
had to have guards in `#initialize` and I'm glad it's going away.

`require` guarantees that we load the file only once, so it's safe to add
filters in the top level. We require these files from the railtie, and it also
inadvertently fixes #909 (NameError: uninitialized constant Airbrake::Rails).