### PR TITLE
rails: add unit tests for hooks

### DIFF
--- a/lib/airbrake/rails/action_controller_performance_breakdown_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_performance_breakdown_subscriber.rb
@@ -1,46 +1,26 @@
+require 'airbrake/rails/event'
+
 module Airbrake
   module Rails
     # @since v8.3.0
     class ActionControllerPerformanceBreakdownSubscriber
-      # @see https://github.com/rails/rails/issues/8987
-      HTML_RESPONSE_WILDCARD = "*/*".freeze
-
       def call(*args)
         routes = Airbrake::Rack::RequestStore[:routes]
         return if !routes || routes.none?
 
-        event = ActiveSupport::Notifications::Event.new(*args)
-        payload = event.payload
+        event = Airbrake::Rails::Event.new(*args)
 
-        routes.each do |route, method|
-          next if (groups = build_groups(payload)).none?
+        routes.each do |route, _params|
+          next if (groups = event.groups).none?
 
           Airbrake.notify_performance_breakdown(
-            method: method,
+            method: event.method,
             route: route,
-            response_type: normalize_response_type(payload[:format]),
+            response_type: event.response_type,
             groups: groups,
             start_time: event.time
           )
         end
-      end
-
-      private
-
-      def build_groups(payload)
-        groups = {}
-
-        db_runtime = payload[:db_runtime] || 0
-        groups[:db] = db_runtime if db_runtime > 0
-
-        view_runtime = payload[:view_runtime] || 0
-        groups[:view] = view_runtime if view_runtime > 0
-
-        groups
-      end
-
-      def normalize_response_type(response_type)
-        response_type == HTML_RESPONSE_WILDCARD ? :html : response_type
       end
     end
   end

--- a/lib/airbrake/rails/action_controller_route_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_route_subscriber.rb
@@ -14,13 +14,16 @@ module Airbrake
 
       def call(*args)
         # We don't track routeless events.
-        return unless Airbrake::Rack::RequestStore[:routes]
+        return unless (routes = Airbrake::Rack::RequestStore[:routes])
 
         event = Airbrake::Rails::Event.new(*args)
         route = find_route(event.params)
         return unless route
 
-        Airbrake::Rack::RequestStore[:routes][route.path] = event.method
+        routes[route.path] = {
+          method: event.method,
+          response_type: event.response_type
+        }
       end
 
       private

--- a/lib/airbrake/rails/backtrace_cleaner.rb
+++ b/lib/airbrake/rails/backtrace_cleaner.rb
@@ -1,0 +1,10 @@
+module Airbrake
+  module Rails
+    # BacktraceCleaner is a wrapper around Rails.backtrace_cleaner.
+    class BacktraceCleaner
+      def self.clean(backtrace)
+        ::Rails.backtrace_cleaner.clean(backtrace).first(1)
+      end
+    end
+  end
+end

--- a/lib/airbrake/rails/event.rb
+++ b/lib/airbrake/rails/event.rb
@@ -5,6 +5,9 @@ module Airbrake
     # @since v9.0.3
     # @api private
     class Event
+      # @see https://github.com/rails/rails/issues/8987
+      HTML_RESPONSE_WILDCARD = "*/*".freeze
+
       def initialize(*args)
         @event = ActiveSupport::Notifications::Event.new(*args)
       end
@@ -13,12 +16,55 @@ module Airbrake
         @event.payload[:method]
       end
 
-      def format
-        @event.payload[:format]
+      def response_type
+        response_type = @event.payload[:format]
+        response_type == HTML_RESPONSE_WILDCARD ? :html : response_type
       end
 
       def params
         @event.payload[:params]
