### PR TITLE
Appraisals: lock i18n to 1.5 on modern Rubies

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -42,6 +42,9 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
     gem 'delayed_job_active_record', '~> 4.1.0'
 
     gem 'mime-types', '~> 3.1'
+
+    # i18n 2+ supports only Ruby 2.3+.
+    gem 'i18n', '~> 1.5'
   end
 
   appraise 'rails-5.1' do
@@ -59,6 +62,9 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
     gem 'delayed_job_active_record', '~> 4.1'
 
     gem 'mime-types', '~> 3.1'
+
+    # i18n 2+ supports only Ruby 2.3+.
+    gem 'i18n', '~> 1.5'
   end
 
   appraise 'rails-5.2' do
@@ -77,6 +83,9 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
     gem 'delayed_job_active_record', '~> 4.1'
 
     gem 'mime-types', '~> 3.1'
+
+    # i18n 2+ supports only Ruby 2.3+.
+    gem 'i18n', '~> 1.5'
   end
 end
 

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -12,5 +12,6 @@ gem "resque", "~> 1.25.2"
 gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job_active_record", "~> 4.1.0"
 gem "mime-types", "~> 3.1"
+gem "i18n", "~> 1.5"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -13,5 +13,6 @@ gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job", github: "collectiveidea/delayed_job"
 gem "delayed_job_active_record", "~> 4.1"
 gem "mime-types", "~> 3.1"
+gem "i18n", "~> 1.5"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -12,5 +12,6 @@ gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job", github: "collectiveidea/delayed_job"
 gem "delayed_job_active_record", "~> 4.1"
 gem "mime-types", "~> 3.1"
+gem "i18n", "~> 1.5"
 
 gemspec path: "../"


### PR DESCRIPTION
i18n doesn't support Rubies below 2.3 anymore:
https://github.com/ruby-i18n/i18n/commit/213641fe9a0c8f59c5b7d57b2e437d9cf4cfc825