### PR TITLE
rails/app: duplicate request before recognising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Airbrake Changelog
 
 ### master
 
+### [v9.5.5][v9.5.5] (December 2, 2019)
+
+* Rails APM: fixed issue with engine links when the enigne has an isolated
+  namespace ([#1035](https://github.com/airbrake/airbrake/issues/1035))
+
 ### [v9.5.4][v9.5.4] (November 27, 2019)
 
 * Rails APM: fixed bug when client sends a request that couldn't be tied to a

--- a/lib/airbrake/rails/app.rb
+++ b/lib/airbrake/rails/app.rb
@@ -10,7 +10,10 @@ module Airbrake
       # @param [] request
       # @return [Airbrake::Rails::App::Route, nil]
       def self.recognize_route(request)
-        ::Rails.application.routes.router.recognize(request) do |route, _params|
+        # Duplicate `request` because `recognize` *can* strip the request's
+        # `path_info`, which results in broken engine links (when the engine has
+        # an isolated namespace).
+        ::Rails.application.routes.router.recognize(request.dup) do |route, _params|
           path =
             if route.app.respond_to?(:app) && route.app.app.respond_to?(:engine_name)
               "#{route.app.app.engine_name}##{route.path.spec}"


### PR DESCRIPTION
It turns out Rails can strip `request.path_info` from the given request. This is
an unexpected mutation, which we work around by duplicating the object.

For example:

```
request.path_info #=> "/"

::Rails.application.routes.router.recognize(request) {}

request.path_info #=> ""
```

This issue can break Rails engine route links. For example, `users_path` inside
an engine is expected to be `/admin/users`, however because of the mutation it
becomes just `/users`.