+      end
+
+      def sql
+        @event.payload[:sql]
+      end
+
+      def db_runtime
+        @db_runtime ||= @event.payload[:db_runtime] || 0
+      end
+
+      def view_runtime
+        @view_runtime ||= @event.payload[:view_runtime] || 0
+      end
+
+      def time
+        @event.time
+      end
+
+      def end
+        @event.end
+      end
+
+      def groups
+        groups = {}
+        groups[:db] = db_runtime if db_runtime > 0
+        groups[:view] = view_runtime if view_runtime > 0
+        groups
+      end
+
+      def status_code
+        return @event.payload[:status] if @event.payload[:status]
+
+        if @event.payload[:exception]
+          status = ActionDispatch::ExceptionWrapper.status_code_for_exception(
+            @event.payload[:exception].first
+          )
+          status = 500 if status == 0
+
+          return status
+        end
+
+        0
       end
     end
   end

--- a/spec/apps/rails/dummy_app.rb
+++ b/spec/apps/rails/dummy_app.rb
@@ -31,6 +31,7 @@ class DummyApp < Rails::Application
     get '/' => 'dummy#index'
     get '/crash' => 'dummy#crash'
     get '/breakdown' => 'dummy#breakdown'
+    get '/breakdown_view_only' => 'dummy#breakdown_view_only'
     get '/notify_airbrake_helper' => 'dummy#notify_airbrake_helper'
     get '/notify_airbrake_sync_helper' => 'dummy#notify_airbrake_sync_helper'
     get '/active_record_after_commit' => 'dummy#active_record_after_commit'
@@ -102,7 +103,8 @@ class DummyController < ActionController::Base
       'dummy/active_job.html.erb' => 'active_job',
       'dummy/resque.html.erb' => 'resque',
       'dummy/delayed_job.html.erb' => 'delayed_job',
-      'dummy/breakdown.html.erb' => 'breakdown'
+      'dummy/breakdown.html.erb' => 'breakdown',
+      'dummy/breakdown_view_only.html.erb' => 'breakdown_view_only'
     )
   ]
 
@@ -116,6 +118,10 @@ class DummyController < ActionController::Base
   def breakdown
     Book.create(title: 'breakdown')
     Book.all
+  end
+
+  def breakdown_view_only
+    render 'dummy/breakdown.html.erb'
   end
 
   def notify_airbrake_helper

--- a/spec/integration/rails/rails_spec.rb
+++ b/spec/integration/rails/rails_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe "Rails integration specs" do
         hash_including(
           route: '/crash(.:format)',
           method: 'GET',
-          func: 'tap',
+          func: 'call',
           file: 'lib/airbrake/rails/active_record_subscriber.rb',
           line: anything
         )
@@ -304,6 +304,22 @@ RSpec.describe "Rails integration specs" do
       ).at_least(:once)
 
       get '/breakdown'
+    end
+
+    context "when response format is */*" do
+      it "normalizes it to :html" do
+        expect(Airbrake).to receive(:notify_performance_breakdown)
+          .with(hash_including(response_type: :html))
+        get '/breakdown', {}, 'HTTP_ACCEPT' => '*/*'
+      end
+    end
+
+    context "when db_runtime is nil" do
+      it "omits the db group" do
+        expect(Airbrake).to receive(:notify_performance_breakdown)
+          .with(hash_including(groups: { view: be > 0 }))
+        get '/breakdown_view_only'
+      end
     end
   end
 end

--- a/spec/unit/rails/action_controller_notify_subscriber_spec.rb
+++ b/spec/unit/rails/action_controller_notify_subscriber_spec.rb
@@ -1,0 +1,43 @@
+require 'airbrake/rails/action_controller_notify_subscriber'
+
+RSpec.describe Airbrake::Rails::ActionControllerNotifySubscriber do
+  after { Airbrake::Rack::RequestStore.clear }
+
+  describe "#call" do
+    let(:event) { double(Airbrake::Rails::Event) }
+
+    before do
+      allow(Airbrake::Rails::Event).to receive(:new).and_return(event)
+    end
+
+    context "when there are no routes in the request store" do
+      it "doesn't notify requests" do
+        expect(Airbrake).not_to receive(:notify_request)
+        subject.call([])
+      end
+    end
+
+    context "when there's a route in the request store" do
+      before do
+        Airbrake::Rack::RequestStore[:routes] = {
+          '/test-route' => { method: 'GET', response_type: :html }
+        }
+
+        expect(event).to receive(:method).and_return('GET')
+        expect(event).to receive(:status_code).and_return(200)
+        expect(event).to receive(:time).and_return(Time.now)
+      end
+
+      it "sends request info to Airbrake" do
+        expect(Airbrake).to receive(:notify_request).with(
+          hash_including(
+            method: 'GET',
+            route: '/test-route',
+            status_code: 200
+          )
+        )
+        subject.call([])
+      end
+    end
+  end
+end

