### PR TITLE
rack/route_filter: don't crash when no Sinatra route is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Fixed `NoMethodError` in `route_filter.rb` on 404 in Sinatra apps
+  ([#939](https://github.com/airbrake/airbrake/pull/939))
+
 ### [v8.3.2][v8.3.2] (March 12, 2019)
 
 * Fixed the Rails performance breakdown hook not maintaining performance

--- a/lib/airbrake/rack/route_filter.rb
+++ b/lib/airbrake/rack/route_filter.rb
@@ -13,11 +13,9 @@ module Airbrake
         return unless (request = notice.stash[:rack_request])
 
         notice[:context][:route] =
-          if defined?(ActionDispatch::Request) &&
-             request.instance_of?(ActionDispatch::Request)
+          if action_dispatch_request?(request)
             rails_route(request)
-          elsif defined?(Sinatra::Request) &&
-                request.instance_of?(Sinatra::Request)
+          elsif sinatra_request?(request)
             sinatra_route(request)
           end
       end
@@ -39,6 +37,15 @@ module Airbrake
 
       def sinatra_route(request)
         request.env['sinatra.route'].split(' ').drop(1).join(' ')
+      end
+
+      def action_dispatch_request?(request)
+        defined?(ActionDispatch::Request) &&
+          request.instance_of?(ActionDispatch::Request)
+      end
+
+      def sinatra_request?(request)
+        defined?(Sinatra::Request) && request.instance_of?(Sinatra::Request)
       end
     end
   end

--- a/lib/airbrake/rack/route_filter.rb
+++ b/lib/airbrake/rack/route_filter.rb
@@ -36,7 +36,8 @@ module Airbrake
       end
 
       def sinatra_route(request)
-        request.env['sinatra.route'].split(' ').drop(1).join(' ')
+        return unless (route = request.env['sinatra.route'])
+        route.split(' ').drop(1).join(' ')
       end
 
       def action_dispatch_request?(request)

--- a/spec/unit/rack/route_filter_spec.rb
+++ b/spec/unit/rack/route_filter_spec.rb
@@ -6,4 +6,47 @@ RSpec.describe Airbrake::Rack::RouteFilter do
       expect(notice[:context][:route]).to be_nil
     end
   end
+
+  context "when Sinatra route is unavailable" do
+    before { stub_const('Sinatra::Request', Class.new) }
+
+    let(:notice) do
+      notice = Airbrake.build_notice('oops')
+
+      request_mock = instance_double(Sinatra::Request)
+      expect(request_mock)
+        .to receive(:instance_of?).with(Sinatra::Request).and_return(true)
+      expect(request_mock).to receive(:env).and_return({})
+
+      notice.stash[:rack_request] = request_mock
+      notice
+    end
+
+    it "doesn't add context/route" do
+      subject.call(notice)
+      expect(notice[:context][:route]).to be_nil
+    end
+  end
+
+  context "when Sinatra route is available" do
+    before { stub_const('Sinatra::Request', Class.new) }
+
+    let(:notice) do
+      notice = Airbrake.build_notice('oops')
+
+      request_mock = instance_double(Sinatra::Request)
+      expect(request_mock)
+        .to receive(:instance_of?).with(Sinatra::Request).and_return(true)
+      expect(request_mock)
+        .to receive(:env).and_return('sinatra.route' => 'GET /test-route')
+
+      notice.stash[:rack_request] = request_mock
+      notice
+    end
+
+    it "doesn't add context/route" do
+      subject.call(notice)
+      expect(notice[:context][:route]).to eq('/test-route')
+    end
+  end
 end


### PR DESCRIPTION
Fixes airbrake/airbrake-ruby#457
(request.env['sinatra.route'] is nil)

The error occurs when a route is not defined (404).