### PR TITLE
rails/breakdown_subscriber: DRY up #build_groups

### DIFF
--- a/lib/airbrake/rails/action_controller_performance_breakdown_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_performance_breakdown_subscriber.rb
@@ -22,16 +22,16 @@ module Airbrake
         end
       end
 
+      private
+
       def build_groups(payload)
-        groups = {}
+        groups = %i[db_runtime view_runtime].map do |metric|
+          ms = payload[metric] || 0
+          next if ms == 0
 
-        db_runtime = payload[:db_runtime] || 0
-        groups[:db] = db_runtime if db_runtime > 0
-
-        view_runtime = payload[:view_runtime] || 0
-        groups[:view] = view_runtime if view_runtime > 0
-
-        groups
+          [metric.to_s.split('_').first, ms]
+        end
+        groups.compact.to_h
       end
     end
   end

--- a/spec/unit/rails/action_controller_performance_breakdown_subscriber_spec.rb
+++ b/spec/unit/rails/action_controller_performance_breakdown_subscriber_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber d
           route: '/test-route',
           method: 'GET',
           response_type: :html,
-          groups: { db: 0.5, view: 0.5 }
+          groups: { 'db' => 0.5, 'view' => 0.5 }
         )
       )
       subject.call([])
@@ -61,7 +61,7 @@ RSpec.describe Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber d
             route: '/test-route',
             method: 'GET',
             response_type: :html,
-            groups: { db: 0.5 }
+            groups: { 'db' => 0.5 }
           )
         )
         subject.call([])
@@ -77,7 +77,7 @@ RSpec.describe Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber d
             route: '/test-route',
             method: 'GET',
             response_type: :html,
-            groups: { view: 0.5 }
+            groups: { 'view' => 0.5 }
           )
         )
         subject.call([])
@@ -93,7 +93,7 @@ RSpec.describe Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber d
             route: '/test-route',
             method: 'GET',
             response_type: :html,
-            groups: { view: 0.5 }
+            groups: { 'view' => 0.5 }
           )
         )
         subject.call([])
@@ -109,7 +109,7 @@ RSpec.describe Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber d
             route: '/test-route',
             method: 'GET',
             response_type: :html,
-            groups: { db: 0.5 }
+            groups: { 'db' => 0.5 }
           )
         )
         subject.call([])


### PR DESCRIPTION
Group names become strings but it's no big deal because airbrake-ruby will
convert everything to JSON anyway.