### PR TITLE
rails/breakdown_subscriber: maintain precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Fixed the Rails performance breakdown hook not maintaining performance
+  precision ([#936](https://github.com/airbrake/airbrake/pull/936))
+
 ### [v8.3.1][v8.3.1] (March 11, 2019)
 
 * Fixes `TypeError` in the `ActionControllerPerformanceBreakdownSubscriber` when

--- a/lib/airbrake/rails/action_controller_performance_breakdown_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_performance_breakdown_subscriber.rb
@@ -15,8 +15,8 @@ module Airbrake
             route: route,
             response_type: payload[:format],
             groups: {
-              db: payload[:db_runtime].to_i,
-              view: payload[:view_runtime].to_i
+              db: payload[:db_runtime] || 0,
+              view: payload[:view_runtime] || 0
             },
             start_time: event.time
           )

--- a/spec/unit/rails/action_controller_performance_breakdown_subscriber_spec.rb
+++ b/spec/unit/rails/action_controller_performance_breakdown_subscriber_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber d
       OpenStruct.new(
         payload: {
           format: :html,
-          view_runtime: 1.0,
-          db_runtime: 1.0
+          view_runtime: 0.5,
+          db_runtime: 0.5
         }
       )
     end
@@ -46,7 +46,7 @@ RSpec.describe Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber d
           route: '/test-route',
           method: 'GET',
           response_type: :html,
-          groups: { db: 1.0, view: 1.0 }
+          groups: { db: 0.5, view: 0.5 }
         )
       )
       subject.call([])
@@ -61,7 +61,7 @@ RSpec.describe Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber d
             route: '/test-route',
             method: 'GET',
             response_type: :html,
-            groups: { db: 1.0, view: 0 }
+            groups: { db: 0.5, view: 0 }
           )
         )
         subject.call([])
@@ -77,7 +77,7 @@ RSpec.describe Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber d
             route: '/test-route',
             method: 'GET',
             response_type: :html,
-            groups: { db: 0, view: 1.0 }
+            groups: { db: 0, view: 0.5 }
           )
         )
         subject.call([])


### PR DESCRIPTION
`.to_i` converts Float numbers to Integer and we actually want Floats to reflect
metrics more accurately.