### PR TITLE
gemspec: don't specify test_files

### DIFF
--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -27,7 +27,6 @@ DESC
 
   s.require_path = 'lib'
   s.files        = ['lib/airbrake.rb', *Dir.glob('lib/**/*')]
-  s.test_files   = Dir.glob('spec/**/*')
 
   s.required_ruby_version = '>= 2.1'
 


### PR DESCRIPTION
Fixes #970 (Spec logs are included in gem builds)

Looks like this option serves no real purpose. It's only there for backwards
comatibility. More info: https://github.com/rubygems/rubygems/issues/735