### PR TITLE
rails/app: fix engine route reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Airbrake Changelog
   ([#1042](https://github.com/airbrake/airbrake/issues/1042))
 * Bumped airbrake-ruby requirement to `~> 4.12`
   ([#1058](https://github.com/airbrake/airbrake/issues/1058))
+* Rails APM: fixed bug where engine routes would always point to root path (for
+  example, `engine_name#/` instead of `engine_name#my_path`)
+  ([#1059](https://github.com/airbrake/airbrake/issues/1059))
 
 ### [v9.5.5][v9.5.5] (December 2, 2019)
 

--- a/lib/airbrake/rails/app.rb
+++ b/lib/airbrake/rails/app.rb
@@ -13,26 +13,42 @@ module Airbrake
         # Duplicate `request` because `recognize` *can* strip the request's
         # `path_info`, which results in broken engine links (when the engine has
         # an isolated namespace).
-        ::Rails.application.routes.router.recognize(request.dup) do |route, _params|
-          path =
-            if route.app.respond_to?(:app) && route.app.app.respond_to?(:engine_name)
-              "#{route.app.app.engine_name}##{route.path.spec}"
-            else
-              route.path.spec.to_s
-            end
+        request_copy = request.dup
 
-          # Rails can recognize multiple routes for the given request. For
-          # example, if we visit /users/2/edit, then Rails sees these routes:
-          #   * "/users/:id/edit(.:format)"
-          #   *  "/"
-          #
-          # We return the first route as, what it seems, the most optimal
-          # approach.
-          return Route.new(path)
+        # We must search every engine individually to find a concrete route. If
+        # we rely only on the `Rails.application.routes.router`, then the
+        # recognize call would return the root route, neglecting PATH_INFO
+        # completely. For example:
+        #   * a request is made to `marketing#pricing`
+        #   * `Rails.application` recognizes it as `marketing#/` (incorrect)
+        #   * `Marketing::Engine` recognizes it as `marketing#/pricing` (correct)
+        engines.each do |engine|
+          engine.routes.router.recognize(request_copy) do |route, _params|
+            path =
+              if engine == ::Rails.application
+                route.path.spec.to_s
+              else
+                "#{engine.engine_name}##{route.path.spec}"
+              end
+
+            # Rails can recognize multiple routes for the given request. For
+            # example, if we visit /users/2/edit, then Rails sees these routes:
+            #   * "/users/:id/edit(.:format)"
+            #   *  "/"
+            #
+            # We return the first route as, what it seems, the most optimal
+            # approach.
+            return Route.new(path)
+          end
         end
 
         nil
       end
+
+      def self.engines
+        @engines ||= [*::Rails::Engine.subclasses, ::Rails.application]
+      end
+      private_class_method :engines
     end
   end
 end


### PR DESCRIPTION
`Rails.application.router.routes.recognize` does not return expected results
when a request is made to an engine. For example, if we have `Marketing::Engine`
and make a request to its route `/pricing`, the call would find this path:
`marketing#/`. Instead, it should be `marketing#pricing`.

In order to fix that issue we must ask every engine separately and call
`recognize` on every engine's routes. This method is supposedly slower but much
more reliable.