### PR TITLE
action_controller_performance_breakdown: treat */* as :html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Changelog
 
 ### master
 
+* Started treating `*/*` response type as `:html` in
+  `ActionControllerPerformanceBreakdownSubscriber`
+  ([#949](https://github.com/airbrake/airbrake/pull/949))
+
 ### [v9.0.0][v9.0.0] (March 29, 2019)
 
 * Fixed `NoMethodError` in `route_filter.rb` on 404 in Sinatra apps

--- a/spec/unit/rails/action_controller_performance_breakdown_subscriber_spec.rb
+++ b/spec/unit/rails/action_controller_performance_breakdown_subscriber_spec.rb
@@ -127,5 +127,16 @@ RSpec.describe Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber d
         subject.call([])
       end
     end
+
+    context "when response format is */*" do
+      before { event.payload[:format] = "*/*" }
+
+      it "normalizes it to :html" do
+        expect(Airbrake).to receive(:notify_performance_breakdown).with(
+          hash_including(response_type: :html)
+        )
+        subject.call([])
+      end
+    end
   end
 end


### PR DESCRIPTION
Some routes can return both `*/*` and `:html` response types. I did some
googling and uncovered that `*/*` means `:html`. Due to historical reasons Rails
cannot change it: https://github.com/rails/rails/issues/8987

Currently, we display both `*/*` and `html`, which is clearly confusing. By
merging them together we will treat `*/*` as HTML.