### PR TITLE
rubocop: enforce trailing commas

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,3 +73,12 @@ Style/SymbolArray:
 
 Style/NumericPredicate:
   Enabled: false
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma

--- a/lib/airbrake/rack/context_filter.rb
+++ b/lib/airbrake/rack/context_filter.rb
@@ -49,7 +49,7 @@ module Airbrake
           else
             {
               'rack_version' => ::Rack.version,
-              'rack_release' => ::Rack.release
+              'rack_release' => ::Rack.release,
             }
           end
       end

--- a/lib/airbrake/rack/http_headers_filter.rb
+++ b/lib/airbrake/rack/http_headers_filter.rb
@@ -9,7 +9,7 @@ module Airbrake
       HTTP_HEADER_PREFIXES = [
         'HTTP_'.freeze,
         'CONTENT_TYPE'.freeze,
-        'CONTENT_LENGTH'.freeze
+        'CONTENT_LENGTH'.freeze,
       ].freeze
 
       # @return [Integer]
@@ -34,7 +34,7 @@ module Airbrake
         notice[:context].merge!(
           httpMethod: request.request_method,
           referer: request.referer,
-          headers: http_headers
+          headers: http_headers,
         )
       end
     end

--- a/lib/airbrake/rack/middleware.rb
+++ b/lib/airbrake/rack/middleware.rb
@@ -94,7 +94,7 @@ end
   Airbrake::Rack::SessionFilter,
   Airbrake::Rack::HttpParamsFilter,
   Airbrake::Rack::HttpHeadersFilter,
-  Airbrake::Rack::RouteFilter
+  Airbrake::Rack::RouteFilter,
 ].each do |filter|
   Airbrake.add_filter(filter.new)
 end

--- a/lib/airbrake/rails.rb
+++ b/lib/airbrake/rails.rb
@@ -12,7 +12,7 @@ module Airbrake
 
           # Rails.logger is not set in some Rake tasks such as
           # 'airbrake:deploy'. In this case we use a sensible fallback.
-          level: (::Rails.logger ? ::Rails.logger.level : Logger::ERROR)
+          level: (::Rails.logger ? ::Rails.logger.level : Logger::ERROR),
         )
       end
     end

--- a/lib/airbrake/rails/action_controller_notify_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_notify_subscriber.rb
@@ -19,7 +19,7 @@ module Airbrake
             route: route,
             status_code: event.status_code,
             start_time: event.time,
-            end_time: Time.new
+            end_time: Time.new,
           )
         end
       end

--- a/lib/airbrake/rails/action_controller_performance_breakdown_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_performance_breakdown_subscriber.rb
@@ -20,7 +20,7 @@ module Airbrake
             route: route,
             response_type: event.response_type,
             groups: groups,
-            start_time: event.time
+            start_time: event.time,
           }
 
           Airbrake.notify_performance_breakdown(breakdown_info, stash)

--- a/lib/airbrake/rails/action_controller_route_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_route_subscriber.rb
@@ -14,14 +14,14 @@ module Airbrake
 
         event = Airbrake::Rails::Event.new(*args)
         route = Airbrake::Rails::App.recognize_route(
-          Airbrake::Rack::RequestStore[:request]
+          Airbrake::Rack::RequestStore[:request],
         )
         return unless route
 
         routes[route.path] = {
           method: event.method,
           response_type: event.response_type,
-          groups: {}
+          groups: {},
         }
       end
     end

--- a/lib/airbrake/rails/active_record_subscriber.rb
+++ b/lib/airbrake/rails/active_record_subscriber.rb
@@ -23,7 +23,7 @@ module Airbrake
             file: frame[:file],
             line: frame[:line],
             start_time: event.time,
-            end_time: event.end
+            end_time: event.end,
           )
         end
       end
