### PR TITLE
rails/breakdown_subscriber: pass 0 instead of nil for db/view values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,14 @@ Airbrake Changelog
 
 ### master
 
+* Fixes `TypeError` in the `ActionControllerPerformanceBreakdownSubscriber` when
+  it tries to pass `nil` as a `db` or `view` value
+  ([#932](https://github.com/airbrake/airbrake/pull/932)
+
 ### [v8.3.0][v8.3.0] (March 11, 2019)
 
 * Added `ActionCable` integration
-  ([#926](https://github.com/airbrake/airbrake/pull/920),
+  ([#926](https://github.com/airbrake/airbrake/pull/926),
   [#896](https://github.com/airbrake/airbrake/pull/896))
 * Added `ActionControllerPerformanceBreakdownSubscriber`
   ([#929](https://github.com/airbrake/airbrake/pull/929))

--- a/lib/airbrake/rails.rb
+++ b/lib/airbrake/rails.rb
@@ -9,6 +9,11 @@ module Airbrake
         require 'airbrake/rails/action_controller_notify_subscriber'
         require 'airbrake/rails/action_controller_performance_breakdown_subscriber'
 
+        ActiveSupport::Notifications.subscribe(
+          'process_action.action_controller',
+          Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber.new
+        )
+
         require 'airbrake/rails/active_record_subscriber' if defined?(ActiveRecord)
 
         # Since Rails 3.2 the ActionDispatch::DebugExceptions middleware is

--- a/lib/airbrake/rails/action_controller_performance_breakdown_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_performance_breakdown_subscriber.rb
@@ -15,8 +15,8 @@ module Airbrake
             route: route,
             response_type: payload[:format],
             groups: {
-              db: payload[:db_runtime],
-              view: payload[:view_runtime]
+              db: payload[:db_runtime].to_i,
+              view: payload[:view_runtime].to_i
             },
             start_time: event.time
           )
@@ -25,8 +25,3 @@ module Airbrake
     end
   end
 end
-
-ActiveSupport::Notifications.subscribe(
-  'process_action.action_controller',
-  Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber.new
-)

--- a/spec/unit/rails/action_controller_performance_breakdown_subscriber_spec.rb
+++ b/spec/unit/rails/action_controller_performance_breakdown_subscriber_spec.rb
@@ -1,0 +1,87 @@
+require 'airbrake/rails/action_controller_performance_breakdown_subscriber'
+
+RSpec.describe Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber do
+  after { Airbrake::Rack::RequestStore[:routes] = nil }
+
+  context "when routes are not set in the request store" do
+    before { Airbrake::Rack::RequestStore[:routes] = nil }
+
+    it "doesn't send performance breakdown info" do
+      expect(Airbrake).not_to receive(:notify_performance_breakdown)
+      subject.call([])
+    end
+  end
+
+  context "when there are no routes in the request store" do
+    before { Airbrake::Rack::RequestStore[:routes] = [] }
+
+    it "doesn't send performance breakdown info" do
+      expect(Airbrake).not_to receive(:notify_performance_breakdown)
+      subject.call([])
+    end
+  end
+
+  context "when there's a route in the request store" do
+    let(:event) do
+      OpenStruct.new(
+        payload: {
+          format: :html,
+          view_runtime: 1.0,
+          db_runtime: 1.0
+        }
+      )
+    end
+
+    before do
+      Airbrake::Rack::RequestStore[:routes] = [['/test-route', 'GET']]
+
+      event_dbl = double
+      expect(event_dbl).to receive(:new).and_return(event)
+      stub_const('ActiveSupport::Notifications::Event', event_dbl)
+    end
+
+    it "sends performance info to Airbrake" do
+      expect(Airbrake).to receive(:notify_performance_breakdown).with(
+        hash_including(
+          route: '/test-route',
+          method: 'GET',
+          response_type: :html,
+          groups: { db: 1.0, view: 1.0 }
+        )
+      )
+      subject.call([])
+    end
+
+    context "and when view_runtime is nil" do
+      before { event.payload[:view_runtime] = nil }
+
+      it "sets the view group runtime to 0" do
+        expect(Airbrake).to receive(:notify_performance_breakdown).with(
+          hash_including(
+            route: '/test-route',
+            method: 'GET',
+            response_type: :html,
+            groups: { db: 1.0, view: 0 }
+          )
+        )
+        subject.call([])
+      end
+    end
+
+    context "and when db_runtime is nil" do
+      before { event.payload[:db_runtime] = nil }
+
+      it "sets the view group runtime to 0" do
+        expect(Airbrake).to receive(:notify_performance_breakdown).with(
+          hash_including(
+            route: '/test-route',
+            method: 'GET',
+            response_type: :html,
+            groups: { db: 0, view: 1.0 }
+          )
+        )
+        subject.call([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Apparentlty, Rails sometimes doesn't set these values for an event. When that
happens, Airbrake Ruby chokes because it doesn't expect `nil` :/

Additionally, to prevent nasty bugs from occurring in the future I added some
unit tests (should've been added from the very beginning TBH).