### PR TITLE
Enhancements to airbrake_capture_timing

### DIFF
--- a/lib/airbrake/rack/instrumentable.rb
+++ b/lib/airbrake/rack/instrumentable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   module Rack
     # Instrumentable holds methods that simplify instrumenting Rack apps.
@@ -15,12 +17,118 @@ module Airbrake
     # @since v9.2.0
     module Instrumentable
       def airbrake_capture_timing(method_name, label: method_name.to_s)
-        alias_method "#{method_name}_without_airbrake", method_name
+        instrumentable = ::Airbrake::Rack::Instrumentable
+        if instrumentable.should_prepend?(self, method_name)
+          instrumentable.prepend_capture_timing(self, method_name, label)
+        else
+          instrumentable.chain_capture_timing(self, method_name, label)
+        end
+        method_name
+      end
 
-        define_method(method_name) do |*args|
-          Airbrake::Rack.capture_timing(label) do
-            __send__("#{method_name}_without_airbrake", *args)
+      # @api private
+      def __airbrake_capture_timing_module__
+        # Module used to store prepended wrapper methods, saved as an instance
+        # variable so each target class/module gets its own module. This just
+        # a convenience to avoid prepending a lot of anonymous modules.
+        @__airbrake_capture_timing_module__ ||= ::Module.new
+      end
+      private :__airbrake_capture_timing_module__
+
+      # Using api private self methods so they don't get defined in the target
+      # class or module, but can still be called by the above method.
+
+      # @api private
+      def self.should_prepend?(klass, method_name)
+        # Don't chain already-prepended or operator methods.
+        klass.module_exec do
+          self_class_idx = ancestors.index(self)
+          method_owner_idx = ancestors.index(instance_method(method_name).owner)
+          method_owner_idx < self_class_idx || !(/\A\W/ =~ method_name).nil?
+        end
+      end
+
+      # @api private
+      def self.prepend_capture_timing(klass, method_name, label)
+        args = method_signature
+        visibility = method_visibility(klass, method_name)
+
+        # Generate the wrapper method.
+        klass.module_exec do
+          mod = __airbrake_capture_timing_module__
+          mod.module_exec do
+            module_eval <<-RUBY, __FILE__, __LINE__ + 1
+              def #{method_name}(#{args})
+                Airbrake::Rack.capture_timing(#{label.to_s.inspect}) do
+                  super
+                end
+              end
+              #{visibility} :#{method_name}
+            RUBY
           end
+          prepend mod
+        end
+      end
+
+      # @api private
+      def self.chain_capture_timing(klass, method_name, label)
+        args = method_signature
+        visibility = method_visibility(klass, method_name)
+
+        # Generate the wrapper method.
+        aliased = method_name.to_s.sub(/([?!=])$/, '')
+        punctuation = Regexp.last_match(1)
+        wrapped_method_name = "#{aliased}_without_airbrake#{punctuation}"
+        needs_removal = method_needs_removal(klass, method_name)
+        klass.module_exec do
+          alias_method wrapped_method_name, method_name
+          remove_method method_name if needs_removal
+          module_eval <<-RUBY, __FILE__, __LINE__ + 1
+            def #{method_name}(#{args})
+              Airbrake::Rack.capture_timing(#{label.to_s.inspect}) do
+                __send__("#{aliased}_without_airbrake#{punctuation}", #{args})
+              end
+            end
+            #{visibility} :#{method_name}
+          RUBY
+        end
+      end
+
+      # @api private
+      def self.method_visibility(klass, method_name)
+        klass.module_exec do
+          if protected_method_defined?(method_name)
+            "protected".freeze
+          elsif private_method_defined?(method_name)
+            "private".freeze
+          else
+            "public".freeze
+          end
+        end
+      end
+
+      # @api private
+      # A method instead of a constant so it isn't accessible in the target.
+      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7")
+        def self.method_signature
+          "*args, **kw_args, &block".freeze
+        end
+      else
+        def self.method_signature
+          "*args, &block".freeze
+        end
+      end
+
+      # @api private
+      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.6")
+        def self.method_needs_removal(klass, method_name)
+          klass.method_defined?(method_name, false) ||
+            klass.private_method_defined?(method_name, false)
+        end
+      else
+        def self.method_needs_removal(klass, method_name)
+          klass.instance_methods(false).include?(method_name) ||
+            klass.private_instance_methods(false).include?(method_name)
         end
       end
     end

--- a/spec/unit/rack/instrumentable_spec.rb
+++ b/spec/unit/rack/instrumentable_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Airbrake::Rack::Instrumentable do
         def method; end
         airbrake_capture_timing :method
 
+        def foo; end
+
         def method_with_arg(a); end
         airbrake_capture_timing :method_with_arg
 
@@ -25,7 +27,128 @@ RSpec.describe Airbrake::Rack::Instrumentable do
 
         def method_with_kwargs(foo:, bar:); end
         airbrake_capture_timing :method_with_kwargs
+
+        def method_with!(val); end
+        airbrake_capture_timing :method_with!
+
+        def method_with?(val); end
+        airbrake_capture_timing :method_with?
+
+        attr_writer :method_with
+        airbrake_capture_timing :method_with=
+
+        def ==(other)
+          super
+        end
+        airbrake_capture_timing :==
+
+        def method_with_block
+          yield(1)
+        end
+        airbrake_capture_timing :method_with_block
+
+        def method_with_everything!(a, b = nil, *args, foo:, bar: nil)
+          raise ArgumentError if !a || !b || !foo || !bar || args.empty?
+          yield(1)
+        end
+        airbrake_capture_timing :method_with_everything!
+
+        def writer_with_everything=(a, b = nil, *args, foo:, bar: nil)
+          raise ArgumentError if !a || !b || !foo || !bar || args.empty?
+          yield(1)
+        end
+        airbrake_capture_timing :writer_with_everything=
+
+        prepend(
+          Module.new do
+            def prepended_method!(*args, **kw_args)
+              super
+            end
+
+            def prepended_writer=(*args, **kw_args)
+              super
+            end
+
+            protected
+
+            def a_prepended_protected_method
+              super
+            end
+
+            private
+
+            def a_prepended_private_method
+              super
+            end
+          end,
+        )
+
+        def prepended_method!(a, b = nil, *args, foo:, bar: nil)
+          raise ArgumentError if !a || !b || !foo || !bar || args.empty?
+          yield(1)
+        end
+        airbrake_capture_timing :prepended_method!
+
+        def prepended_writer=(a, b = nil, *args, foo:, bar: nil)
+          raise ArgumentError if !a || !b || !foo || !bar || args.empty?
+          yield(1)
+        end
+        airbrake_capture_timing :prepended_writer=
+
+        protected
+
+        def a_protected_method; end
+        airbrake_capture_timing :a_protected_method
+
+        def a_prepended_protected_method; end
+        airbrake_capture_timing :a_prepended_protected_method
+
+        private
+
+        def a_private_method; end
+        airbrake_capture_timing :a_private_method
+
+        def a_prepended_private_method; end
+        airbrake_capture_timing :a_prepended_private_method
       end
+    end
+
+    if defined?(Warning) && Warning.respond_to?(:warn)
+      # Make sure there are no Ruby 2.7+ warnings.
+      before do
+        expect(Warning).to_not receive(:warn).with(any_args)
+      end
+    end
+
+    it "doesn't generate any methods with invalid names" do
+      expect(klass.instance_methods + klass.private_instance_methods)
+        .to all match(/\A(\w+[?!=]?|\W+)\z/)
+    end
+
+    it "doesn't change visibility of public methods" do
+      expect(klass.public_instance_methods)
+        .to include(:method_with!, :prepended_method!)
+    end
+
+    it "doesn't change visibility of protected methods" do
+      expect(klass.protected_instance_methods)
+        .to include(:a_protected_method, :a_prepended_protected_method)
+    end
+
+    it "doesn't change visibility of private methods" do
+      expect(klass.private_instance_methods)
+        .to include(:a_private_method, :a_prepended_private_method)
+    end
+
+    it "returns the method name so other methods can use it" do
+      expect(klass.airbrake_capture_timing(:foo)).to be :foo
+    end
+
+    it "doesn't generate too many anonymous modules" do
+      # We should have two anonymous modules, including the one defined above.
+      expect(klass.ancestors.index(klass)).to eq 2
+      mod = klass.__send__("__airbrake_capture_timing_module__")
+      expect(klass.ancestors.index(mod)).to be < 2
     end
 
     context "when request store doesn't have any routes" do
@@ -75,6 +198,57 @@ RSpec.describe Airbrake::Rack::Instrumentable do
         expect(groups).to match('method_with_kwargs' => be > 0)
       end
 
+      it "attaches timing for a method with !" do
+        klass.new.method_with!(1)
+        expect(groups).to match('method_with!' => be > 0)
+      end
+
+      it "attaches timing for a method with ?" do
+        klass.new.method_with?(1)
+        expect(groups).to match('method_with?' => be > 0)
+      end
+
+      it "attaches timing for a writer method" do
+        klass.new.method_with = 1
+        expect(groups).to match('method_with=' => be > 0)
+      end
+
+      it "attaches timing for an inherited method" do
+        klass.airbrake_capture_timing :dup
+        klass.new.dup
+        expect(groups).to match('dup' => be > 0)
+      end
+
+      it "attaches timing for an operator method" do
+        expect(klass.new == 1).to eq false
+        expect(groups).to match('==' => be > 0)
+      end
+
+      it "attaches timing for a method with a block given" do
+        expect(klass.new.method_with_block(&->(_) { 'Hi!' })).to eq 'Hi!'
+        expect(groups).to match('method_with_block' => be > 0)
+      end
+
+      it "attaches timing for a method with all arg types" do
+        klass.new.send('method_with_everything!', 1, 2, 3, foo: 4, bar: 5) {}
+        expect(groups).to match('method_with_everything!' => be > 0)
+      end
+
+      it "attaches timing for a writer method with all arg types" do
+        klass.new.send('writer_with_everything=', 1, 2, 3, foo: 4, bar: 5) {}
+        expect(groups).to match('writer_with_everything=' => be > 0)
+      end
+
+      it "attaches timing for a prepended method with all arg types" do
+        klass.new.prepended_method!(1, 2, 3, foo: 4, bar: 5, &->(_) { "Hi!" })
+        expect(groups).to match('prepended_method!' => be > 0)
+      end
+
+      it "attaches timing for a prepended writer method with all arg types" do
+        klass.new.send('prepended_writer=', 1, 2, 3, foo: 4, bar: 5) {}
+        expect(groups).to match('prepended_writer=' => be > 0)
+      end
+
       it "attaches all timings for multiple methods to the request store" do
         klass.new.method
         klass.new.method_with_arg(1)
@@ -92,12 +266,18 @@ RSpec.describe Airbrake::Rack::Instrumentable do
 
             def method; end
             airbrake_capture_timing :method, label: 'custom label'
+
+            def bar; end
           end
         end
 
         it "attaches timing under the provided label" do
           klass.new.method
           expect(groups).to match('custom label' => be > 0)
+        end
+
+        it "returns the method name so other methods can use it" do
+          expect(klass.airbrake_capture_timing(:bar, label: :foo)).to be :bar
         end
       end
     end


### PR DESCRIPTION
- Now supports wrapping the target method with alias_method_chain style
  or Module prepend style. Which one you should use depends on whether
  the method you're wrapping is chained or prepended already.
- Prevents you from wrapping a method more than once in chain mode,
  because that leads to stack overflows.
- Can handle method names ending in "?", "!", or "=".
- Can wrap operator methods (in prepend mode, at least).
- Uses Ruby 2.7+ style method forwarding when that's supported.
- Defines the wrappers using module_eval so we don't have closure
  references left in memory.

[Fixes #1062]