### PR TITLE
Fix keyword argument error in Sneakers integration

### DIFF
--- a/lib/airbrake/sneakers.rb
+++ b/lib/airbrake/sneakers.rb
@@ -10,12 +10,15 @@ module Airbrake
       # @see https://github.com/airbrake/airbrake/issues/850
       IGNORED_KEYS = %i[delivery_tag consumer channel].freeze
 
-      def call(exception, worker = nil, **context)
+      # rubocop:disable Style/OptionalArguments
+      def call(exception, worker = nil, context)
+        # Later versions add a middle argument.
         Airbrake.notify(exception, filter_context(context)) do |notice|
           notice[:context][:component] = 'sneakers'
           notice[:context][:action] = worker.class.to_s
         end
       end
+      # rubocop:enable Style/OptionalArguments
 
       private
 


### PR DESCRIPTION
The Sneakers::ErrorReporter worker_error method context_hash parameter
is Hash data, not keyword parameters. Declare our handler accordingly.