### PR TITLE
rack/context_filter: use #remote_ip instead of #ip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Airbrake Changelog
 
 * Sidekiq: started sending job execution statistics
   ([#1040](https://github.com/airbrake/airbrake/issues/1040))
+* Rack: fixed `context/userAddr` sometimes not reporting the actual client IP
+  (but a proxy IP instead)
+  ([#1042](https://github.com/airbrake/airbrake/issues/1042))
 
 ### [v9.5.5][v9.5.5] (December 2, 2019)
 

--- a/lib/airbrake/rack/context_filter.rb
+++ b/lib/airbrake/rack/context_filter.rb
@@ -18,7 +18,12 @@ module Airbrake
         context = notice[:context]
 
         context[:url] = request.url
-        context[:userAddr] = request.ip
+        context[:userAddr] =
+          if request.respond_to?(:remote_ip)
+            request.remote_ip
+          else
+            request.ip
+          end
         context[:userAgent] = request.user_agent
 
         add_framework_version(context)


### PR DESCRIPTION
Since we want to report the client IP, we should be using `#remote_ip` instead
of `#ip`.

The difference between the two is explained in
https://stackoverflow.com/q/10997005/511205

> `request.ip` returns the client ip even if that client is a proxy.
>
> `request.remote_ip` is smarter and gets the actual client ip. This can only be
  done if the all the proxies along the way set the X-Forwarded-For header.