### PR TITLE
Add option to notify of sidekiq retries after a given number

### DIFF
--- a/lib/airbrake/sidekiq/retryable_jobs_filter.rb
+++ b/lib/airbrake/sidekiq/retryable_jobs_filter.rb
@@ -13,6 +13,10 @@ module Airbrake
         DEFAULT_MAX_RETRY_ATTEMPTS = ::Sidekiq::JobRetry::DEFAULT_MAX_RETRY_ATTEMPTS
       end
 
+      def initialize(max_retries: nil)
+        @max_retries = max_retries
+      end
+
       def call(notice)
         job = notice[:params][:job]
 
@@ -30,7 +34,9 @@ module Airbrake
       end
 
       def max_attempts_for(job)
-        if job['retry'].is_a?(Integer)
+        if @max_retries
+          @max_retries
+        elsif job['retry'].is_a?(Integer)
           job['retry']
         else
           max_retries

--- a/spec/unit/sidekiq/retryable_jobs_filter_spec.rb
+++ b/spec/unit/sidekiq/retryable_jobs_filter_spec.rb
@@ -3,8 +3,9 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
   require 'sidekiq/cli'
   require 'airbrake/sidekiq'
 
-  RSpec.describe "airbrake/sidekiq/retryable_jobs_filter" do
-    subject(:filter) { Airbrake::Sidekiq::RetryableJobsFilter.new }
+  RSpec.describe Airbrake::Sidekiq::RetryableJobsFilter do
+    subject(:filter) { described_class.new }
+
     def build_notice(job = nil)
       Airbrake::Notice.new(StandardError.new, job: job)
     end

--- a/spec/unit/sidekiq/retryable_jobs_filter_spec.rb
+++ b/spec/unit/sidekiq/retryable_jobs_filter_spec.rb
@@ -13,13 +13,13 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
     it "does not ignore notices that are not from jobs" do
       notice = build_notice
       filter.call(notice)
-      expect(build_notice).to_not be_ignored
+      expect(notice).to_not be_ignored
     end
 
     it "does not ignore notices from jobs that have retries disabled" do
       notice = build_notice('retry' => false)
       filter.call(notice)
-      expect(build_notice).to_not be_ignored
+      expect(notice).to_not be_ignored
     end
 
     it "ignore notices from jobs that will be retried" do

--- a/spec/unit/sidekiq/retryable_jobs_filter_spec.rb
+++ b/spec/unit/sidekiq/retryable_jobs_filter_spec.rb
@@ -38,5 +38,27 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
       notice = build_notice('retry' => 3)
       expect { filter.call(notice) }.to_not raise_error
     end
+
+    context 'with max_retries = 2' do
+      subject(:filter) { described_class.new(max_retries: 2) }
+
+      it "ignores notices when retry_count is null" do
+        notice = build_notice('retry' => 5)
+        filter.call(notice)
+        expect(notice).to be_ignored
+      end
+
+      it "ignores notices when retry_count is 0" do
+        notice = build_notice('retry' => 5, 'retry_count' => 0)
+        filter.call(notice)
+        expect(notice).to be_ignored
+      end
+
+      it "does not ignore notices when retry_count is 1" do
+        notice = build_notice('retry' => 5, 'retry_count' => 1)
+        filter.call(notice)
+        expect(notice).to_not be_ignored
+      end
+    end
   end
 end


### PR DESCRIPTION
This is useful if we don't want to be spammed by a couple of retries,
but *do* want repeated warnings if a job continues to fail multiple
times.