### PR TITLE
generators/airbrake_initializer: be Rubocop Rails compatible

### DIFF
--- a/lib/generators/airbrake_initializer.rb.erb
+++ b/lib/generators/airbrake_initializer.rb.erb
@@ -38,7 +38,7 @@ Airbrake.configure do |c|
       Logger.new(STDOUT, level: Rails.logger.level)
     else
       Logger.new(
-        File.join(Rails.root, 'log', 'airbrake.log'),
+        Rails.root.join('log', 'airbrake.log'),
         level: Rails.logger.level
       )
     end


### PR DESCRIPTION
When I ran Rubocop Rails cops against this file, it showed me a warning and
suggested to use `Rails.root.join`. We want to be compatible with that since
people who use Rubocop in their apps will likely complain about this.