### PR TITLE
circle: test Rails v4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,10 @@ references:
     run:
       name: Test Rails 3.2
       command: bundle exec appraisal rails-3.2 rake spec:integration:rails
+  rails41: &rails41
+    run:
+      name: Test Rails 4.1
+      command: bundle exec appraisal rails-4.1 rake spec:integration:rails
   rails42: &rails42
     run:
       name: Test Rails 4.2
@@ -71,6 +75,7 @@ jobs:
       - <<: *appraisal_install
       - <<: *unit
       - <<: *rails32
+      - <<: *rails41
       - <<: *rails42
       - <<: *sinatra
       - <<: *rack
@@ -87,6 +92,7 @@ jobs:
       - <<: *appraisal_install
       - <<: *unit
       - <<: *rails32
+      - <<: *rails41
       - <<: *rails42
       - <<: *rails50
       - <<: *rails51
@@ -103,6 +109,7 @@ jobs:
       - <<: *appraisal_install
       - <<: *unit
       - <<: *rails32
+      - <<: *rails41
       - <<: *rails42
       - <<: *rails50
       - <<: *rails51

--- a/Appraisals
+++ b/Appraisals
@@ -11,6 +11,21 @@ appraise 'rails-3.2' do
   gem 'delayed_job_active_record', '~> 4.1.0'
 end
 
+appraise 'rails-4.1' do
+  gem 'rails', '~> 4.1.16'
+  gem 'warden', '~> 1.2.3'
+
+  gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.18', platforms: :jruby
+  gem 'sqlite3', '~> 1.3.11', platforms: %i[mri rbx]
+
+  gem 'resque', '~> 1.25.2'
+  gem 'resque_spec', github: 'airbrake/resque_spec'
+
+  gem 'delayed_job_active_record', '~> 4.1.0'
+
+  gem 'mime-types', '~> 3.1'
+end
+
 appraise 'rails-4.2' do
   gem 'rails', '~> 4.2.10'
   gem 'warden', '~> 1.2.3'

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "rubocop", "= 0.51", require: false
-gem "rails", "~> 4.1.13"
+gem "rubocop", "= 0.55", require: false
+gem "rails", "~> 4.1.16"
 gem "warden", "~> 1.2.3"
 gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.18", platforms: :jruby
 gem "sqlite3", "~> 1.3.11", platforms: [:mri, :rbx]


### PR DESCRIPTION
It turns out some customers still use Rails v4.1. I decided to add it back to
the build matrix, so that we can be sure we still support it. We are not
building it on JRuby, 2.6 and 2.4 due to segfaults. It's not really worth
spending time on figuring out why it happens, since other Rubies pass just
fine.