### PR TITLE
Fix broken retry count logic in Sidekiq RetryableJobsFilter

### DIFF
--- a/lib/airbrake/sidekiq/retryable_jobs_filter.rb
+++ b/lib/airbrake/sidekiq/retryable_jobs_filter.rb
@@ -25,7 +25,8 @@ module Airbrake
         return false unless job && job['retry']
 
         max_attempts = max_attempts_for(job)
-        job['retry_count'] < max_attempts
+        retry_count = (job['retry_count'] || -1) + 1
+        retry_count < max_attempts
       end
 
       def max_attempts_for(job)

--- a/lib/airbrake/sidekiq/retryable_jobs_filter.rb
+++ b/lib/airbrake/sidekiq/retryable_jobs_filter.rb
@@ -13,6 +13,10 @@ module Airbrake
         DEFAULT_MAX_RETRY_ATTEMPTS = ::Sidekiq::JobRetry::DEFAULT_MAX_RETRY_ATTEMPTS
       end
 
+      def initialize(notify_after: nil)
+        @notify_after = notify_after
+      end
+
       def call(notice)
         job = notice[:params][:job]
 
@@ -30,7 +34,9 @@ module Airbrake
       end
 
       def max_attempts_for(job)
-        if job['retry'].is_a?(Integer)
+        if @notify_after
+          @notify_after
+        elsif job['retry'].is_a?(Integer)
           job['retry']
         else
           max_retries


### PR DESCRIPTION
It seems Sidekiq must have modified behaviour this filter relies on in recent versions. The existing code fails in two conditions:

1) When `job['retry_count']` is nil, which happens the first time a job fails. (There is no nil check.)
2) When `job['retry_count']` is not nil, the number represent how many retries have *already* been attempted. We must add 1 to this number, or `retry_count` will *always* be lower than `max_attempts`, even on the final retry when we want to actually notify.