### PR TITLE
rails/railtie: do not include the `after_commit` patch on Rails 5+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Changelog
 
 ### master
 
+* Rails: Stopped including the `after_commit` ActiveRecord patch for Rails
+  versions above 4.2 (because they are irrelevant ant cause buggy behaviour)
+  ([#1023](https://github.com/airbrake/airbrake/pull/1023))
+
 ### [v9.5.0][v9.5.0] (October 23, 2019)
 
 * Started depending on airbrake-ruby

--- a/lib/airbrake/rails/railtie.rb
+++ b/lib/airbrake/rails/railtie.rb
@@ -96,8 +96,11 @@ module Airbrake
         ActiveSupport.on_load(:active_record, run_once: true) do
           # Reports exceptions occurring in some bugged ActiveRecord callbacks.
           # Applicable only to the versions of Rails lower than 4.2.
-          require 'airbrake/rails/active_record'
-          include Airbrake::Rails::ActiveRecord
+          if defined?(::Rails) &&
+             Gem::Version.new(::Rails.version) <= Gem::Version.new('4.2')
+            require 'airbrake/rails/active_record'
+            include Airbrake::Rails::ActiveRecord
+          end
 
           if defined?(ActiveRecord) && Airbrake::Config.instance.query_stats
             # Send SQL queries.

--- a/spec/integration/rails/rails_spec.rb
+++ b/spec/integration/rails/rails_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe "Rails integration specs" do
 
   describe(
     "Active Record callbacks",
-    skip: Gem::Version.new(Rails.version) < Gem::Version.new('5.1.0')
+    skip: Gem::Version.new(Rails.version) > Gem::Version.new('4.2')
   ) do
     it "reports exceptions in after_commit callbacks" do
       expect(Airbrake).to receive(:notify).with(


### PR DESCRIPTION
Fixes #1021 (Patch for Active Record < 4.2 causes unexpected behaviour on Rails
>= 5.1)