@@ -33,7 +33,7 @@ module Airbrake
       def last_caller
         exception = StandardError.new
         exception.set_backtrace(
-          Airbrake::Rails::BacktraceCleaner.clean(Kernel.caller)
+          Airbrake::Rails::BacktraceCleaner.clean(Kernel.caller),
         )
         Airbrake::Backtrace.parse(exception).first || {}
       end

--- a/lib/airbrake/rails/event.rb
+++ b/lib/airbrake/rails/event.rb
@@ -59,7 +59,7 @@ module Airbrake
 
         if @event.payload[:exception]
           status = ActionDispatch::ExceptionWrapper.status_code_for_exception(
-            @event.payload[:exception].first
+            @event.payload[:exception].first,
           )
           status = 500 if status == 0
 

--- a/lib/airbrake/rails/railtie.rb
+++ b/lib/airbrake/rails/railtie.rb
@@ -16,20 +16,20 @@ module Airbrake
           # exist in Rails 5 anymore.
           app.config.middleware.insert_after(
             ActionDispatch::DebugExceptions,
-            Airbrake::Rack::Middleware
+            Airbrake::Rack::Middleware,
           )
         elsif defined?(::ActiveRecord::ConnectionAdapters::ConnectionManagement)
           # Insert after ConnectionManagement to avoid DB connection leakage:
           # https://github.com/airbrake/airbrake/pull/568
           app.config.middleware.insert_after(
             ::ActiveRecord::ConnectionAdapters::ConnectionManagement,
-            'Airbrake::Rack::Middleware'
+            'Airbrake::Rack::Middleware',
           )
         else
           # Insert after DebugExceptions for apps without ActiveRecord.
           app.config.middleware.insert_after(
             ActionDispatch::DebugExceptions,
-            'Airbrake::Rack::Middleware'
+            'Airbrake::Rack::Middleware',
           )
         end
       end
@@ -55,21 +55,21 @@ module Airbrake
             require 'airbrake/rails/action_controller_route_subscriber'
             ActiveSupport::Notifications.subscribe(
               'start_processing.action_controller',
-              Airbrake::Rails::ActionControllerRouteSubscriber.new
+              Airbrake::Rails::ActionControllerRouteSubscriber.new,
             )
 
             # Send route stats.
             require 'airbrake/rails/action_controller_notify_subscriber'
             ActiveSupport::Notifications.subscribe(
               'process_action.action_controller',
-              Airbrake::Rails::ActionControllerNotifySubscriber.new
+              Airbrake::Rails::ActionControllerNotifySubscriber.new,
             )
 
             # Send performance breakdown: where a request spends its time.
             require 'airbrake/rails/action_controller_performance_breakdown_subscriber'
             ActiveSupport::Notifications.subscribe(
               'process_action.action_controller',
-              Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber.new
+              Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber.new,
             )
 
             require 'airbrake/rails/net_http' if defined?(Net) && defined?(Net::HTTP)
@@ -112,8 +112,8 @@ module Airbrake
             # Filter out parameters from SQL body.
             Airbrake.add_performance_filter(
               Airbrake::Filters::SqlFilter.new(
-                ::ActiveRecord::Base.connection_config[:adapter]
-              )
+                ::ActiveRecord::Base.connection_config[:adapter],
+              ),
             )
           end
         end

--- a/lib/airbrake/rake.rb
+++ b/lib/airbrake/rake.rb
@@ -30,7 +30,7 @@ module Rake
       notice[:params].merge!(
         rake_task: task_info,
         execute_args: args,
-        argv: ARGV.join(' ')
+        argv: ARGV.join(' '),
       )
 
       Airbrake.notify_sync(notice)

--- a/lib/airbrake/rake/tasks.rb
+++ b/lib/airbrake/rake/tasks.rb
@@ -55,7 +55,7 @@ namespace :airbrake do
       username: ENV['USERNAME'],
       revision: ENV['REVISION'],
       repository: ENV['REPOSITORY'],
-      version: ENV['VERSION']
+      version: ENV['VERSION'],
     }
     promise = Airbrake.notify_deploy(deploy_params)
     promise.then do

