### PR TITLE
action_controller_route_subscriber: use "recognize" to find routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Airbrake Changelog
 * Rails: Stopped including the `after_commit` ActiveRecord patch for Rails
   versions above 4.2 (because they are irrelevant ant cause buggy behaviour)
   ([#1023](https://github.com/airbrake/airbrake/pull/1023))
+* Rails: improved support for route aliases. Fixed bug where an aliased route
+  would be reported as two separate routes. Now it is recognized as the same
+  route ([#1026](https://github.com/airbrake/airbrake/pull/1026))
 
 ### [v9.5.0][v9.5.0] (October 23, 2019)
 

--- a/lib/airbrake/rack/route_filter.rb
+++ b/lib/airbrake/rack/route_filter.rb
@@ -14,26 +14,13 @@ module Airbrake
 
         notice[:context][:route] =
           if action_dispatch_request?(request)
-            rails_route(request)
+            Airbrake::Rails::App.recognize_route(request)
           elsif sinatra_request?(request)
             sinatra_route(request)
           end
       end
 
       private
-
-      def rails_route(request)
-        ::Rails.application.routes.router.recognize(request) do |route, _parameters|
-          # Rails can recognize multiple routes for the given request. For
-          # example, if we visit /users/2/edit, then Rails sees these routes:
-          #   * "/users/:id/edit(.:format)"
-          #   *  "/"
-          #
-          # We return the first route as, what it seems, the most optimal
-          # approach.
-          return route.path.spec.to_s
-        end
-      end
 
       def sinatra_route(request)
         return unless (route = request.env['sinatra.route'])

--- a/lib/airbrake/rails/action_controller_route_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_route_subscriber.rb
@@ -23,23 +23,16 @@ module Airbrake
         return unless (routes = Airbrake::Rack::RequestStore[:routes])
 
         event = Airbrake::Rails::Event.new(*args)
-        route = find_route(event.params)
+        route = Airbrake::Rails::App.recognize_route(
+          Airbrake::Rack::RequestStore[:request]
+        )
         return unless route
 
-        routes[route.path] = {
+        routes[route] = {
           method: event.method,
           response_type: event.response_type,
           groups: {}
         }
-      end
-
-      private
-
-      def find_route(params)
-        @app.routes.find do |route|
-          route.controller == params[CONTROLLER_KEY] &&
-            route.action == params[ACTION_KEY]
-        end
       end
     end
   end

--- a/lib/airbrake/rails/app.rb
+++ b/lib/airbrake/rails/app.rb
@@ -7,6 +7,19 @@ module Airbrake
     class App
       Route = Struct.new(:path, :controller, :action)
 
+      def self.recognize_route(request)
+        ::Rails.application.routes.router.recognize(request) do |route, _parameters|
+          # Rails can recognize multiple routes for the given request. For
+          # example, if we visit /users/2/edit, then Rails sees these routes:
+          #   * "/users/:id/edit(.:format)"
+          #   *  "/"
+          #
+          # We return the first route as, what it seems, the most optimal
+          # approach.
+          return route.path.spec.to_s
+        end
+      end
+
       def routes
         @routes ||= app_routes.merge(engine_routes).flat_map do |(engine_name, routes)|
           routes.map { |rails_route| build_route(engine_name, rails_route) }

--- a/spec/unit/rails/action_controller_route_subscriber_spec.rb
+++ b/spec/unit/rails/action_controller_route_subscriber_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe Airbrake::Rails::ActionControllerRouteSubscriber do
 
       before do
         allow(app).to receive(:routes).and_return(routes)
-        allow(event).to receive(:params).and_return(params)
         allow(event).to receive(:method).and_return('HEAD')
         allow(event).to receive(:response_type).and_return(:html)
 
@@ -38,8 +37,9 @@ RSpec.describe Airbrake::Rails::ActionControllerRouteSubscriber do
       after { Airbrake::Rack::RequestStore.clear }
 
       context "and when the route can be found" do
-        let(:params) do
-          OpenStruct.new(controller: 'DummyController', action: 'crash')
+        before do
+          allow(Airbrake::Rails::App)
+            .to receive(:recognize_route).and_return('/crash')
         end
 
         it "stores a route in the request store under :routes" do
@@ -50,8 +50,8 @@ RSpec.describe Airbrake::Rails::ActionControllerRouteSubscriber do
       end
 
       context "and when the event controller can't be found" do
-        let(:params) do
-          OpenStruct.new(controller: 'BananaController', action: 'crash')
+        before do
+          allow(Airbrake::Rails::App).to receive(:recognize_route).and_return(nil)
         end
 
         it "doesn't store any routes in the request store under :routes" do
@@ -61,8 +61,8 @@ RSpec.describe Airbrake::Rails::ActionControllerRouteSubscriber do
       end
 
       context "and when the event action can't be found" do
-        let(:params) do
-          OpenStruct.new(controller: 'DummyController', action: 'banana')
+        before do
+          allow(Airbrake::Rails::App).to receive(:recognize_route).and_return(nil)
         end
 
         it "doesn't store any routes in the request store under :routes" do


### PR DESCRIPTION
The library uses two different ways for route identification:

* the first way is to use Rails' `recognize` API (used in `Rack::RouteFilter`)
* the second way is to compare controller and action
  (used in `ActionControllerRouteSubscriber`)

This approach causes troubles for apps that define routes the following way:

```
get '/billing/edit', to: 'accounts#edit'
```

`Rack::RouteFilter` would find route `/account/edit` while
`ActionControllerRouteSubscriber` would find `/billing/edit`.

This is unwanted because Airbrake will think these are two separate routes while
in reality it's the same route (just aliased).

In this fix we unify the approach of route identification and use a more stable
API provided by Rails ("recognize"). The additional benefit is that we no longer
need to worry about route's params (because they're handled by Rails' APIs):

```
get '/billing/edit', to: 'accounts#edit', tab: 'settings'
```