### PR TITLE
rails: load performance hooks only if performance_stats is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Airbrake Changelog
 
 * Fixed `NoMethodError` in `route_filter.rb` on 404 in Sinatra apps
   ([#939](https://github.com/airbrake/airbrake/pull/939))
+* Stopped loading Rails performance hooks for apps that don't use performance
+  stats ([#942](https://github.com/airbrake/airbrake/pull/942))
+* Stopped loading default Rack filters for Sinatra & Rack integrations (Rails is
+  not affected). You must load them manually after you `configure` your notifier
+  with help of `Airbrake::Rack.add_default_filters`. Please refer to the README
+  ([#942](https://github.com/airbrake/airbrake/pull/942))
 
 ### [v8.3.2][v8.3.2] (March 12, 2019)
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,9 @@ the [dedicated issue][rails-sub-keys].
 ### Sinatra
 
 To use Airbrake with Sinatra, simply `require` the gem, [configure][config] it
-and `use` our Rack middleware.
+and `use` our Rack middleware. To use default filters that append information
+about routes, HTTP headers and more, invoke `Airbrake::Rack.add_default_filters`
+after `Airbrake.configure`.
 
 ```ruby
 # myapp.rb
@@ -201,6 +203,8 @@ Airbrake.configure do |c|
   # Display debug output.
   c.logger.level = Logger::DEBUG
 end
+
+Airbrake::Rack.add_default_filters
 
 class MyApp < Sinatra::Base
   use Airbrake::Rack::Middleware
@@ -233,7 +237,9 @@ accordingly](#configuring-individual-notifier-for-each-subproject).
 ### Rack
 
 To send exceptions to Airbrake from any Rack application, simply `use` our Rack
-middleware, and [configure][config] the default notifier.
+middleware, and [configure][config] the default notifier. To use default filters
+that append information about routes, HTTP headers and more, invoke
+`Airbrake::Rack.add_default_filters` after `Airbrake.configure`.
 
 ```ruby
 require 'airbrake'
@@ -243,6 +249,8 @@ Airbrake.configure do |c|
   c.project_id = 113743
   c.project_key = 'fd04e13d806a90f96614ad8e529b2822'
 end
+
+Airbrake::Rack.add_default_filters
 
 use Airbrake::Rack::Middleware
 ```
@@ -267,9 +275,18 @@ The `notice` object carries a real `Rack::Request` object in
 its [stash](https://github.com/airbrake/airbrake-ruby#noticestash--noticestash).
 Rack requests will always be accessible through the `:rack_request` stash key.
 
-#### Optional Rack request filters
+#### Default Rack filters
 
-The library comes with optional predefined builders listed below.
+Default Rack request filters are loaded with
+`Airbrake::Rack.add_default_filters`. These filters provide additonal
+information about Rack requests, such as route info, certain HTTP parameters,
+session and more. These filters are considered essential for every app.
+
+#### Optional Rack filters
+
+The library comes with optional predefined builders listed below. These filters
+are not essential and therefore `Airbrake::Rack.add_default_filters` doesn't
+load them.
 
 ##### RequestBodyFilter
 

--- a/lib/airbrake/rack.rb
+++ b/lib/airbrake/rack.rb
@@ -8,3 +8,24 @@ require 'airbrake/rack/request_body_filter'
 require 'airbrake/rack/route_filter'
 require 'airbrake/rack/middleware'
 require 'airbrake/rack/request_store'
+
+module Airbrake
+  # Rack is a namespace for all Rack-related features.
+  module Rack
+    # Adds the list of default Rack filters that read Rack request information
+    # and append it to notices.
+    # @since 9.0.0
+    def self.add_default_filters
+      [
+        Airbrake::Rack::ContextFilter,
+        Airbrake::Rack::UserFilter,
+        Airbrake::Rack::SessionFilter,
+        Airbrake::Rack::HttpParamsFilter,
+        Airbrake::Rack::HttpHeadersFilter,
+        Airbrake::Rack::RouteFilter
+      ].each do |filter|
+        Airbrake.add_filter(filter.new)
+      end
+    end
+  end
+end

--- a/lib/airbrake/rack/middleware.rb
+++ b/lib/airbrake/rack/middleware.rb
@@ -79,19 +79,3 @@ module Airbrake
     end
   end
 end
-
-# The list of Rack filters that read Rack request information and append it to
-# notices.
-[
-  Airbrake::Rack::ContextFilter,
-  Airbrake::Rack::UserFilter,
-  Airbrake::Rack::SessionFilter,
-  Airbrake::Rack::HttpParamsFilter,
-  Airbrake::Rack::HttpHeadersFilter,
-  Airbrake::Rack::RouteFilter,
-
-  # Optional filters (must be included by users):
-  # Airbrake::Rack::RequestBodyFilter
-].each do |filter|
-  Airbrake.add_filter(filter.new)
-end

--- a/lib/airbrake/rails/action_controller_notify_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_notify_subscriber.rb
@@ -42,8 +42,3 @@ module Airbrake
     end
   end
 end
-
-ActiveSupport::Notifications.subscribe(
-  'process_action.action_controller',
-  Airbrake::Rails::ActionControllerNotifySubscriber.new
-)

--- a/lib/airbrake/rails/action_controller_route_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_route_subscriber.rb
@@ -46,8 +46,3 @@ module Airbrake
     end
   end
 end
-
-ActiveSupport::Notifications.subscribe(
-  'start_processing.action_controller',
-  Airbrake::Rails::ActionControllerRouteSubscriber.new
-)

--- a/lib/airbrake/rails/active_record_subscriber.rb
+++ b/lib/airbrake/rails/active_record_subscriber.rb
@@ -36,13 +36,3 @@ module Airbrake
     end
   end
 end
-
-Airbrake.add_performance_filter(
-  Airbrake::Filters::SqlFilter.new(
-    ActiveRecord::Base.connection_config[:adapter]
-  )
-)
-
-ActiveSupport::Notifications.subscribe(
-  'sql.active_record', Airbrake::Rails::ActiveRecordSubscriber.new
-)

--- a/spec/apps/rack/dummy_app.rb
+++ b/spec/apps/rack/dummy_app.rb
@@ -3,6 +3,8 @@ DummyApp = Rack::Builder.new do
   use Airbrake::Rack::Middleware
   use Warden::Manager
 
+  Airbrake::Rack.add_default_filters
+
   map '/' do
     run(
       proc do |_env|

--- a/spec/apps/sinatra/sinatra_test_app.rb
+++ b/spec/apps/sinatra/sinatra_test_app.rb
@@ -10,3 +10,5 @@ class SinatraTestApp < Sinatra::Base
     raise AirbrakeTestError
   end
 end
+
+Airbrake::Rack.add_default_filters

--- a/spec/unit/rack/middleware_spec.rb
+++ b/spec/unit/rack/middleware_spec.rb
@@ -1,4 +1,20 @@
 RSpec.describe Airbrake::Rack::Middleware do
+  # The list of Rack filters that read Rack request information and append it to
+  # notices.
+  [
+    Airbrake::Rack::ContextFilter,
+    Airbrake::Rack::UserFilter,
+    Airbrake::Rack::SessionFilter,
+    Airbrake::Rack::HttpParamsFilter,
+    Airbrake::Rack::HttpHeadersFilter,
+    Airbrake::Rack::RouteFilter,
+
+    # Optional filters (must be included by users):
+    # Airbrake::Rack::RequestBodyFilter
+  ].each do |filter|
+    Airbrake.add_filter(filter.new)
+  end
+
   let(:app) { proc { |env| [200, env, 'Bingo bango content'] } }
   let(:faulty_app) { proc { raise AirbrakeTestError } }
   let(:endpoint) { 'https://api.airbrake.io/api/v3/projects/113743/notices' }


### PR DESCRIPTION
We load these hooks unnecessarily for those customers who don't use performance
stats. It may cause an unwanted overhead for them: we spend CPU time collecting
info but never send it. In this commit we check if performance_stats is enabled
and include the hooks only if it is.