### PR TITLE
rails/action_controller: pass block along with standard arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Airbrake Changelog
   ```
 * Exceptions occurring in `current_user` no longer crash the library
   ([#1007](https://github.com/airbrake/airbrake/pull/1007))
+* Rails controller helpers started supporting the block argument for notifying
+  ([#1010](https://github.com/airbrake/airbrake/pull/1010))
 
 ### [v9.4.3][v9.4.3] (August 8, 2019)
 

--- a/lib/airbrake/rails/action_controller.rb
+++ b/lib/airbrake/rails/action_controller.rb
@@ -10,17 +10,17 @@ module Airbrake
       # A helper method for sending notices to Airbrake *asynchronously*.
       # Attaches information from the Rack env.
       # @see Airbrake#notify, #notify_airbrake_sync
-      def notify_airbrake(exception, params = {})
+      def notify_airbrake(exception, params = {}, &block)
         return unless (notice = build_notice(exception, params))
-        Airbrake.notify(notice, params)
+        Airbrake.notify(notice, params, &block)
       end
 
       # A helper method for sending notices to Airbrake *synchronously*.
       # Attaches information from the Rack env.
       # @see Airbrake#notify_sync, #notify_airbrake
-      def notify_airbrake_sync(exception, params = {})
+      def notify_airbrake_sync(exception, params = {}, &block)
         return unless (notice = build_notice(exception, params))
-        Airbrake.notify_sync(notice, params)
+        Airbrake.notify_sync(notice, params, &block)
       end
 
       # @param [Exception] exception


### PR DESCRIPTION
Fixes #1008 (Helpers should pass provided blocks on to Airbrake.notify)