### PR TITLE
Appraisals: fix build on Ruby 2.2.0

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -47,7 +47,7 @@ unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
 end
 
 # Rails 5.0 & 5.1 supports only modern Rubies (2.2.2+)
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2')
   appraise 'rails-5.0' do
     gem 'rails', '~> 5.0.7'
     gem 'warden', '~> 1.2.3'


### PR DESCRIPTION
CircleCI pulls Ruby 2.2.0 but we expect 2.2.2. Because of this the i18n lock to
1.4 has no effect and it makes the build fail:

https://circleci.com/gh/airbrake/airbrake/7325