### PR TITLE
action_controller_route_subscriber: fix support for engine routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Rails: fixed engine support for routes which became broken since v9.5.1
+  ([#1028](https://github.com/airbrake/airbrake/pull/1028))
+
 ### [v9.5.1][v9.5.1] (November 25, 2019)
 
 * Rails: Stopped including the `after_commit` ActiveRecord patch for Rails

--- a/lib/airbrake/rack/route_filter.rb
+++ b/lib/airbrake/rack/route_filter.rb
@@ -14,13 +14,18 @@ module Airbrake
 
         notice[:context][:route] =
           if action_dispatch_request?(request)
-            Airbrake::Rails::App.recognize_route(request)
+            rails_route(request)
           elsif sinatra_request?(request)
             sinatra_route(request)
           end
       end
 
       private
+
+      def rails_route(request)
+        return unless (route = Airbrake::Rails::App.recognize_route(request))
+        route.path.spec.to_s
+      end
 
       def sinatra_route(request)
         return unless (route = request.env['sinatra.route'])

--- a/lib/airbrake/rails/action_controller_route_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_route_subscriber.rb
@@ -3,21 +3,11 @@ require 'airbrake/rails/app'
 
 module Airbrake
   module Rails
-    # @return [String]
-    CONTROLLER_KEY = 'controller'.freeze
-
-    # @return [String]
-    ACTION_KEY = 'action'.freeze
-
     # ActionControllerRouteSubscriber sends route stat information, including
     # performance data.
     #
     # @since v8.0.0
     class ActionControllerRouteSubscriber
-      def initialize
-        @app = Airbrake::Rails::App.new
-      end
-
       def call(*args)
         # We don't track routeless events.
         return unless (routes = Airbrake::Rack::RequestStore[:routes])
@@ -28,11 +18,19 @@ module Airbrake
         )
         return unless route
 
-        routes[route] = {
+        routes[find_route_name(route)] = {
           method: event.method,
           response_type: event.response_type,
           groups: {}
         }
+      end
+
+      def find_route_name(route)
+        if route.app.respond_to?(:app) && route.app.app.respond_to?(:engine_name)
+          "#{route.app.app.engine_name}##{route.path.spec}"
+        else
+          route.path.spec.to_s
+        end
       end
     end
   end

--- a/lib/airbrake/rails/app.rb
+++ b/lib/airbrake/rails/app.rb
@@ -1,14 +1,12 @@
 module Airbrake
   module Rails
-    # App is a wrapper around Rails.application and Rails::Engine.
+    # App is a wrapper around Rails.application.
     #
     # @since v9.0.3
     # @api private
     class App
-      Route = Struct.new(:path, :controller, :action)
-
       def self.recognize_route(request)
-        ::Rails.application.routes.router.recognize(request) do |route, _parameters|
+        ::Rails.application.routes.router.recognize(request) do |route, _params|
           # Rails can recognize multiple routes for the given request. For
           # example, if we visit /users/2/edit, then Rails sees these routes:
           #   * "/users/:id/edit(.:format)"
@@ -16,40 +14,8 @@ module Airbrake
           #
           # We return the first route as, what it seems, the most optimal
           # approach.
-          return route.path.spec.to_s
+          return route
         end
-      end
-
-      def routes
-        @routes ||= app_routes.merge(engine_routes).flat_map do |(engine_name, routes)|
-          routes.map { |rails_route| build_route(engine_name, rails_route) }
-        end
-      end
-
-      private
-
-      def app_routes
-        # Engine name is nil because this is default (non-engine) routes.
-        { nil => ::Rails.application.routes.routes.routes }
-      end
-
-      def engine_routes
-        ::Rails::Engine.subclasses.flat_map.with_object({}) do |engine, hash|
-          next if (eng_routes = engine.routes.routes.routes).none?
-
-          hash[engine.engine_name] = eng_routes
-        end
-      end
-
-      def build_route(engine_name, rails_route)
-        engine_prefix = engine_name
-        engine_prefix += '#' if engine_prefix
-
-        Route.new(
-          "#{engine_prefix}#{rails_route.path.spec}",
-          rails_route.defaults[:controller],
-          rails_route.defaults[:action]
-        )
       end
     end
   end


### PR DESCRIPTION
v9.5.1 introduced a bug where engine routes would not be recognised
anymore. This is because the new algorithm for route finding doesn't query
cached routes anymore. Instead, it relies on Rails APIs, which don't provide
enigne by default. With a bit of tinkering we can restore engine support again.