### PR TITLE
Rails 6: Pass middleware class instead of a string

### DIFF
--- a/lib/airbrake/rails.rb
+++ b/lib/airbrake/rails.rb
@@ -23,13 +23,13 @@ module Airbrake
           # https://github.com/airbrake/airbrake/pull/568
           app.config.middleware.insert_after(
             ::ActiveRecord::ConnectionAdapters::ConnectionManagement,
-            'Airbrake::Rack::Middleware'
+            Airbrake::Rack::Middleware
           )
         else
           # Insert after DebugExceptions for apps without ActiveRecord.
           app.config.middleware.insert_after(
             ActionDispatch::DebugExceptions,
-            'Airbrake::Rack::Middleware'
+            Airbrake::Rack::Middleware
           )
         end
       end


### PR DESCRIPTION
While attempting to upgrade to Rails `6.0.0.rc1`, I ran into an issue with Airbrake's middleware. It appears that [using strings or symbols for middleware class names is deprecated](https://github.com/rails/rails/commit/83b767ce). I have verified that this fixes the issue, though I'm not entirely sure of any side effects this may have within the Airbrake gem itself. Let me know if there is anything else I can do to help here. Here are the details:

* **Ruby**: 2.6.1
* **Rails**: 6.0.0.rc1
* **Stack trace**: 
![image](https://user-images.githubusercontent.com/651946/56904471-e81c8300-6a63-11e9-8590-10e87be10fbf.png)
