### PR TITLE
gemspec: bump airbrake-ruby to '~> 4.2'

### DIFF
--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -31,7 +31,7 @@ DESC
 
   s.required_ruby_version = '>= 2.1'
 
-  s.add_dependency 'airbrake-ruby', '~> 4.1'
+  s.add_dependency 'airbrake-ruby', '~> 4.2'
 
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rspec-wait', '~> 0'


### PR DESCRIPTION
Fixes #941 ([REQUEST] Start depending on airbrake-ruby 4.2.2?)