### PR TITLE
sneakers: update API for job execution timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Airbrake Changelog
   ([#1040](https://github.com/airbrake/airbrake/issues/1040))
 * Resque: started sending job execution statistics
   ([#1044](https://github.com/airbrake/airbrake/issues/1044))
+* Sneakers: started sending job execution statistics
+  ([#1047](https://github.com/airbrake/airbrake/issues/1047))
 * Rack: fixed `context/userAddr` sometimes not reporting the actual client IP
   (but a proxy IP instead)
   ([#1042](https://github.com/airbrake/airbrake/issues/1042))


### PR DESCRIPTION
With `airbrake-ruby` v4.11.0 we can now send `:timing`, which is the correct way
to call `notify_queue`.