### PR TITLE
rails/railtie: run airbrake.middleware after config initializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Airbrake Changelog
 
 * Bumped airbrake-ruby requirement to `~> 4.13`
   ([#1065](https://github.com/airbrake/airbrake/issues/1065))
+* Rails APM: fixed bug where `query_stats = false` would sometimes have no
+  effect ([#1069](https://github.com/airbrake/airbrake/pull/1069))
 
 ### [v10.0.0][v10.0.0] (January 8, 2020)
 

--- a/lib/airbrake/rails/railtie.rb
+++ b/lib/airbrake/rails/railtie.rb
@@ -4,7 +4,7 @@ module Airbrake
     # 3.2+ apps). It makes Airbrake Ruby work with Rails and report errors
     # occurring in the application automatically.
     class Railtie < ::Rails::Railtie
-      initializer('airbrake.middleware') do |app|
+      initializer('airbrake.middleware', after: :load_config_initializers) do |app|
         # Since Rails 3.2 the ActionDispatch::DebugExceptions middleware is
         # responsible for logging exceptions and showing a debugging page in
         # case the request is local. We want to insert our middleware after


### PR DESCRIPTION
Fixes #1057 (Airbrake 9.5.5 update Error: config.query_stats = false is not
working)