--- a/lib/airbrake/shoryuken.rb
+++ b/lib/airbrake/shoryuken.rb
@@ -24,7 +24,7 @@ module Airbrake
       def notice_context(queue, body)
         {
           queue: queue,
-          body: body.is_a?(Array) ? { batch: body } : { body: body }
+          body: body.is_a?(Array) ? { batch: body } : { body: body },
         }
       end
     end

--- a/spec/apps/rack/dummy_app.rb
+++ b/spec/apps/rack/dummy_app.rb
@@ -7,7 +7,7 @@ DummyApp = Rack::Builder.new do
     run(
       proc do |_env|
         [200, { 'Content-Type' => 'text/plain' }, ['Hello from index']]
-      end
+      end,
     )
   end
 

--- a/spec/apps/rails/dummy_app.rb
+++ b/spec/apps/rails/dummy_app.rb
@@ -123,8 +123,8 @@ class DummyController < ActionController::Base
       'dummy/breakdown_excon.erb' => 'breakdown_excon',
       'dummy/breakdown_http_rb.erb' => 'breakdown_http_rb',
       'dummy/breakdown_http_client.erb' => 'breakdown_http_client',
-      'dummy/breakdown_typhoeus.erb' => 'breakdown_typhoeus'
-    )
+      'dummy/breakdown_typhoeus.erb' => 'breakdown_typhoeus',
+    ),
   ]
 
   def index; end
@@ -228,8 +228,8 @@ ActiveRecord::Migration.verbose = false
 migration_template = File.open(
   File.join(
     $LOAD_PATH.grep(/delayed_job/)[0],
-    'generators/delayed_job/templates/migration.rb'
-  )
+    'generators/delayed_job/templates/migration.rb',
+  ),
 )
 
 # need to eval the template with the migration_version intact

--- a/spec/integration/rails/rails_spec.rb
+++ b/spec/integration/rails/rails_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Rails integration specs" do
       OpenStruct.new(
         id: 1,
         email: 'qa@example.com',
-        username: 'qa-dept'
+        username: 'qa-dept',
       )
     end
 
@@ -97,11 +97,11 @@ RSpec.describe "Rails integration specs" do
 
   describe(
     "Active Record callbacks",
-    skip: Gem::Version.new(Rails.version) > Gem::Version.new('4.2')
+    skip: Gem::Version.new(Rails.version) > Gem::Version.new('4.2'),
   ) do
     it "reports exceptions in after_commit callbacks" do
       expect(Airbrake).to receive(:notify).with(
-        an_instance_of(AirbrakeTestError)
+        an_instance_of(AirbrakeTestError),
       ) do |exception|
         expect(exception.message).to eq('after_commit')
       end
@@ -111,7 +111,7 @@ RSpec.describe "Rails integration specs" do
 
     it "reports exceptions in after_rollback callbacks" do
       expect(Airbrake).to receive(:notify).with(
-        an_instance_of(AirbrakeTestError)
+        an_instance_of(AirbrakeTestError),
       ) do |exception|
         expect(exception.message).to eq('after_rollback')
       end
@@ -136,13 +136,13 @@ RSpec.describe "Rails integration specs" do
           # integration will try to handle error 500 and we want to prevent
           # that: https://github.com/airbrake/airbrake/pull/583
           allow_any_instance_of(Airbrake::Rack::Middleware).to(
-            receive(:notify_airbrake).and_return(nil)
+            receive(:notify_airbrake).and_return(nil),
           )
         end
 
         it "doesn't report errors" do
           expect(Airbrake).to receive(:notify).with(
-            an_instance_of(Airbrake::Notice)
+            an_instance_of(Airbrake::Notice),
           ) { |notice|
             # TODO: this doesn't actually fail but prints a failure. Figure
             # out how to test properly.
@@ -162,8 +162,8 @@ RSpec.describe "Rails integration specs" do
         anything,
         hash_including(
           'class' => 'BingoWorker',
-          'args' => %w[bango bongo]
-        )
+          'args' => %w[bango bongo],
+        ),
       )
       with_resque { get '/resque' }
     end
