### PR TITLE
rails/app: return nil when request is unrecognized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Rails APM: fixed bug when client sends a request that couldn't be tied to a
+  certain route ([#1032](https://github.com/airbrake/airbrake/issues/1032))
+
 ### [v9.5.3][v9.5.3] (November 27, 2019)
 
 * Fixed `uninitialized constant Airbrake::Rails::App`

--- a/lib/airbrake/rack/route_filter.rb
+++ b/lib/airbrake/rack/route_filter.rb
@@ -26,7 +26,7 @@ module Airbrake
 
       def rails_route(request)
         return unless (route = Airbrake::Rails::App.recognize_route(request))
-        route.path.spec.to_s
+        route.path
       end
 
       def sinatra_route(request)

--- a/lib/airbrake/rails/action_controller_route_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_route_subscriber.rb
@@ -18,19 +18,11 @@ module Airbrake
         )
         return unless route
 
-        routes[find_route_name(route)] = {
+        routes[route.path] = {
           method: event.method,
           response_type: event.response_type,
           groups: {}
         }
-      end
-
-      def find_route_name(route)
-        if route.app.respond_to?(:app) && route.app.app.respond_to?(:engine_name)
-          "#{route.app.app.engine_name}##{route.path.spec}"
-        else
-          route.path.spec.to_s
-        end
       end
     end
   end

--- a/lib/airbrake/rails/app.rb
+++ b/lib/airbrake/rails/app.rb
@@ -5,8 +5,19 @@ module Airbrake
     # @since v9.0.3
     # @api private
     class App
+      Route = Struct.new(:path)
+
+      # @param [] request
+      # @return [Airbrake::Rails::App::Route, nil]
       def self.recognize_route(request)
         ::Rails.application.routes.router.recognize(request) do |route, _params|
+          path =
+            if route.app.respond_to?(:app) && route.app.app.respond_to?(:engine_name)
+              "#{route.app.app.engine_name}##{route.path.spec}"
+            else
+              route.path.spec.to_s
+            end
+
           # Rails can recognize multiple routes for the given request. For
           # example, if we visit /users/2/edit, then Rails sees these routes:
           #   * "/users/:id/edit(.:format)"
@@ -14,8 +25,10 @@ module Airbrake
           #
           # We return the first route as, what it seems, the most optimal
           # approach.
-          return route
+          return Route.new(path)
         end
+
+        nil
       end
     end
   end

--- a/spec/unit/rails/action_controller_route_subscriber_spec.rb
+++ b/spec/unit/rails/action_controller_route_subscriber_spec.rb
@@ -33,34 +33,15 @@ RSpec.describe Airbrake::Rails::ActionControllerRouteSubscriber do
 
       context "and when the route can be found" do
         before do
-          route = double
-          allow(route).to receive_message_chain('app.app') { nil }
-          allow(route).to receive_message_chain('path.spec.to_s') { '/crash' }
-
-          allow(Airbrake::Rails::App).to receive(:recognize_route).and_return(route)
+          allow(Airbrake::Rails::App).to receive(:recognize_route).and_return(
+            Airbrake::Rails::App::Route.new('/crash')
+          )
         end
 
         it "stores a route in the request store under :routes" do
           subject.call(event_params)
           expect(Airbrake::Rack::RequestStore[:routes])
             .to eq('/crash' => { method: 'HEAD', response_type: :html, groups: {} })
-        end
-      end
-
-      context "and when the route belongs to an engine" do
-        before do
-          route = double
-          allow(route).to receive_message_chain('app.app.engine_name') { 'engine' }
-          allow(route).to receive_message_chain('path.spec.to_s') { '/crash' }
-
-          allow(Airbrake::Rails::App).to receive(:recognize_route).and_return(route)
-        end
-
-        it "stores a route in the request store under :routes with engine info" do
-          subject.call(event_params)
-          expect(Airbrake::Rack::RequestStore[:routes]).to eq(
-            'engine#/crash' => { method: 'HEAD', response_type: :html, groups: {} }
-          )
         end
       end
 


### PR DESCRIPTION
By returning nil explicitly we make sure that the code will not blow up in the
future if Rails' `recognize` decides to return something other than a
route (which happened to me locally on Rails 5 while I was testing something).

Additionaly, we return our own Route now (again), so that we don't leak Rails
code all over our codebase.