### PR TITLE
Rails: log to airbrake.log from now on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Airbrake Changelog
   It configures the amount of allowed job retries that won't trigger an Airbrake
   notification. After it's exhausted, Airbrake will start sending errors again
   ([#979](https://github.com/airbrake/airbrake/pull/979))
+* Rails: started logging to `airbrake.log` by default. This affects only new
+  Rails apps. Apps that already use Airbrake have to update the logger manually
+  (not mandatory). Please consult README for instructions
+  ([#986](https://github.com/airbrake/airbrake/pull/986))
+* Added support for `RAILS_LOG_TO_STDOUT`. This variable redirects all Airbrake
+  logging to STDOUT, despite the configured logger
+  ([#986](https://github.com/airbrake/airbrake/pull/986))
 
 ### [v9.3.0][v9.3.0] (June 25, 2019)
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,6 @@ Consult the
 [example application](https://github.com/kyrylo/airbrake-ruby-issue108), which
 was created to show how to configure `filter_parameters`.
 
-
 ##### filter_parameters dot notation warning
 
 The dot notation introduced in [rails/pull/13897][rails-13897] for
@@ -183,6 +182,28 @@ The dot notation introduced in [rails/pull/13897][rails-13897] for
 performance reasons. Instead, simply specify the `code` key. If you have a
 strong opinion on this, leave a comment in
 the [dedicated issue][rails-sub-keys].
+
+##### Logging
+
+In new Rails apps, by default, all the Airbrake logs are written into
+`log/airbrake.log`. In older versions we used to write to wherever
+`Rails.logger` writes. If you wish to upgrade your app to the new behaviour,
+please configure your logger the following way:
+
+```ruby
+c.logger =
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
+    Logger.new(STDOUT, level: Rails.logger.level)
+  else
+    Logger.new(
+      File.join(Rails.root, 'log', 'airbrake.log', level: Rails.logger.level)
+    )
+  end
+```
+
+Note the `RAILS_LOG_TO_STDOUT` environment variable. This variable is supported
+by Rails 5+ only. When set, it would redirect all `Rails.logger` (and
+`Airbrake.logger`) output to STDOUT, despite the configured logger.
 
 ### Sinatra
 

--- a/lib/generators/airbrake_initializer.rb.erb
+++ b/lib/generators/airbrake_initializer.rb.erb
@@ -33,7 +33,10 @@ Airbrake.configure do |c|
   # By default, Airbrake Ruby outputs to STDOUT. In Rails apps it makes sense to
   # use the Rails' logger.
   # https://github.com/airbrake/airbrake-ruby#logger
-  c.logger = Rails.logger
+  c.logger = Logger.new(
+    File.join(Rails.root, 'log', 'airbrake.log'),
+    level: Rails.logger.level
+  )
 
   # Configures the environment the application is running in. Helps the Airbrake
   # dashboard to distinguish between exceptions occurring in different

--- a/lib/generators/airbrake_initializer.rb.erb
+++ b/lib/generators/airbrake_initializer.rb.erb
@@ -33,10 +33,15 @@ Airbrake.configure do |c|
   # By default, Airbrake Ruby outputs to STDOUT. In Rails apps it makes sense to
   # use the Rails' logger.
   # https://github.com/airbrake/airbrake-ruby#logger
-  c.logger = Logger.new(
-    File.join(Rails.root, 'log', 'airbrake.log'),
-    level: Rails.logger.level
-  )
+  c.logger =
+    if ENV['RAILS_LOG_TO_STDOUT'].present?
+      Logger.new(STDOUT, level: Rails.logger.level)
+    else
+      Logger.new(
+        File.join(Rails.root, 'log', 'airbrake.log'),
+        level: Rails.logger.level
+      )
+    end
 
   # Configures the environment the application is running in. Helps the Airbrake
   # dashboard to distinguish between exceptions occurring in different


### PR DESCRIPTION
With [`performance_stats = true`][1] Airbrake generates a lot of logs now. This
causes some inconvenience in the development environment because Rails uses
`debug` severity for its logger.

We don't have a lot of places where we log but we do log frequently (on every
request we log performance data for that request). Simply removing that debug
output would solve the issue but we need it so we can debug the library.

The best decision would be using a separate file, where we can be noisy without
annoying our users. If we ever need that debug output, we can ask the users to
check `airbrake.log`.

---

* generators/airbrake_initializer: support RAILS_LOG_TO_STDOUT 

`RAILS_LOG_TO_STDOUT` was added in rails/rails@4a836dc

This variable is pretty much self-documenting, so all I have to say is that it
would be nice to support it as well.

[1]: https://github.com/airbrake/airbrake-ruby/pull/485