@@ -176,8 +176,8 @@ RSpec.describe "Rails integration specs" do
       expect(Airbrake).to receive(:notify).with(
         anything,
         'job' => hash_including(
-          'handler' => "--- !ruby/struct:BangoJob\nbingo: bingo\nbongo: bongo\n"
-        )
+          'handler' => "--- !ruby/struct:BangoJob\nbingo: bingo\nbongo: bongo\n",
+        ),
       )
 
       get '/delayed_job'
@@ -189,8 +189,8 @@ RSpec.describe "Rails integration specs" do
       expect(Airbrake).to receive(:notify).with(
         anything,
         hash_including(
-          'handler' => "--- !ruby/struct:BangoJob\nbingo: bingo\nbongo: bongo\n"
-        )
+          'handler' => "--- !ruby/struct:BangoJob\nbingo: bingo\nbongo: bongo\n",
+        ),
       )
 
       get '/delayed_job'
@@ -203,7 +203,7 @@ RSpec.describe "Rails integration specs" do
         OpenStruct.new(
           id: 1,
           email: 'qa@example.com',
-          username: 'qa-dept'
+          username: 'qa-dept',
         )
       end
 
@@ -233,8 +233,8 @@ RSpec.describe "Rails integration specs" do
       expect(Airbrake).to receive(:notify_request).with(
         hash_including(
           route: '/crash(.:format)',
-          method: 'GET'
-        )
+          method: 'GET',
+        ),
       )
       get '/crash'
     end
@@ -247,8 +247,8 @@ RSpec.describe "Rails integration specs" do
         hash_including(
           route: '/crash(.:format)',
           method: 'HEAD',
-          status_code: 500
-        )
+          status_code: 500,
+        ),
       )
       head '/crash'
     end
@@ -264,8 +264,8 @@ RSpec.describe "Rails integration specs" do
           method: 'GET',
           func: 'call',
           file: 'lib/airbrake/rails/active_record_subscriber.rb',
-          line: anything
-        )
+          line: anything,
+        ),
       ).at_least(:once)
 
       get '/crash'
@@ -281,8 +281,8 @@ RSpec.describe "Rails integration specs" do
             method: 'GET',
             func: nil,
             file: nil,
-            line: nil
-          )
+            line: nil,
+          ),
         ).at_least(:once)
 
         get '/crash'
@@ -299,9 +299,9 @@ RSpec.describe "Rails integration specs" do
           route: '/breakdown(.:format)',
           method: 'GET',
           response_type: :html,
-          groups: hash_including(db: an_instance_of(Float))
+          groups: hash_including(db: an_instance_of(Float)),
         ),
-        an_instance_of(Hash)
+        an_instance_of(Hash),
       ).at_least(:once)
 
       get '/breakdown'
@@ -331,7 +331,7 @@ RSpec.describe "Rails integration specs" do
       it "includes the http breakdown" do
         expect(Airbrake).to receive(:notify_performance_breakdown).with(
           hash_including(groups: { view: be > 0, http: be > 0 }),
-          an_instance_of(Hash)
+          an_instance_of(Hash),
         )
         get '/breakdown_http'
         expect(example_request).to have_been_made
@@ -348,7 +348,7 @@ RSpec.describe "Rails integration specs" do
       it "includes the http breakdown" do
         expect(Airbrake).to receive(:notify_performance_breakdown).with(
           hash_including(groups: { view: be > 0, http: be > 0 }),
-          an_instance_of(Hash)
+          an_instance_of(Hash),
         )
         get '/breakdown_curl_http'
         expect(example_request).to have_been_made
@@ -365,7 +365,7 @@ RSpec.describe "Rails integration specs" do
       it "includes the http breakdown" do
         expect(Airbrake).to receive(:notify_performance_breakdown).with(
           hash_including(groups: { view: be > 0, http: be > 0 }),
-          an_instance_of(Hash)
+          an_instance_of(Hash),
         )
         get '/breakdown_curl_http_easy'
         expect(example_request).to have_been_made
