### PR TITLE
Fix broken retry count logic in Sidekiq RetryableJobsFilter

### DIFF
--- a/lib/airbrake/sidekiq/retryable_jobs_filter.rb
+++ b/lib/airbrake/sidekiq/retryable_jobs_filter.rb
@@ -25,7 +25,8 @@ module Airbrake
         return false unless job && job['retry']
 
         max_attempts = max_attempts_for(job)
-        job['retry_count'] < max_attempts
+        retry_count = (job['retry_count'] || -1) + 1
+        retry_count < max_attempts
       end
 
       def max_attempts_for(job)

--- a/spec/unit/sidekiq/retryable_jobs_filter_spec.rb
+++ b/spec/unit/sidekiq/retryable_jobs_filter_spec.rb
@@ -28,9 +28,14 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
     end
 
     it "does not ignore notices from jobs that will not be retried" do
-      notice = build_notice('retry' => 5, 'retry_count' => 5)
+      notice = build_notice('retry' => 5, 'retry_count' => 4)
       filter.call(notice)
-      expect(build_notice).to_not be_ignored
+      expect(notice).to_not be_ignored
+    end
+
+    it "does not error if retry_count is missing" do
+      notice = build_notice('retry' => 3)
+      expect { filter.call(notice) }.to_not raise_error
     end
   end
 end


### PR DESCRIPTION
It seems Sidekiq must have modified behaviour this filter relies on in recent versions. The existing code fails in two conditions:

1) When `job['retry_count']` is nil, which happens the first time a job fails. (There is no nil check.)
2) When `job['retry_count']` is not nil, the number represent how many retries have *already* been attempted. We must add 1 to this number, or `retry_count` will *always* be lower than `max_attempts`, even on the final retry when we want to actually notify.