### PR TITLE
resque: send proper timing for job execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Airbrake Changelog
 
 * Sidekiq: started sending job execution statistics
   ([#1040](https://github.com/airbrake/airbrake/issues/1040))
+* Resque: started sending job execution statistics
+  ([#1044](https://github.com/airbrake/airbrake/issues/1044))
 * Rack: fixed `context/userAddr` sometimes not reporting the actual client IP
   (but a proxy IP instead)
   ([#1042](https://github.com/airbrake/airbrake/issues/1042))


### PR DESCRIPTION
With `airbrake-ruby` v4.11.0 we can now send `:timing`, which is the correct way
to call `notify_queue`. Here we update the code to the new API and also fix
timing reporting, which was actually broken before.