### PR TITLE
Reintroduce ActiveRecord guard clause

### DIFF
--- a/lib/airbrake/rails.rb
+++ b/lib/airbrake/rails.rb
@@ -7,7 +7,7 @@ module Airbrake
       initializer('airbrake.middleware') do |app|
         require 'airbrake/rails/action_controller_route_subscriber'
         require 'airbrake/rails/action_controller_notify_subscriber'
-        require 'airbrake/rails/active_record_subscriber'
+        require 'airbrake/rails/active_record_subscriber' if defined?(ActiveRecord)
 
         # Since Rails 3.2 the ActionDispatch::DebugExceptions middleware is
         # responsible for logging exceptions and showing a debugging page in


### PR DESCRIPTION
If ActiveRecord has not been defined, loading ActiveRecordSubscriber will fail because of its call to ActiveRecord::Base.

Chose to add the guard clause to [lib/airbrake/rails.rb](https://github.com/airbrake/airbrake/blob/b21502812f7da58a8a3c508108c6a574cf1659f0/lib/airbrake/rails.rb) instead of to [airbrake/rails/active_record_subscriber](https://github.com/airbrake/airbrake/blob/b21502812f7da58a8a3c508108c6a574cf1659f0/lib/airbrake/rails/active_record_subscriber.rb), since that class name implies ActiveRecord is already available.

You can see a guard clause [used to exist](https://github.com/airbrake/airbrake/commit/4e5628f680aede2aeca5e422ccf54fca38fde8d8#diff-e09b896e9abbe09861d7846819a7bd56L32), but the code it referenced was removed and added into `Airbrake::Rails::ActiveRecordSubscriber` where it will break [on this line](https://github.com/airbrake/airbrake/blob/b21502812f7da58a8a3c508108c6a574cf1659f0/lib/airbrake/rails/active_record_subscriber.rb#L42) whenever that file tries to be loaded and ActiveRecord does not exist. 