### PR TITLE
rails: fix broken 'airbrake:deploy'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ Airbrake Changelog
 
 ### master
 
+* Fixed broken `bundle exec rake airbrake:deploy`
+  ([#1003](https://github.com/airbrake/airbrake/pull/1003))
+* Introduced `Airbrake::Rails.logger`, which replaces the old way of configuring
+  Rails apps. The logging setup becomes as simple as
+  ([#1003](https://github.com/airbrake/airbrake/pull/1003)):
+
+  ```ruby
+  c.logger = Airbrake::Rails.logger
+  ```
+
 ### [v9.4.3][v9.4.3] (August 8, 2019)
 
 * Rails: report unauthorized requests properly. Instead of 0 HTTP code the

--- a/README.md
+++ b/README.md
@@ -191,19 +191,8 @@ In new Rails apps, by default, all the Airbrake logs are written into
 please configure your logger the following way:
 
 ```ruby
-c.logger =
-  if ENV['RAILS_LOG_TO_STDOUT'].present?
-    Logger.new(STDOUT, level: Rails.logger.level)
-  else
-    Logger.new(
-      File.join(Rails.root, 'log', 'airbrake.log'), level: Rails.logger.level
-    )
-  end
+c.logger = Airbrake::Rails.logger
 ```
-
-Note the `RAILS_LOG_TO_STDOUT` environment variable. This variable is supported
-by Rails 5+ only. When set, it would redirect all `Rails.logger` (and
-`Airbrake.logger`) output to STDOUT, despite the configured logger.
 
 ### Sinatra
 

--- a/lib/airbrake/rails.rb
+++ b/lib/airbrake/rails.rb
@@ -1,140 +1,19 @@
+require 'airbrake/rails/railtie'
+
 module Airbrake
+  # Rails namespace holds all Rails-related functionality.
   module Rails
-    # This railtie works for any Rails application that supports railties (Rails
-    # 3.2+ apps). It makes Airbrake Ruby work with Rails and report errors
-    # occurring in the application automatically.
-    class Railtie < ::Rails::Railtie
-      initializer('airbrake.middleware') do |app|
-        # Since Rails 3.2 the ActionDispatch::DebugExceptions middleware is
-        # responsible for logging exceptions and showing a debugging page in
-        # case the request is local. We want to insert our middleware after
-        # DebugExceptions, so we don't notify Airbrake about local requests.
+    def self.logger
+      if ENV['RAILS_LOG_TO_STDOUT'].present?
+        Logger.new(STDOUT, level: ::Rails.logger.level)
+      else
+        Logger.new(
+          ::Rails.root.join('log', 'airbrake.log'),
 
-        if ::Rails.version.to_i >= 5
-          # Avoid the warning about deprecated strings.
-          # Insert after DebugExceptions, since ConnectionManagement doesn't
-          # exist in Rails 5 anymore.
-          app.config.middleware.insert_after(
-            ActionDispatch::DebugExceptions,
-            Airbrake::Rack::Middleware
-          )
-        elsif defined?(::ActiveRecord::ConnectionAdapters::ConnectionManagement)
-          # Insert after ConnectionManagement to avoid DB connection leakage:
-          # https://github.com/airbrake/airbrake/pull/568
-          app.config.middleware.insert_after(
-            ::ActiveRecord::ConnectionAdapters::ConnectionManagement,
-            'Airbrake::Rack::Middleware'
-          )
-        else
-          # Insert after DebugExceptions for apps without ActiveRecord.
-          app.config.middleware.insert_after(
-            ActionDispatch::DebugExceptions,
-            'Airbrake::Rack::Middleware'
-          )
-        end
-      end
-
-      rake_tasks do
-        # Report exceptions occurring in Rake tasks.
-        require 'airbrake/rake'
-
-        # Defines tasks such as `airbrake:test` & `airbrake:deploy`.
-        require 'airbrake/rake/tasks'
-      end
-
-      # rubocop:disable Metrics/BlockLength
-      initializer('airbrake.action_controller') do
-        ActiveSupport.on_load(:action_controller) do
-          # Patches ActionController with methods that allow us to retrieve
-          # interesting request data. Appends that information to notices.
-          require 'airbrake/rails/action_controller'
-          include Airbrake::Rails::ActionController
-
-          if Airbrake::Config.instance.performance_stats
-            # Cache route information for the duration of the request.
-            require 'airbrake/rails/action_controller_route_subscriber'
-            ActiveSupport::Notifications.subscribe(
-              'start_processing.action_controller',
-              Airbrake::Rails::ActionControllerRouteSubscriber.new
-            )
-
-            # Send route stats.
-            require 'airbrake/rails/action_controller_notify_subscriber'
-            ActiveSupport::Notifications.subscribe(
-              'process_action.action_controller',
-              Airbrake::Rails::ActionControllerNotifySubscriber.new
-            )
-
-            # Send performance breakdown: where a request spends its time.
-            require 'airbrake/rails/action_controller_performance_breakdown_subscriber'
-            ActiveSupport::Notifications.subscribe(
-              'process_action.action_controller',
-              Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber.new
-            )
-
-            require 'airbrake/rails/net_http' if defined?(Net) && defined?(Net::HTTP)
-
-            if defined?(Curl) && defined?(Curl::CURB_VERSION)
-              require 'airbrake/rails/curb'
-            end
-
-            require 'airbrake/rails/http' if defined?(HTTP) && defined?(HTTP::Client)
-            require 'airbrake/rails/http_client' if defined?(HTTPClient)
-            require 'airbrake/rails/typhoeus' if defined?(Typhoeus)
-
-            if defined?(Excon)
-              require 'airbrake/rails/excon_subscriber'
-              ActiveSupport::Notifications.subscribe(/excon/, Airbrake::Rails::Excon.new)
-              ::Excon.defaults[:instrumentor] = ActiveSupport::Notifications
-            end
-          end
-        end
-      end
-      # rubocop:enable Metrics/BlockLength
-
-      initializer('airbrake.active_record') do
-        ActiveSupport.on_load(:active_record) do
-          # Reports exceptions occurring in some bugged ActiveRecord callbacks.
-          # Applicable only to the versions of Rails lower than 4.2.
-          require 'airbrake/rails/active_record'
-          include Airbrake::Rails::ActiveRecord
-
-          if defined?(ActiveRecord) && Airbrake::Config.instance.query_stats
-            # Send SQL queries.
-            require 'airbrake/rails/active_record_subscriber'
-            ActiveSupport::Notifications.subscribe(
-              'sql.active_record', Airbrake::Rails::ActiveRecordSubscriber.new
-            )
-
-            # Filter out parameters from SQL body.
-            Airbrake.add_performance_filter(
-              Airbrake::Filters::SqlFilter.new(
-                ::ActiveRecord::Base.connection_config[:adapter]
-              )
-            )
-          end
-        end
-      end
-
-      initializer('airbrake.active_job') do
-        ActiveSupport.on_load(:active_job) do
-          # Reports exceptions occurring in ActiveJob jobs.
-          require 'airbrake/rails/active_job'
-          include Airbrake::Rails::ActiveJob
-        end
-      end
-
-      initializer('airbrake.action_cable') do
-        ActiveSupport.on_load(:action_cable) do
-          # Reports exceptions occurring in ActionCable connections.
-          require 'airbrake/rails/action_cable'
-        end
-      end
-
-      runner do
-        at_exit do
-          Airbrake.notify_sync($ERROR_INFO) if $ERROR_INFO
-        end
+          # Rails.logger is not set in some Rake tasks such as
+          # 'airbrake:deploy'. In this case we use a sensible fallback.
+          level: (::Rails.logger ? ::Rails.logger.level : Logger::ERROR)
+        )
       end
     end
   end

--- a/lib/airbrake/rails/railtie.rb
+++ b/lib/airbrake/rails/railtie.rb
@@ -1,0 +1,141 @@
+module Airbrake
+  module Rails
+    # This railtie works for any Rails application that supports railties (Rails
+    # 3.2+ apps). It makes Airbrake Ruby work with Rails and report errors
+    # occurring in the application automatically.
+    class Railtie < ::Rails::Railtie
+      initializer('airbrake.middleware') do |app|
+        # Since Rails 3.2 the ActionDispatch::DebugExceptions middleware is
+        # responsible for logging exceptions and showing a debugging page in
+        # case the request is local. We want to insert our middleware after
+        # DebugExceptions, so we don't notify Airbrake about local requests.
+
+        if ::Rails.version.to_i >= 5
+          # Avoid the warning about deprecated strings.
+          # Insert after DebugExceptions, since ConnectionManagement doesn't
+          # exist in Rails 5 anymore.
+          app.config.middleware.insert_after(
+            ActionDispatch::DebugExceptions,
+            Airbrake::Rack::Middleware
+          )
+        elsif defined?(::ActiveRecord::ConnectionAdapters::ConnectionManagement)
+          # Insert after ConnectionManagement to avoid DB connection leakage:
+          # https://github.com/airbrake/airbrake/pull/568
+          app.config.middleware.insert_after(
+            ::ActiveRecord::ConnectionAdapters::ConnectionManagement,
+            'Airbrake::Rack::Middleware'
+          )
+        else
+          # Insert after DebugExceptions for apps without ActiveRecord.
+          app.config.middleware.insert_after(
+            ActionDispatch::DebugExceptions,
+            'Airbrake::Rack::Middleware'
+          )
+        end
+      end
+
+      rake_tasks do
+        # Report exceptions occurring in Rake tasks.
+        require 'airbrake/rake'
+
+        # Defines tasks such as `airbrake:test` & `airbrake:deploy`.
+        require 'airbrake/rake/tasks'
+      end
+
+      # rubocop:disable Metrics/BlockLength
+      initializer('airbrake.action_controller') do
+        ActiveSupport.on_load(:action_controller) do
+          # Patches ActionController with methods that allow us to retrieve
+          # interesting request data. Appends that information to notices.
+          require 'airbrake/rails/action_controller'
+          include Airbrake::Rails::ActionController
+
+          if Airbrake::Config.instance.performance_stats
+            # Cache route information for the duration of the request.
+            require 'airbrake/rails/action_controller_route_subscriber'
+            ActiveSupport::Notifications.subscribe(
+              'start_processing.action_controller',
+              Airbrake::Rails::ActionControllerRouteSubscriber.new
+            )
+
+            # Send route stats.
+            require 'airbrake/rails/action_controller_notify_subscriber'
+            ActiveSupport::Notifications.subscribe(
+              'process_action.action_controller',
+              Airbrake::Rails::ActionControllerNotifySubscriber.new
+            )
+
+            # Send performance breakdown: where a request spends its time.
+            require 'airbrake/rails/action_controller_performance_breakdown_subscriber'
+            ActiveSupport::Notifications.subscribe(
+              'process_action.action_controller',
+              Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber.new
+            )
+
+            require 'airbrake/rails/net_http' if defined?(Net) && defined?(Net::HTTP)
+
+            if defined?(Curl) && defined?(Curl::CURB_VERSION)
+              require 'airbrake/rails/curb'
+            end
+
+            require 'airbrake/rails/http' if defined?(HTTP) && defined?(HTTP::Client)
+            require 'airbrake/rails/http_client' if defined?(HTTPClient)
+            require 'airbrake/rails/typhoeus' if defined?(Typhoeus)
+
+            if defined?(Excon)
+              require 'airbrake/rails/excon_subscriber'
+              ActiveSupport::Notifications.subscribe(/excon/, Airbrake::Rails::Excon.new)
+              ::Excon.defaults[:instrumentor] = ActiveSupport::Notifications
+            end
+          end
+        end
+      end
+      # rubocop:enable Metrics/BlockLength
+
+      initializer('airbrake.active_record') do
+        ActiveSupport.on_load(:active_record) do
+          # Reports exceptions occurring in some bugged ActiveRecord callbacks.
+          # Applicable only to the versions of Rails lower than 4.2.
+          require 'airbrake/rails/active_record'
+          include Airbrake::Rails::ActiveRecord
+
+          if defined?(ActiveRecord) && Airbrake::Config.instance.query_stats
+            # Send SQL queries.
+            require 'airbrake/rails/active_record_subscriber'
+            ActiveSupport::Notifications.subscribe(
+              'sql.active_record', Airbrake::Rails::ActiveRecordSubscriber.new
+            )
+
+            # Filter out parameters from SQL body.
+            Airbrake.add_performance_filter(
+              Airbrake::Filters::SqlFilter.new(
+                ::ActiveRecord::Base.connection_config[:adapter]
+              )
+            )
+          end
+        end
+      end
+
+      initializer('airbrake.active_job') do
+        ActiveSupport.on_load(:active_job) do
+          # Reports exceptions occurring in ActiveJob jobs.
+          require 'airbrake/rails/active_job'
+          include Airbrake::Rails::ActiveJob
+        end
+      end
+
+      initializer('airbrake.action_cable') do
+        ActiveSupport.on_load(:action_cable) do
+          # Reports exceptions occurring in ActionCable connections.
+          require 'airbrake/rails/action_cable'
+        end
+      end
+
+      runner do
+        at_exit do
+          Airbrake.notify_sync($ERROR_INFO) if $ERROR_INFO
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/airbrake_initializer.rb.erb
+++ b/lib/generators/airbrake_initializer.rb.erb
@@ -33,15 +33,7 @@ Airbrake.configure do |c|
   # By default, Airbrake Ruby outputs to STDOUT. In Rails apps it makes sense to
   # use the Rails' logger.
   # https://github.com/airbrake/airbrake-ruby#logger
-  c.logger =
-    if ENV['RAILS_LOG_TO_STDOUT'].present?
-      Logger.new(STDOUT, level: Rails.logger.level)
-    else
-      Logger.new(
-        Rails.root.join('log', 'airbrake.log'),
-        level: Rails.logger.level
-      )
-    end
+  c.logger = Airbrake::Rails.logger
 
   # Configures the environment the application is running in. Helps the Airbrake
   # dashboard to distinguish between exceptions occurring in different


### PR DESCRIPTION
The new suggested way to configure logger in Rails apps was added in pull
request #986. Unfortunately, there's an issue with it. We load the initialiser
on `bundle exec rake airbrake:deploy` and at this time `Rails.logger` is not
defined yet. Therefore, the deploys would fail in 100% of cases because of
NoMethodError.

To work around this issue we simply check for the existence of `Rails.logger`.
This change is simple. However, what I don't like is that we leak a lot of *our*
code to the user space. The users have to study how we setup logging. For the
sake of simplicity we want to avoid that and keep the config simple.

To achieve that, `Airbrake::Rails.logger` was added. It hides all the complexity
from the users. Probably the best part is that if users stumble upon another bug
in the logging setup, they won't need to update how the config works. Right now,
because of this bug, they have to touch their config again and this is an
oversight on my part.