### PR TITLE
circle: actually test against Rails 5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ references:
     run:
       name: Test Rails 4.2
       command: bundle exec appraisal rails-4.2 rake spec:integration:rails
-  rails41: &rails50
+  rails50: &rails50
     run:
       name: Test Rails 5.0
       command: bundle exec appraisal rails-5.0 rake spec:integration:rails
@@ -88,6 +88,7 @@ jobs:
       - <<: *unit
       - <<: *rails32
       - <<: *rails42
+      - <<: *rails50
       - <<: *rails51
       - <<: *rails52
       - <<: *sinatra
@@ -103,6 +104,7 @@ jobs:
       - <<: *unit
       - <<: *rails32
       - <<: *rails42
+      - <<: *rails50
       - <<: *rails51
       - <<: *rails52
       - <<: *sinatra
@@ -118,6 +120,7 @@ jobs:
       - <<: *unit
       - <<: *rails32
       - <<: *rails42
+      - <<: *rails50
       - <<: *rails51
       - <<: *rails52
       - <<: *sinatra
@@ -148,6 +151,7 @@ jobs:
       - <<: *unit
       - <<: *rails32
       - <<: *rails42
+      - <<: *rails50
       - <<: *rails51
       - <<: *rails52
       - <<: *sinatra

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -12,6 +12,6 @@ gem "resque", "~> 1.25.2"
 gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job_active_record", "~> 4.1.0"
 gem "mime-types", "~> 3.1"
-gem "i18n", "~> 1.5"
+gem "i18n", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -13,6 +13,6 @@ gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job", github: "collectiveidea/delayed_job"
 gem "delayed_job_active_record", "~> 4.1"
 gem "mime-types", "~> 3.1"
-gem "i18n", "~> 1.5"
+gem "i18n", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -12,6 +12,6 @@ gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job", github: "collectiveidea/delayed_job"
 gem "delayed_job_active_record", "~> 4.1"
 gem "mime-types", "~> 3.1"
-gem "i18n", "~> 1.5"
+gem "i18n", "~> 1.4"
 
 gemspec path: "../"


### PR DESCRIPTION
Looks like we forgot to include the Rails 5.0 step.

Note that we don't test on JRuby because of a bug in activerecrod-jdbc-adapter.
https://github.com/jruby/activerecord-jdbc-adapter/issues/700