### PR TITLE
gemspec: bump airbrake-ruby to `~> 4.1.0`

### DIFF
--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -31,7 +31,7 @@ DESC
 
   s.required_ruby_version = '>= 2.1'
 
-  s.add_dependency 'airbrake-ruby', '~> 4.0'
+  s.add_dependency 'airbrake-ruby', '~> 4.1'
 
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rspec-wait', '~> 0'


### PR DESCRIPTION
While upgrading, I noticed some tests are failing. Not sure why, so I decided to give them another though. Using mocks seemed to be a brilliant idea:

* these tests are faster by order of magnitude
* we no longer pry into low-level details such as HTTP calls. This layer is
  tested in airbrake-ruby