@@ -378,7 +378,7 @@ RSpec.describe "Rails integration specs" do
       it "includes the http breakdown" do
         expect(Airbrake).to receive(:notify_performance_breakdown).with(
           hash_including(groups: { view: be > 0, http: be > 0 }),
-          an_instance_of(Hash)
+          an_instance_of(Hash),
         )
         get '/breakdown_curl_http_multi'
       end
@@ -392,7 +392,7 @@ RSpec.describe "Rails integration specs" do
       it "includes the http breakdown" do
         expect(Airbrake).to receive(:notify_performance_breakdown).with(
           hash_including(groups: { http: be > 0 }),
-          an_instance_of(Hash)
+          an_instance_of(Hash),
         )
         get '/breakdown_excon'
         expect(example_request).to have_been_made
@@ -407,7 +407,7 @@ RSpec.describe "Rails integration specs" do
       it "includes the http breakdown" do
         expect(Airbrake).to receive(:notify_performance_breakdown).with(
           hash_including(groups: { http: be > 0 }),
-          an_instance_of(Hash)
+          an_instance_of(Hash),
         )
         get '/breakdown_http_rb'
         expect(example_request).to have_been_made
@@ -422,7 +422,7 @@ RSpec.describe "Rails integration specs" do
       it "includes the http breakdown" do
         expect(Airbrake).to receive(:notify_performance_breakdown).with(
           hash_including(groups: { http: be > 0 }),
-          an_instance_of(Hash)
+          an_instance_of(Hash),
         )
         get '/breakdown_http_client'
         expect(example_request).to have_been_made
@@ -437,7 +437,7 @@ RSpec.describe "Rails integration specs" do
       it "includes the http breakdown" do
         expect(Airbrake).to receive(:notify_performance_breakdown).with(
           hash_including(groups: { http: be > 0 }),
-          an_instance_of(Hash)
+          an_instance_of(Hash),
         )
         get '/breakdown_typhoeus'
         expect(example_request).to have_been_made
@@ -459,8 +459,8 @@ RSpec.describe "Rails integration specs" do
           an_instance_of(Hash),
           hash_including(
             request: anything,
-            user: { id: '1', username: 'qa-dept', email: 'qa@example.com' }
-          )
+            user: { id: '1', username: 'qa-dept', email: 'qa@example.com' },
+          ),
         )
 
         get '/breakdown'

--- a/spec/integration/shared_examples/rack_examples.rb
+++ b/spec/integration/shared_examples/rack_examples.rb
@@ -25,7 +25,7 @@ RSpec.shared_examples 'rack examples' do
     describe "/crash" do
       it "returns 500 and sends a notice to Airbrake" do
         expect(Airbrake).to receive(:notify).with(
-          an_instance_of(Airbrake::Notice)
+          an_instance_of(Airbrake::Notice),
         ) do |notice|
           expect(notice[:errors].first[:type]).to eq('AirbrakeTestError')
         end
@@ -42,7 +42,7 @@ RSpec.shared_examples 'rack examples' do
         email: 'qa@example.com',
         username: 'qa-dept',
         first_name: 'John',
-        last_name: 'Doe'
+        last_name: 'Doe',
       )
     end
 

--- a/spec/unit/logger_spec.rb
+++ b/spec/unit/logger_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Airbrake::AirbrakeLogger do
 
         wait_for(
           a_request(:post, endpoint)
-            .with(body: %r{"file":".+/logger.rb"})
+            .with(body: %r{"file":".+/logger.rb"}),
         ).not_to have_been_made
         wait_for(a_request(:post, endpoint)).to have_been_made.once
       end

