### PR TITLE
rails: install the ActiveRecord hook only when `query_stats = true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Airbrake Changelog
 
 ### master
 
+* Started depending on airbrake-ruby
+  [v4.6.0](https://github.com/airbrake/airbrake-ruby/releases/tag/v4.6.0) and
+  higher ([#982](https://github.com/airbrake/airbrake/pull/982))
+* Disabled SQL query collection by default because it's in alpha
+  ([#982](https://github.com/airbrake/airbrake/pull/982))
+
 ### [v9.4.0][v9.4.0] (July 29, 2019)
 
 * Added the new `max_retries` optional parameter to

--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -30,7 +30,7 @@ DESC
 
   s.required_ruby_version = '>= 2.1'
 
-  s.add_dependency 'airbrake-ruby', '~> 4.5'
+  s.add_dependency 'airbrake-ruby', '~> 4.6'
 
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rspec-wait', '~> 0'

--- a/lib/airbrake/rails.rb
+++ b/lib/airbrake/rails.rb
@@ -99,7 +99,7 @@ module Airbrake
           require 'airbrake/rails/active_record'
           include Airbrake::Rails::ActiveRecord
 
-          if defined?(ActiveRecord) && Airbrake::Config.instance.performance_stats
+          if defined?(ActiveRecord) && Airbrake::Config.instance.query_stats
             # Send SQL queries.
             require 'airbrake/rails/active_record_subscriber'
             ActiveSupport::Notifications.subscribe(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,7 @@ Airbrake.configure do |c|
   c.workers = 5
   c.performance_stats = true
   c.performance_stats_flush_period = 1
+  c.query_stats = true
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
Likely fixes:

* #994 (Memory usage)
* #990 (Add support for Rails engine route prefixes)

More details in airbrake/airbrake-ruby#495. In short,
this disables SQL query collection by default and allows enabling it only for
certain accounts.