### PR TITLE
rack/instrumentable: add the ability to set custom label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Changelog
 
 ### master
 
+* Added the ability to provide a custom optional label for
+  `Airbrake::Rack::Instrumentable#airbrake_capture_timing`
+  ([#968](https://github.com/airbrake/airbrake/pull/968))
+
 ### [v9.2.0][v9.2.0] (April 30, 2019)
 
 * Rails: added support for Curb for HTTP performance breakdown

--- a/lib/airbrake/rack/instrumentable.rb
+++ b/lib/airbrake/rack/instrumentable.rb
@@ -14,11 +14,11 @@ module Airbrake
     # @api public
     # @since v9.2.0
     module Instrumentable
-      def airbrake_capture_timing(method_name)
+      def airbrake_capture_timing(method_name, label: method_name.to_s)
         alias_method "#{method_name}_without_airbrake", method_name
 
         define_method(method_name) do |*args|
-          Airbrake::Rack.capture_timing(method_name.to_s) do
+          Airbrake::Rack.capture_timing(label) do
             __send__("#{method_name}_without_airbrake", *args)
           end
         end

--- a/spec/unit/rack/instrumentable_spec.rb
+++ b/spec/unit/rack/instrumentable_spec.rb
@@ -84,6 +84,22 @@ RSpec.describe Airbrake::Rack::Instrumentable do
           'method_with_arg' => be > 0
         )
       end
+
+      context "and when a custom label was provided" do
+        let(:klass) do
+          Class.new do
+            extend Airbrake::Rack::Instrumentable
+
+            def method; end
+            airbrake_capture_timing :method, label: 'custom label'
+          end
+        end
+
+        it "attaches timing under the provided label" do
+          klass.new.method
+          expect(groups).to match('custom label' => be > 0)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This functionality is useful when you want to decouple your Airbrake dashboard
and your code from each other. For example, if you instrument a method called
"do_http()", you'd rather instrument it under the "HTTP" label, so it looks more
concise. Use cases are endless.