### PR TITLE
Ignore .ruby-version and .ruby-gemset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ pkg
 gemfiles/*.lock
 .rbenv-version
 .rvmrc
+.ruby-version
+.ruby-gemset
 resources/notice.xml
 Gemfile.lock
 .#*


### PR DESCRIPTION
Make local development easier for rvm and rbenv users.

I know .rbenv-version and .rvmrc are already ignored, but neither of
those files are recommended for use. Good to ignore the portable ones.