### PR TITLE
Appraisals: lock i18n to '~> 1.4'

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -44,7 +44,7 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
     gem 'mime-types', '~> 3.1'
 
     # i18n 2+ supports only Ruby 2.3+.
-    gem 'i18n', '~> 1.5'
+    gem 'i18n', '~> 1.4'
   end
 
   appraise 'rails-5.1' do
@@ -64,7 +64,7 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
     gem 'mime-types', '~> 3.1'
 
     # i18n 2+ supports only Ruby 2.3+.
-    gem 'i18n', '~> 1.5'
+    gem 'i18n', '~> 1.4'
   end
 
   appraise 'rails-5.2' do
@@ -85,7 +85,7 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
     gem 'mime-types', '~> 3.1'
 
     # i18n 2+ supports only Ruby 2.3+.
-    gem 'i18n', '~> 1.5'
+    gem 'i18n', '~> 1.4'
   end
 end
 


### PR DESCRIPTION
i18n doesn't support Ruby 2.2 but we still do. Our build has started failing
because of this: https://circleci.com/gh/airbrake/airbrake/6226