### PR TITLE
spec/unit/rails/breakdown_subscriber: cleanup properly

### DIFF
--- a/spec/unit/rails/action_controller_performance_breakdown_subscriber_spec.rb
+++ b/spec/unit/rails/action_controller_performance_breakdown_subscriber_spec.rb
@@ -1,7 +1,7 @@
 require 'airbrake/rails/action_controller_performance_breakdown_subscriber'
 
 RSpec.describe Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber do
-  after { Airbrake::Rack::RequestStore[:routes] = nil }
+  after { Airbrake::Rack::RequestStore.clear }
 
   context "when routes are not set in the request store" do
     before { Airbrake::Rack::RequestStore[:routes] = nil }


### PR DESCRIPTION
Setting nil leaves the `routes` key, which is violating the clean state
principle.