### PR TITLE
rails,rack: add the ability to send performance breakdown manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Airbrake Changelog
   ([#960](https://github.com/airbrake/airbrake/pull/960))
 * Rails: added support for Typhoeus for HTTP performance breakdown
   ([#961](https://github.com/airbrake/airbrake/pull/961))
+* Added `Airbrake::Rack.capture_timing` and `Airbrake::Rack::Instrumentable` for
+  manual performance measurements
+  ([#965](https://github.com/airbrake/airbrake/pull/965))
 
 ### [v9.1.0][v9.1.0] (April 17, 2019)
 

--- a/README.md
+++ b/README.md
@@ -289,6 +289,45 @@ filter. For example, read up to 512 bytes:
 Airbrake.add_filter(Airbrake::Rack::RequestBodyFilter.new(512))
 ```
 
+#### Sending custom route breakdown performance
+
+##### Arbitrary code performance instrumentation
+
+For every route in your app Airbrake collects performance breakdown
+statistics. If you need to monitor a specific operation, you can capture your
+own breakdown:
+
+```ruby
+def index
+  Airbrake::Rack.capture_timing('operation name') do
+    call_operation(...)
+  end
+
+  call_other_operation
+end
+```
+
+That will benchmark `call_operation` and send performance information to
+Airbrake, to the corresponding route (under the 'operation name' label).
+
+##### Method performance instrumentation
+
+Alternatively, you can measure performance of a specific method:
+
+```ruby
+class UsersController
+  extend Airbrake::Rack::Instrumentable
+
+  def index
+    call_operation(...)
+  end
+  airbrake_capture_timing :index
+end
+```
+
+Similarly to the previous example, performance information of the `index` method
+will be sent to Airbrake.
+
 ### Sidekiq
 
 We support Sidekiq v2+. The configurations steps for them are identical. Simply

--- a/lib/airbrake/rack/instrumentable.rb
+++ b/lib/airbrake/rack/instrumentable.rb
@@ -1,0 +1,28 @@
+module Airbrake
+  module Rack
+    # Instrumentable holds methods that simplify instrumenting Rack apps.
+    # @example
+    #   class UsersController
+    #     extend Airbrake::Rack::Instrumentable
+    #
+    #     def index
+    #       # ...
+    #     end
+    #     airbrake_capture_timing :index
+    #   end
+    #
+    # @api public
+    # @since v9.2.0
+    module Instrumentable
+      def airbrake_capture_timing(method_name)
+        alias_method "#{method_name}_without_airbrake", method_name
+
+        define_method(method_name) do |*args|
+          Airbrake::Rack.capture_timing(method_name.to_s) do
+            __send__("#{method_name}_without_airbrake", *args)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/airbrake/rails/curb.rb
+++ b/lib/airbrake/rails/curb.rb
@@ -4,7 +4,7 @@ module Curl
     alias http_without_airbrake http
 
     def http(verb)
-      Airbrake::Rack.capture_http_performance do
+      Airbrake::Rack.capture_timing(:http) do
         http_without_airbrake(verb)
       end
     end
@@ -12,7 +12,7 @@ module Curl
     alias perform_without_airbrake perform
 
     def perform(&block)
-      Airbrake::Rack.capture_http_performance do
+      Airbrake::Rack.capture_timing(:http) do
         perform_without_airbrake(&block)
       end
     end
@@ -26,7 +26,7 @@ module Curl
       alias http_without_airbrake http
 
       def http(urls_with_config, multi_options = {}, &block)
-        Airbrake::Rack.capture_http_performance do
+        Airbrake::Rack.capture_timing(:http) do
           http_without_airbrake(urls_with_config, multi_options, &block)
         end
       end

--- a/lib/airbrake/rails/http.rb
+++ b/lib/airbrake/rails/http.rb
@@ -4,7 +4,7 @@ module HTTP
     alias perform_without_airbrake perform
 
     def perform(request, options)
-      Airbrake::Rack.capture_http_performance do
+      Airbrake::Rack.capture_timing(:http) do
         perform_without_airbrake(request, options)
       end
     end

--- a/lib/airbrake/rails/http_client.rb
+++ b/lib/airbrake/rails/http_client.rb
@@ -3,7 +3,7 @@ class HTTPClient
   alias do_get_without_airbrake do_get_block
 
   def do_get_block(request, proxy, connection, &block)
-    Airbrake::Rack.capture_http_performance do
+    Airbrake::Rack.capture_timing(:http) do
       do_get_without_airbrake(request, proxy, connection, &block)
     end
   end

--- a/lib/airbrake/rails/net_http.rb
+++ b/lib/airbrake/rails/net_http.rb
@@ -3,7 +3,7 @@ Net::HTTP.class_eval do
   alias_method :request_without_airbrake, :request
 
   def request(request, *args, &block)
-    Airbrake::Rack.capture_http_performance do
+    Airbrake::Rack.capture_timing(:http) do
       request_without_airbrake(request, *args, &block)
     end
   end

--- a/lib/airbrake/rails/typhoeus.rb
+++ b/lib/airbrake/rails/typhoeus.rb
@@ -4,7 +4,7 @@ module Typhoeus
     alias run_without_airbrake run
 
     def run
-      Airbrake::Rack.capture_http_performance do
+      Airbrake::Rack.capture_timing(:http) do
         run_without_airbrake
       end
     end

--- a/spec/unit/rack/instrumentable_spec.rb
+++ b/spec/unit/rack/instrumentable_spec.rb
@@ -1,0 +1,87 @@
+RSpec.describe Airbrake::Rack::Instrumentable do
+  describe ".airbrake_capture_timing" do
+    let(:routes) { Airbrake::Rack::RequestStore[:routes] }
+
+    let(:klass) do
+      Class.new do
+        extend Airbrake::Rack::Instrumentable
+
+        def method; end
+        airbrake_capture_timing :method
+
+        def method_with_arg(a); end
+        airbrake_capture_timing :method_with_arg
+
+        def method_with_args(a, b); end
+        airbrake_capture_timing :method_with_args
+
+        def method_with_vla(*args); end
+        airbrake_capture_timing :method_with_vla
+
+        def method_with_args_and_vla(*args); end
+        airbrake_capture_timing :method_with_args_and_vla
+
+        def method_with_kwargs(foo:, bar:); end
+        airbrake_capture_timing :method_with_kwargs
+      end
+    end
+
+    context "when request store doesn't have any routes" do
+      before { Airbrake::Rack::RequestStore.clear }
+
+      it "doesn't store timing of the tracked method" do
+        klass.new.method
+        expect(Airbrake::Rack::RequestStore.store).to be_empty
+      end
+    end
+
+    context "when request store has a route" do
+      let(:groups) { routes['/about'][:groups] }
+
+      before do
+        Airbrake::Rack::RequestStore[:routes] = {
+          '/about' => {
+            method: 'GET',
+            response_type: :html,
+            groups: {}
+          }
+        }
+      end
+
+      it "attaches timing for a method without an argument" do
+        klass.new.method
+        expect(groups).to match('method' => be > 0)
+      end
+
+      it "attaches timing for a method with an argument" do
+        klass.new.method_with_arg(1)
+        expect(groups).to match('method_with_arg' => be > 0)
+      end
+
+      it "attaches timing for a variable-length argument method" do
+        klass.new.method_with_vla(1, 2, 3)
+        expect(groups).to match('method_with_vla' => be > 0)
+      end
+
+      it "attaches timing for a method with args and a variable-length array" do
+        klass.new.method_with_args_and_vla(1, 2, 3)
+        expect(groups).to match('method_with_args_and_vla' => be > 0)
+      end
+
+      it "attaches timing for a method with kwargs" do
+        klass.new.method_with_kwargs(foo: 1, bar: 2)
+        expect(groups).to match('method_with_kwargs' => be > 0)
+      end
+
+      it "attaches all timings for multiple methods to the request store" do
+        klass.new.method
+        klass.new.method_with_arg(1)
+
+        expect(groups).to match(
+          'method' => be > 0,
+          'method_with_arg' => be > 0
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
The new `Airbrake::Rack::Instrumentable` module adds
`airbrake_capture_timing`. This method expects the name of the method to
instrument. When such a method is called, Airbrake measures its timing and sends
the stats to Airbrake. The stats will be displayed in the performance breakdown
view of a route. Routes are determined automatically.

```ruby
class UsersController
  extend Airbrake::Rack::Instrumentable

  def index
    # ...
  end
  airbrake_capture_timing :index
end
```

Alternatively, you can measure performance within a method:

```ruby
def index
  Airbrake::Rack.capture_timing('operation name') do
    do_measured_stuff
  end

  do_other_stuff
end
```