### PR TITLE
rails/event: report unauthorized access routes as 401 instead of 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Rails: report unauthorized requests properly. Instead of 0 HTTP code the
+  library sends 401 now ([#997](https://github.com/airbrake/airbrake/pull/997))
+
 ### [v9.4.2][v9.4.2] (August 7, 2019)
 
 * Rails: engine routes are now being marked with the engine name prefix

--- a/lib/airbrake/rails/event.rb
+++ b/lib/airbrake/rails/event.rb
@@ -66,11 +66,13 @@ module Airbrake
           return status
         end
 
-        logger.error do
-          "#{Airbrake::LOG_LABEL} unknown status code for: #{@event.payload}"
-        end
-
-        0
+        # The ActiveSupport event doesn't have status only in two cases:
+        #   - an exception was thrown
+        #   - unauthorized access
+        # We have already handled the exception so what's left is unauthorized
+        # access. There's no way to know for sure it's unauthorized access, so
+        # we are rather optimistic here.
+        401
       end
 
       def duration


### PR DESCRIPTION
Fixes #991 (Airbrake: got status_code=0, wanted >=200 and <600)

The ActiveSupport event doesn't have status only in two cases:
  - an exception was thrown
  - unauthorized access

We have already handled the exception so what's left is unauthorized
access. There's no way to know for sure it's unauthorized access, so
we are rather optimistic here.