### PR TITLE
rails: add HTTP breakdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Rails: added HTTP performance breakdown (`Net::HTTP` support only)
+  ([#955](https://github.com/airbrake/airbrake/pull/955))
+
 ### [v9.0.2][v9.0.2] (April 8, 2019)
 
 * Delete `Airbrake::Rack.add_default_filters`

--- a/lib/airbrake/rails.rb
+++ b/lib/airbrake/rails.rb
@@ -70,6 +70,8 @@ module Airbrake
               'process_action.action_controller',
               Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber.new
             )
+
+            require 'airbrake/rails/net_http'
           end
         end
       end

--- a/lib/airbrake/rails/action_controller_performance_breakdown_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_performance_breakdown_subscriber.rb
@@ -10,8 +10,9 @@ module Airbrake
 
         event = Airbrake::Rails::Event.new(*args)
 
-        routes.each do |route, _params|
-          next if (groups = event.groups).none?
+        routes.each do |route, params|
+          groups = event.groups.merge(params[:groups])
+          next if groups.none?
 
           Airbrake.notify_performance_breakdown(
             method: event.method,

--- a/lib/airbrake/rails/action_controller_route_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_route_subscriber.rb
@@ -22,7 +22,8 @@ module Airbrake
 
         routes[route.path] = {
           method: event.method,
-          response_type: event.response_type
+          response_type: event.response_type,
+          groups: {}
         }
       end
 

--- a/lib/airbrake/rails/net_http.rb
+++ b/lib/airbrake/rails/net_http.rb
@@ -1,0 +1,23 @@
+require 'net/http'
+
+# Monkey-patch Net::HTTP to benchmark it.
+Net::HTTP.class_eval do
+  alias_method :request_without_airbrake, :request
+
+  def request(request, *args, &block)
+    routes = Airbrake::Rack::RequestStore[:routes]
+    if !routes || routes.none?
+      response = request_without_airbrake(request, *args, &block)
+    else
+      elapsed = Airbrake::Benchmark.measure do
+        response = request_without_airbrake(request, *args, &block)
+      end
+
+      routes.each do |route_path, _params|
+        Airbrake::Rack::RequestStore[:routes][route_path][:groups][:http] = elapsed
+      end
+    end
+
+    response
+  end
+end

--- a/spec/apps/rails/dummy_app.rb
+++ b/spec/apps/rails/dummy_app.rb
@@ -32,6 +32,7 @@ class DummyApp < Rails::Application
     get '/crash' => 'dummy#crash'
     get '/breakdown' => 'dummy#breakdown'
     get '/breakdown_view_only' => 'dummy#breakdown_view_only'
+    get '/breakdown_http' => 'dummy#breakdown_http'
     get '/notify_airbrake_helper' => 'dummy#notify_airbrake_helper'
     get '/notify_airbrake_sync_helper' => 'dummy#notify_airbrake_sync_helper'
     get '/active_record_after_commit' => 'dummy#active_record_after_commit'
@@ -104,7 +105,8 @@ class DummyController < ActionController::Base
       'dummy/resque.html.erb' => 'resque',
       'dummy/delayed_job.html.erb' => 'delayed_job',
       'dummy/breakdown.html.erb' => 'breakdown',
-      'dummy/breakdown_view_only.html.erb' => 'breakdown_view_only'
+      'dummy/breakdown_view_only.html.erb' => 'breakdown_view_only',
+      'dummy/breakdown_http.html.erb' => 'breakdown_http'
     )
   ]
 
@@ -122,6 +124,11 @@ class DummyController < ActionController::Base
 
   def breakdown_view_only
     render 'dummy/breakdown.html.erb'
+  end
+
+  def breakdown_http
+    Net::HTTP.get('example.com', '/')
+    render 'dummy/breakdown_http.html.erb'
   end
 
   def notify_airbrake_helper

--- a/spec/integration/rails/rails_spec.rb
+++ b/spec/integration/rails/rails_spec.rb
@@ -321,5 +321,18 @@ RSpec.describe "Rails integration specs" do
         get '/breakdown_view_only'
       end
     end
+
+    context "when an action performs a HTTP request" do
+      let!(:example_request) do
+        stub_request(:get, 'http://example.com').to_return(body: '')
+      end
+
+      it "includes the http breakdown" do
+        expect(Airbrake).to receive(:notify_performance_breakdown)
+          .with(hash_including(groups: { view: be > 0, http: be > 0 }))
+        get '/breakdown_http'
+        expect(example_request).to have_been_made
+      end
+    end
   end
 end

--- a/spec/unit/rails/action_controller_route_subscriber_spec.rb
+++ b/spec/unit/rails/action_controller_route_subscriber_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Airbrake::Rails::ActionControllerRouteSubscriber do
         it "stores a route in the request store under :routes" do
           subject.call(event_params)
           expect(Airbrake::Rack::RequestStore[:routes])
-            .to eq('/crash' => { method: 'HEAD', response_type: :html })
+            .to eq('/crash' => { method: 'HEAD', response_type: :html, groups: {} })
         end
       end
 


### PR DESCRIPTION
We currently integrate only with `Net::HTTP` since it's the most popular HTTP
library for Ruby.