### PR TITLE
gemspec: bump airbrake-ruby to `~> 4.5`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Airbrake Changelog
 * Fixed `Sidekiq RetryableJobsFilter` when `job['retry_count']` is `nil` (which
   happens the first time a job fails)
   ([#980](https://github.com/airbrake/airbrake/pull/980))
+* Started depending on airbrake-ruby
+  [v4.5.0](https://github.com/airbrake/airbrake-ruby/releases/tag/v4.5.0) and
+  higher ([#982](https://github.com/airbrake/airbrake/pull/982))
+
 
 ### [v9.2.2][v9.2.2] (May 10, 2019)
 

--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -30,7 +30,7 @@ DESC
 
   s.required_ruby_version = '>= 2.1'
 
-  s.add_dependency 'airbrake-ruby', '~> 4.4'
+  s.add_dependency 'airbrake-ruby', '~> 4.5'
 
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rspec-wait', '~> 0'


### PR DESCRIPTION
This enables performance stats by default.