--- a/spec/unit/rack/context_filter_spec.rb
+++ b/spec/unit/rack/context_filter_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Airbrake::Rack::ContextFilter do
     subject.call(notice)
     expect(notice[:context][:versions]).to include(
       'rack_version' => a_string_matching(/\d.\d/),
-      'rack_release' => a_string_matching(/\d.\d\.\d/)
+      'rack_release' => a_string_matching(/\d.\d\.\d/),
     )
   end
 

--- a/spec/unit/rack/http_headers_filter_spec.rb
+++ b/spec/unit/rack/http_headers_filter_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Airbrake::Rack::HttpHeadersFilter do
     {
       'HTTP_HOST' => 'example.com',
       'CONTENT_TYPE' => 'text/html',
-      'CONTENT_LENGTH' => 100500
+      'CONTENT_LENGTH' => 100500,
     }
   end
 

--- a/spec/unit/rack/http_params_filter_spec.rb
+++ b/spec/unit/rack/http_params_filter_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Airbrake::Rack::HttpParamsFilter do
       {
         'rack.request.form_hash' => params,
         'rack.request.form_input' => input,
-        'rack.input' => input
+        'rack.input' => input,
       }
     end
 

--- a/spec/unit/rack/instrumentable_spec.rb
+++ b/spec/unit/rack/instrumentable_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe Airbrake::Rack::Instrumentable do
           '/about' => {
             method: 'GET',
             response_type: :html,
-            groups: {}
-          }
+            groups: {},
+          },
         }
       end
 
@@ -81,7 +81,7 @@ RSpec.describe Airbrake::Rack::Instrumentable do
 
         expect(groups).to match(
           'method' => be > 0,
-          'method_with_arg' => be > 0
+          'method_with_arg' => be > 0,
         )
       end
 

--- a/spec/unit/rack/middleware_spec.rb
+++ b/spec/unit/rack/middleware_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Airbrake::Rack::Middleware do
           .to raise_error(AirbrakeTestError)
 
         wait_for_a_request_with_body(
-          /"context":{.*"versions":{"(rails|sinatra|rack_version)"/
+          /"context":{.*"versions":{"(rails|sinatra|rack_version)"/,
         )
       end
     end

--- a/spec/unit/rack/rack_spec.rb
+++ b/spec/unit/rack/rack_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Airbrake::Rack do
           '/about' => {
             method: 'GET',
             response_type: :html,
-            groups: {}
-          }
+            groups: {},
+          },
         }
       end
 
@@ -34,7 +34,7 @@ RSpec.describe Airbrake::Rack do
         expect(routes['/about'][:groups]).to match(
           'operation 1' => be > 0,
           'operation 2' => be > 0,
-          'operation 3' => be > 0
+          'operation 3' => be > 0,
         )
       end
 

--- a/spec/unit/rack/user_spec.rb
+++ b/spec/unit/rack/user_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Airbrake::Rack::User do
       email: 'qa@example.com',
       username: 'qa-dept',
       first_name: 'Bingo',
-      last_name: 'Bongo'
+      last_name: 'Bongo',
     )
   end
 
@@ -210,7 +210,7 @@ RSpec.describe Airbrake::Rack::User do
             def username(*optional_params)
               "username is #{optional_params.inspect}"
             end
-          end.new
+          end.new,
         ).as_json
       end
 

--- a/spec/unit/rails/action_cable/notify_callback_spec.rb
+++ b/spec/unit/rails/action_cable/notify_callback_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Airbrake::Rails::ActionCable::NotifyCallback do
 
       it "notifies Airbrake" do
         expect(Airbrake).to(
-          receive(:notify).with(an_instance_of(Airbrake::Notice))
+          receive(:notify).with(an_instance_of(Airbrake::Notice)),
         ) do |notice|
           expect(notice[:context][:component]).to eq('action_cable')
           expect(notice[:context][:action]).to eq('web_notifications')

