### PR TITLE
rack/middleware: keep rack request until we're done reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Changelog
 
 ### master
 
+* Fixed `notice.stash[:rack_request]` not being attached for exceptions that are
+  reported through Rack environment (such as `rack.exception`)
+  ([#977](https://github.com/airbrake/airbrake/pull/977))
+
 ### [v9.2.2][v9.2.2] (May 10, 2019)
 
 * Rails: started attaching Rack request and User info to the resource object,

--- a/lib/airbrake/rack/middleware.rb
+++ b/lib/airbrake/rack/middleware.rb
@@ -33,15 +33,15 @@ module Airbrake
         rescue Exception => ex # rubocop:disable Lint/RescueException
           notify_airbrake(ex)
           raise ex
-        ensure
-          # Clear routes for the next request.
-          RequestStore.clear
         end
 
         exception = framework_exception(env)
         notify_airbrake(exception) if exception
 
         response
+      ensure
+        # Clear routes for the next request.
+        RequestStore.clear
       end
 
       private


### PR DESCRIPTION
Fixes https://github.com/airbrake/airbrake/issues/976#issuecomment-499064689

We clear too soon, so "framework" exceptions never have attached requests.