### PR TITLE
rails/active_record_subscriber: handle `nil` frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Fix `NoMethodError` in `ActiveRecordSubscriber` when a caller of SQL query
+  cannot be defined ([#920](https://github.com/airbrake/airbrake/pull/920))
+
 ### [v8.2.0][v8.2.0] (March 4, 2019)
 
 * Started depending on airbrake-ruby

--- a/lib/airbrake/rails/active_record_subscriber.rb
+++ b/lib/airbrake/rails/active_record_subscriber.rb
@@ -31,7 +31,7 @@ module Airbrake
         exception = StandardError.new.tap do |ex|
           ex.set_backtrace(::Rails.backtrace_cleaner.clean(Kernel.caller).first(1))
         end
-        Airbrake::Backtrace.parse(exception).first
+        Airbrake::Backtrace.parse(exception).first || {}
       end
     end
   end

--- a/spec/integration/rails/rails_spec.rb
+++ b/spec/integration/rails/rails_spec.rb
@@ -271,5 +271,23 @@ RSpec.describe "Rails integration specs" do
 
       get '/crash'
     end
+
+    context "when caller location cannot be found for a query" do
+      before { allow(Kernel).to receive(:caller).and_return([]) }
+
+      it "sends query to Airbrake without caller location" do
+        expect(Airbrake).to receive(:notify_query).with(
+          hash_including(
+            route: '/crash(.:format)',
+            method: 'GET',
+            func: nil,
+            file: nil,
+            line: nil
+          )
+        ).at_least(:once)
+
+        get '/crash'
+      end
+    end
   end
 end


### PR DESCRIPTION
If for whatever reason `caller` doesn't return anything, we shouldn't crash.