--- a/spec/unit/rails/action_controller_notify_subscriber_spec.rb
+++ b/spec/unit/rails/action_controller_notify_subscriber_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Airbrake::Rails::ActionControllerNotifySubscriber do
     context "when there's a route in the request store" do
       before do
         Airbrake::Rack::RequestStore[:routes] = {
-          '/test-route' => { method: 'GET', response_type: :html }
+          '/test-route' => { method: 'GET', response_type: :html },
         }
 
         expect(event).to receive(:method).and_return('GET')
@@ -33,8 +33,8 @@ RSpec.describe Airbrake::Rails::ActionControllerNotifySubscriber do
           hash_including(
             method: 'GET',
             route: '/test-route',
-            status_code: 200
-          )
+            status_code: 200,
+          ),
         )
         subject.call([])
       end

--- a/spec/unit/rails/action_controller_performance_breakdown_subscriber_spec.rb
+++ b/spec/unit/rails/action_controller_performance_breakdown_subscriber_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber d
           '/test-route' => {
             method: 'GET',
             response_type: :html,
-            groups: { http: 0.5 }
-          }
+            groups: { http: 0.5 },
+          },
         }
       end
 
@@ -53,7 +53,7 @@ RSpec.describe Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber d
             route: '/test-route',
             method: 'GET',
             response_type: :html,
-            groups: { db: 0.5, view: 0.5, http: 0.5 }
+            groups: { db: 0.5, view: 0.5, http: 0.5 },
           ),
           {}
         )
@@ -69,14 +69,14 @@ RSpec.describe Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber d
         Airbrake::Rack::RequestStore[:request] = request
 
         Airbrake::Rack::RequestStore[:routes] = {
-          '/test-route' => { method: 'GET', response_type: :html, groups: {} }
+          '/test-route' => { method: 'GET', response_type: :html, groups: {} },
         }
       end
 
       it "sends request info as resource stash" do
         expect(Airbrake).to receive(:notify_performance_breakdown).with(
           an_instance_of(Hash),
-          hash_including(request: request)
+          hash_including(request: request),
         )
         subject.call([])
       end
@@ -87,14 +87,14 @@ RSpec.describe Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber d
         before do
           expect(Airbrake::Rack::User).to receive(:extract).and_return(user)
           expect(user).to receive(:as_json).and_return(
-            user: { 'id' => 1, 'name' => 'Arthur' }
+            user: { 'id' => 1, 'name' => 'Arthur' },
           )
         end
 
         it "sends user info as resource stash" do
           expect(Airbrake).to receive(:notify_performance_breakdown).with(
             an_instance_of(Hash),
-            hash_including(user: { 'id' => 1, 'name' => 'Arthur' })
+            hash_including(user: { 'id' => 1, 'name' => 'Arthur' }),
           )
           subject.call([])
         end

--- a/spec/unit/rails/action_controller_route_subscriber_spec.rb
+++ b/spec/unit/rails/action_controller_route_subscriber_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Airbrake::Rails::ActionControllerRouteSubscriber do
         Time.new,
         Time.new,
         '123',
-        { method: 'HEAD', path: '/crash' }
+        { method: 'HEAD', path: '/crash' },
       ]
     end
 
@@ -34,7 +34,7 @@ RSpec.describe Airbrake::Rails::ActionControllerRouteSubscriber do
       context "and when the route can be found" do
         before do
           allow(Airbrake::Rails::App).to receive(:recognize_route).and_return(
-            Airbrake::Rails::App::Route.new('/crash')
+            Airbrake::Rails::App::Route.new('/crash'),
           )
         end
 

--- a/spec/unit/rails/active_record_subscriber_spec.rb
+++ b/spec/unit/rails/active_record_subscriber_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe Airbrake::Rails::ActiveRecordSubscriber do
     context "when there's a route in the request store" do
       before do
         Airbrake::Rack::RequestStore[:routes] = {
-          '/test-route' => { method: 'GET', response_type: :html }
+          '/test-route' => { method: 'GET', response_type: :html },
         }
 
         allow(event).to receive(:sql).and_return('SELECT * FROM bananas')
         allow(event).to receive(:time).and_return(Time.now)
         allow(event).to receive(:end).and_return(Time.now)
         allow(Airbrake::Rails::BacktraceCleaner).to receive(:clean).and_return(
-          "/lib/pry/cli.rb:117:in `start'"
+          "/lib/pry/cli.rb:117:in `start'",
         )
       end
 
