### PR TITLE
rails/action_controller_route_subscriber: reduce allocations

### DIFF
--- a/lib/airbrake/rails/action_controller_route_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_route_subscriber.rb
@@ -3,6 +3,12 @@ require 'airbrake/rails/app'
 
 module Airbrake
   module Rails
+    # @return [String]
+    CONTROLLER_KEY = 'controller'.freeze
+
+    # @return [String]
+    ACTION_KEY = 'action'.freeze
+
     # ActionControllerRouteSubscriber sends route stat information, including
     # performance data.
     #
@@ -31,8 +37,8 @@ module Airbrake
 
       def find_route(params)
         @app.routes.find do |route|
-          route.controller == params['controller'] &&
-            route.action == params['action']
+          route.controller == params[CONTROLLER_KEY] &&
+            route.action == params[ACTION_KEY]
         end
       end
     end


### PR DESCRIPTION
The `memory_profiler` gem reports that Ruby allocates 22.6 Kb just for the
'controller' string. Since this code path is critical, we want to squeeze out
the best performance we can achieve. Making the keys constant reduces
allocations to zero.