--- a/spec/unit/rails/action_controller_route_subscriber_spec.rb
+++ b/spec/unit/rails/action_controller_route_subscriber_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Airbrake::Rails::ActionControllerRouteSubscriber do
         allow(app).to receive(:routes).and_return(routes)
         allow(event).to receive(:params).and_return(params)
         allow(event).to receive(:method).and_return('HEAD')
+        allow(event).to receive(:response_type).and_return(:html)
 
         Airbrake::Rack::RequestStore[:routes] = {}
       end
@@ -44,7 +45,7 @@ RSpec.describe Airbrake::Rails::ActionControllerRouteSubscriber do
         it "stores a route in the request store under :routes" do
           subject.call(event_params)
           expect(Airbrake::Rack::RequestStore[:routes])
-            .to eq('/crash' => 'HEAD')
+            .to eq('/crash' => { method: 'HEAD', response_type: :html })
         end
       end
 

--- a/spec/unit/rails/active_record_subscriber_spec.rb
+++ b/spec/unit/rails/active_record_subscriber_spec.rb
@@ -1,0 +1,70 @@
+require 'airbrake/rails/active_record_subscriber'
+
+RSpec.describe Airbrake::Rails::ActiveRecordSubscriber do
+  after { Airbrake::Rack::RequestStore.clear }
+
+  describe "#call" do
+    let(:event) { double(Airbrake::Rails::Event) }
+
+    before do
+      allow(Airbrake::Rails::Event).to receive(:new).and_return(event)
+    end
+
+    context "when there are no routes in the request store" do
+      it "doesn't notify requests" do
+        expect(Airbrake).not_to receive(:notify_query)
+        subject.call([])
+      end
+    end
+
+    context "when there's a route in the request store" do
+      before do
+        Airbrake::Rack::RequestStore[:routes] = {
+          '/test-route' => { method: 'GET', response_type: :html }
+        }
+
+        allow(event).to receive(:sql).and_return('SELECT * FROM bananas')
+        allow(event).to receive(:time).and_return(Time.now)
+        allow(event).to receive(:end).and_return(Time.now)
+        allow(Airbrake::Rails::BacktraceCleaner).to receive(:clean).and_return(
+          "/lib/pry/cli.rb:117:in `start'"
+        )
+      end
+
+      it "sends query info to Airbrake" do
+        expect(Airbrake).to receive(:notify_query).with(
+          hash_including(
+            method: 'GET',
+            route: '/test-route',
+            query: 'SELECT * FROM bananas',
+            func: 'start',
+            line: 117,
+            file: '/lib/pry/cli.rb'
+          )
+        )
+        subject.call([])
+      end
+
+      context "and when backtrace couldn't be parsed" do
+        before do
+          allow(Airbrake::Rails::BacktraceCleaner)
+            .to receive(:clean).and_return([])
+        end
+
+        it "sends empty func/file/line to Airbrake" do
+          expect(Airbrake).to receive(:notify_query).with(
+            hash_including(
+              method: 'GET',
+              route: '/test-route',
+              query: 'SELECT * FROM bananas',
+              func: nil,
+              line: nil,
+              file: nil
+            )
+          )
+          subject.call([])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Continuing work started in https://github.com/airbrake/airbrake/pull/953.

`Airbrake::Rails::Event` turns out to be a good idea because it encapsulates a
lot of related logic together (previously it was scattered all around hooks).