@@ -39,8 +39,8 @@ RSpec.describe Airbrake::Rails::ActiveRecordSubscriber do
             query: 'SELECT * FROM bananas',
             func: 'start',
             line: 117,
-            file: '/lib/pry/cli.rb'
-          )
+            file: '/lib/pry/cli.rb',
+          ),
         )
         subject.call([])
       end
@@ -59,8 +59,8 @@ RSpec.describe Airbrake::Rails::ActiveRecordSubscriber do
               query: 'SELECT * FROM bananas',
               func: nil,
               line: nil,
-              file: nil
-            )
+              file: nil,
+            ),
           )
           subject.call([])
         end

--- a/spec/unit/rails/excon_spec.rb
+++ b/spec/unit/rails/excon_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Airbrake::Rails::Excon do
 
     before do
       Airbrake::Rack::RequestStore[:routes] = {
-        '/test-route' => { groups: {} }
+        '/test-route' => { groups: {} },
       }
 
       expect(event).to receive(:duration).and_return(0.1)

--- a/spec/unit/shoryuken_spec.rb
+++ b/spec/unit/shoryuken_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Airbrake::Shoryuken::ErrorHandler do
         wait_for_a_request_with_body(/"message":"shoryuken\serror"/)
         wait_for_a_request_with_body(/"params":{.*"queue":"#{queue}"/)
         wait_for_a_request_with_body(
-          /"params":{.*"batch":\[\{"message1":"message1"\},\{"message2":"message2"\}\]/
+          /"params":{.*"batch":\[\{"message1":"message1"\},\{"message2":"message2"\}\]/,
         )
         wait_for_a_request_with_body(/"component":"shoryuken","action":"FooWorker"/)
       end

--- a/spec/unit/sidekiq_spec.rb
+++ b/spec/unit/sidekiq_spec.rb
@@ -14,7 +14,7 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
       handler = Sidekiq.error_handlers.last
       handler.call(
         AirbrakeTestError.new('sidekiq error'),
-        'class' => 'HardSidekiqWorker', 'args' => %w[bango bongo]
+        'class' => 'HardSidekiqWorker', 'args' => %w[bango bongo],
       )
     end
 

--- a/spec/unit/sneakers_spec.rb
+++ b/spec/unit/sneakers_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Airbrake::Sneakers::ErrorReporter do
     allow(queue).to receive_messages(
       name: 'test-queue',
       opts: {},
-      exchange: instance_double('exchange')
+      exchange: instance_double('exchange'),
     )
 
     Class.new do
@@ -64,7 +64,7 @@ RSpec.describe Airbrake::Sneakers::ErrorReporter do
     wait_for_a_request_with_body(/"action":"String"/)
     wait_for_a_request_with_body(/"component":"sneakers"/)
     wait_for_a_request_with_body(
-      /"params":{"message":"my_special_message","delivery_info":{}}/
+      /"params":{"message":"my_special_message","delivery_info":{}}/,
     )
   end
 
@@ -75,7 +75,7 @@ RSpec.describe Airbrake::Sneakers::ErrorReporter do
           error, '', message: 'msg', delivery_info: { key => 'a', foo: 'b' }
         )
         wait_for_a_request_with_body(
-          /"params":{"message":"msg","delivery_info":{"foo":"b"}}/
+          /"params":{"message":"msg","delivery_info":{"foo":"b"}}/,
         )
       end
     end


### PR DESCRIPTION
When you edit Go, Rust, JS and Ruby at the same time, it's a headache to keep
remembering various style guides. I found that trailing commas generate better
diffs and also allow inserting new elements faster.