### PR TITLE
gemspec: lock sprockets to '~> 3.7'

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -9,6 +9,7 @@ appraise 'rails-3.2' do
   gem 'resque_spec', github: 'airbrake/resque_spec'
 
   gem 'delayed_job_active_record', '~> 4.1.0'
+  gem 'sprockets', '~> 2.2'
 end
 
 appraise 'rails-4.1' do
@@ -24,6 +25,7 @@ appraise 'rails-4.1' do
   gem 'delayed_job_active_record', '~> 4.1.0'
 
   gem 'mime-types', '~> 3.1'
+  gem 'sprockets', '~> 3.7'
 end
 
 appraise 'rails-4.2' do
@@ -39,6 +41,7 @@ appraise 'rails-4.2' do
   gem 'delayed_job_active_record', '~> 4.1.0'
 
   gem 'mime-types', '~> 3.1'
+  gem 'sprockets', '~> 3.7'
 end
 
 # Rails 5+ supports only modern Rubies (2.2.2+)
@@ -60,6 +63,8 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
 
     # i18n 2+ supports only Ruby 2.3+.
     gem 'i18n', '~> 1.4'
+
+    gem 'sprockets', '~> 3.7'
   end
 
   appraise 'rails-5.1' do
@@ -80,6 +85,8 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
 
     # i18n 2+ supports only Ruby 2.3+.
     gem 'i18n', '~> 1.4'
+
+    gem 'sprockets', '~> 3.7'
   end
 
   appraise 'rails-5.2' do

--- a/gemfiles/rails_3.2.gemfile
+++ b/gemfiles/rails_3.2.gemfile
@@ -10,5 +10,6 @@ gem "sqlite3", "~> 1.3.11", platforms: [:mri, :rbx]
 gem "resque", "~> 1.25.2"
 gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job_active_record", "~> 4.1.0"
+gem "sprockets", "~> 2.2"
 
 gemspec path: "../"

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -11,5 +11,6 @@ gem "resque", "~> 1.25.2"
 gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job_active_record", "~> 4.1.0"
 gem "mime-types", "~> 3.1"
+gem "sprockets", "~> 3.7"
 
 gemspec path: "../"

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -11,5 +11,6 @@ gem "resque", "~> 1.25.2"
 gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job_active_record", "~> 4.1.0"
 gem "mime-types", "~> 3.1"
+gem "sprockets", "~> 3.7"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -13,5 +13,6 @@ gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job_active_record", "~> 4.1.0"
 gem "mime-types", "~> 3.1"
 gem "i18n", "~> 1.4"
+gem "sprockets", "~> 3.7"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -14,5 +14,6 @@ gem "delayed_job", github: "collectiveidea/delayed_job"
 gem "delayed_job_active_record", "~> 4.1"
 gem "mime-types", "~> 3.1"
 gem "i18n", "~> 1.4"
+gem "sprockets", "~> 3.7"
 
 gemspec path: "../"


### PR DESCRIPTION
Sprockets 4.0 requires Ruby 2.5+, which is way too radical for us.