### PR TITLE
Fix deprecation warnings about `:start_time` & `:end_time`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Airbrake Changelog
 * Rails APM: fixed bug where engine routes would always point to root path (for
   example, `engine_name#/` instead of `engine_name#my_path`)
   ([#1059](https://github.com/airbrake/airbrake/issues/1059))
+* Fixed deprecation warnings about `:start_time` & `:end_time` coming from
+  `airbrake-ruby` ([#1060](https://github.com/airbrake/airbrake/issues/1060))
 
 ### [v9.5.5][v9.5.5] (December 2, 2019)
 

--- a/lib/airbrake/rails/action_controller_notify_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_notify_subscriber.rb
@@ -18,8 +18,8 @@ module Airbrake
             method: event.method,
             route: route,
             status_code: event.status_code,
-            start_time: event.time,
-            end_time: Time.new,
+            timing: event.duration,
+            time: event.time,
           )
         end
       end

--- a/lib/airbrake/rails/action_controller_performance_breakdown_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_performance_breakdown_subscriber.rb
@@ -20,7 +20,8 @@ module Airbrake
             route: route,
             response_type: event.response_type,
             groups: groups,
-            start_time: event.time,
+            timing: event.duration,
+            time: event.time,
           }
 
           Airbrake.notify_performance_breakdown(breakdown_info, stash)

--- a/lib/airbrake/rails/active_record_subscriber.rb
+++ b/lib/airbrake/rails/active_record_subscriber.rb
@@ -22,8 +22,8 @@ module Airbrake
             func: frame[:function],
             file: frame[:file],
             line: frame[:line],
-            start_time: event.time,
-            end_time: event.end,
+            timing: event.duration,
+            time: event.time,
           )
         end
       end

--- a/lib/airbrake/rails/event.rb
+++ b/lib/airbrake/rails/event.rb
@@ -43,10 +43,6 @@ module Airbrake
         @event.time
       end
 
-      def end
-        @event.end
-      end
-
       def groups
         groups = {}
         groups[:db] = db_runtime if db_runtime > 0

--- a/spec/unit/rails/action_controller_notify_subscriber_spec.rb
+++ b/spec/unit/rails/action_controller_notify_subscriber_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Airbrake::Rails::ActionControllerNotifySubscriber do
         expect(event).to receive(:method).and_return('GET')
         expect(event).to receive(:status_code).and_return(200)
         expect(event).to receive(:time).and_return(Time.now)
+        expect(event).to receive(:duration).and_return(1.234)
       end
 
       it "sends request info to Airbrake" do

--- a/spec/unit/rails/action_controller_performance_breakdown_subscriber_spec.rb
+++ b/spec/unit/rails/action_controller_performance_breakdown_subscriber_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber d
       expect(event).to receive(:method).and_return('GET')
       expect(event).to receive(:response_type).and_return(:html)
       expect(event).to receive(:time).and_return(Time.new)
+      expect(event).to receive(:duration).and_return(1.234)
     end
 
     context "when request store routes have extra groups" do

--- a/spec/unit/rails/active_record_subscriber_spec.rb
+++ b/spec/unit/rails/active_record_subscriber_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Airbrake::Rails::ActiveRecordSubscriber do
 
         allow(event).to receive(:sql).and_return('SELECT * FROM bananas')
         allow(event).to receive(:time).and_return(Time.now)
-        allow(event).to receive(:end).and_return(Time.now)
+        allow(event).to receive(:duration).and_return(1.234)
         allow(Airbrake::Rails::BacktraceCleaner).to receive(:clean).and_return(
           "/lib/pry/cli.rb:117:in `start'",
         )


### PR DESCRIPTION
Resolves https://github.com/airbrake/airbrake-ruby/issues/532
(Airbrake performance changes are filling logs with deprecation messages)

This was inroduced by https://github.com/airbrake/airbrake-ruby/pull/526
We can now pass `event.duration`, so there's no need to calculate it again. This
is more accurate as well since we pass monotonic time instead of realtime.