### PR TITLE
rails/app: detect and attach engine name to routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Rails: engine routes are now being marked with the engine name prefix
+  ([#997](https://github.com/airbrake/airbrake/pull/997))
+
 ### [v9.4.1][v9.4.1] (August 5, 2019)
 
 * Started depending on airbrake-ruby

--- a/lib/airbrake/rails/app.rb
+++ b/lib/airbrake/rails/app.rb
@@ -8,25 +8,35 @@ module Airbrake
       Route = Struct.new(:path, :controller, :action)
 
       def routes
-        @routes ||= [*app_routes, *engine_routes].map do |route|
-          Route.new(
-            route.path.spec.to_s,
-            route.defaults[:controller],
-            route.defaults[:action]
-          )
+        @routes ||= app_routes.merge(engine_routes).flat_map do |(engine_name, routes)|
+          routes.map { |rails_route| build_route(engine_name, rails_route) }
         end
       end
 
       private
 
       def app_routes
-        ::Rails.application.routes.routes.routes
+        # Engine name is nil because this is default (non-engine) routes.
+        { nil => ::Rails.application.routes.routes.routes }
       end
 
       def engine_routes
-        ::Rails::Engine.subclasses.flat_map do |engine|
-          engine.routes.routes.routes
+        ::Rails::Engine.subclasses.flat_map.with_object({}) do |engine, hash|
+          next if (eng_routes = engine.routes.routes.routes).none?
+
+          hash[engine.engine_name] = eng_routes
         end
+      end
+
+      def build_route(engine_name, rails_route)
+        engine_prefix = engine_name
+        engine_prefix += '#' if engine_prefix
+
+        Route.new(
+          "#{engine_prefix}#{rails_route.path.spec}",
+          rails_route.defaults[:controller],
+          rails_route.defaults[:action]
+        )
       end
     end
   end


### PR DESCRIPTION
Fixes #988 (Add support for Rails engine route prefixes)