### PR TITLE
Add ActionControllerPerformanceBreakdownSubscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Airbrake Changelog
 * Added `ActionCable` integration
   ([#926](https://github.com/airbrake/airbrake/pull/920),
   [#896](https://github.com/airbrake/airbrake/pull/896))
+* Added `ActionControllerPerformanceBreakdownSubscriber`
+  ([#929](https://github.com/airbrake/airbrake/pull/929))
 
 ### [v8.2.1][v8.2.1] (March 4, 2019)
 

--- a/lib/airbrake/rails.rb
+++ b/lib/airbrake/rails.rb
@@ -7,6 +7,8 @@ module Airbrake
       initializer('airbrake.middleware') do |app|
         require 'airbrake/rails/action_controller_route_subscriber'
         require 'airbrake/rails/action_controller_notify_subscriber'
+        require 'airbrake/rails/action_controller_performance_breakdown_subscriber'
+
         require 'airbrake/rails/active_record_subscriber' if defined?(ActiveRecord)
 
         # Since Rails 3.2 the ActionDispatch::DebugExceptions middleware is

--- a/lib/airbrake/rails/action_controller_performance_breakdown_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_performance_breakdown_subscriber.rb
@@ -1,0 +1,32 @@
+module Airbrake
+  module Rails
+    # @since v8.3.0
+    class ActionControllerPerformanceBreakdownSubscriber
+      def call(*args)
+        routes = Airbrake::Rack::RequestStore[:routes]
+        return if !routes || routes.none?
+
+        event = ActiveSupport::Notifications::Event.new(*args)
+        payload = event.payload
+
+        routes.each do |route, method|
+          Airbrake.notify_performance_breakdown(
+            method: method,
+            route: route,
+            response_type: payload[:format],
+            groups: {
+              db: payload[:db_runtime],
+              view: payload[:view_runtime]
+            },
+            start_time: event.time
+          )
+        end
+      end
+    end
+  end
+end
+
+ActiveSupport::Notifications.subscribe(
+  'process_action.action_controller',
+  Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber.new
+)

--- a/spec/integration/rails/rails_spec.rb
+++ b/spec/integration/rails/rails_spec.rb
@@ -289,4 +289,24 @@ RSpec.describe "Rails integration specs" do
       end
     end
   end
+
+  describe "performance breakdown hook" do
+    before { allow(Airbrake).to receive(:notify).and_return(nil) }
+
+    it "sends performance breakdown info to Airbrake" do
+      expect(Airbrake).to receive(:notify_performance_breakdown).with(
+        hash_including(
+          route: '/crash(.:format)',
+          method: 'GET',
+          response_type: :html,
+          groups: {
+            db: anything,
+            view: anything
+          }
+        )
+      ).at_least(:once)
+
+      get '/crash'
+    end
+  end
 end


### PR DESCRIPTION
This subscriber sends performance breakdown information to Airbrake. It sends
database and view performance info.