### PR TITLE
sidekiq: update API for job execution timing

### DIFF
--- a/spec/unit/sidekiq_spec.rb
+++ b/spec/unit/sidekiq_spec.rb
@@ -56,6 +56,7 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
         expect(Airbrake).to receive(:notify_queue).with(
           queue: 'HardSidekiqWorker',
           error_count: 1,
+          timing: 0.01,
         )
         call_handler
       end
@@ -80,7 +81,7 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
         expect(Airbrake).to receive(:notify_queue).with(
           queue: 'HardSidekiqWorker',
           error_count: 0,
-          groups: { 'other' => an_instance_of(Float) },
+          timing: an_instance_of(Float),
         )
         call_handler
       end


### PR DESCRIPTION
With `airbrake-ruby` v4.11.0 we can now send `:timing`, which is the correct way
to call `notify_queue`.