### PR TITLE
Make sure there are frozen string literals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,9 +30,13 @@ Style/NumericLiterals:
 Style/SignalException:
   EnforcedStyle: only_raise
 
-# TODO: enable this when Ruby 3.0 is out.
 Style/FrozenStringLiteralComment:
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: always
+  Exclude:
+    - 'Gemfile'
+    - 'airbrake.gemspec'
+    - '**/*.gemfile'
 
 Metrics/BlockLength:
   CountComments: false

--- a/Appraisals
+++ b/Appraisals
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
   appraise 'rails-3.2' do
     gem 'rails', '~> 3.2.22.5'

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec/core/rake_task'
 
 task default: 'spec:unit'

--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'shellwords'
 require 'English'
 

--- a/lib/airbrake/capistrano.rb
+++ b/lib/airbrake/capistrano.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if defined?(Capistrano::VERSION) &&
    Gem::Version.new(Capistrano::VERSION).release >= Gem::Version.new('3.0.0')
   require 'airbrake/capistrano/capistrano3'

--- a/lib/airbrake/capistrano/capistrano2.rb
+++ b/lib/airbrake/capistrano/capistrano2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   # The Capistrano v2 integration.
   module Capistrano

--- a/lib/airbrake/capistrano/capistrano3.rb
+++ b/lib/airbrake/capistrano/capistrano3.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :airbrake do
   desc "Notify Airbrake of the deploy"
   task :deploy do

--- a/lib/airbrake/delayed_job.rb
+++ b/lib/airbrake/delayed_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Delayed
   module Plugins
     # Provides integration with Delayed Job.

--- a/lib/airbrake/logger.rb
+++ b/lib/airbrake/logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'logger'
 require 'delegate'
 

--- a/lib/airbrake/rack.rb
+++ b/lib/airbrake/rack.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'airbrake/rack/user'
 require 'airbrake/rack/user_filter'
 require 'airbrake/rack/context_filter'

--- a/lib/airbrake/rack/context_filter.rb
+++ b/lib/airbrake/rack/context_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   module Rack
     # Adds context (URL, User-Agent, framework version, controller and more).

--- a/lib/airbrake/rack/http_headers_filter.rb
+++ b/lib/airbrake/rack/http_headers_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   module Rack
     # Adds HTTP request parameters.

--- a/lib/airbrake/rack/http_params_filter.rb
+++ b/lib/airbrake/rack/http_params_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   module Rack
     # Adds HTTP request parameters.

--- a/lib/airbrake/rack/instrumentable.rb
+++ b/lib/airbrake/rack/instrumentable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   module Rack
     # Instrumentable holds methods that simplify instrumenting Rack apps.

--- a/lib/airbrake/rack/middleware.rb
+++ b/lib/airbrake/rack/middleware.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   module Rack
     # Airbrake Rack middleware for Rails and Sinatra applications (or any other

--- a/lib/airbrake/rack/request_body_filter.rb
+++ b/lib/airbrake/rack/request_body_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   module Rack
     # A filter that appends Rack request body to the notice.

--- a/lib/airbrake/rack/request_store.rb
+++ b/lib/airbrake/rack/request_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   module Rack
     # RequestStore is a thin (and limited) wrapper around *Thread.current* that

--- a/lib/airbrake/rack/route_filter.rb
+++ b/lib/airbrake/rack/route_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'airbrake/rails/app'
 
 module Airbrake

--- a/lib/airbrake/rack/session_filter.rb
+++ b/lib/airbrake/rack/session_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   module Rack
     # Adds HTTP session.

--- a/lib/airbrake/rack/user.rb
+++ b/lib/airbrake/rack/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   module Rack
     # Represents an authenticated user, which can be converted to Airbrake's

--- a/lib/airbrake/rack/user_filter.rb
+++ b/lib/airbrake/rack/user_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   module Rack
     # Adds current user information.

--- a/lib/airbrake/rails.rb
+++ b/lib/airbrake/rails.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'airbrake/rails/railtie'
 
 module Airbrake

--- a/lib/airbrake/rails/action_cable.rb
+++ b/lib/airbrake/rails/action_cable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'airbrake/rails/action_cable/notify_callback'
 
 %i[subscribe unsubscribe].each do |callback_name|

--- a/lib/airbrake/rails/action_cable/notify_callback.rb
+++ b/lib/airbrake/rails/action_cable/notify_callback.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   module Rails
     module ActionCable

--- a/lib/airbrake/rails/action_controller.rb
+++ b/lib/airbrake/rails/action_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   module Rails
     # Contains helper methods that can be used inside Rails controllers to send

--- a/lib/airbrake/rails/action_controller_notify_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_notify_subscriber.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'airbrake/rails/event'
 
 module Airbrake

--- a/lib/airbrake/rails/action_controller_performance_breakdown_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_performance_breakdown_subscriber.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'airbrake/rails/event'
 
 module Airbrake

--- a/lib/airbrake/rails/action_controller_route_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_route_subscriber.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'airbrake/rails/event'
 require 'airbrake/rails/app'
 

--- a/lib/airbrake/rails/active_job.rb
+++ b/lib/airbrake/rails/active_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   module Rails
     # Enables support for exceptions occurring in ActiveJob jobs.

--- a/lib/airbrake/rails/active_record.rb
+++ b/lib/airbrake/rails/active_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   module Rails
     # Rails <4.2 has a bug with regard to swallowing exceptions in the

--- a/lib/airbrake/rails/active_record_subscriber.rb
+++ b/lib/airbrake/rails/active_record_subscriber.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'airbrake/rails/event'
 require 'airbrake/rails/backtrace_cleaner'
 

--- a/lib/airbrake/rails/app.rb
+++ b/lib/airbrake/rails/app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   module Rails
     # App is a wrapper around Rails.application.

--- a/lib/airbrake/rails/backtrace_cleaner.rb
+++ b/lib/airbrake/rails/backtrace_cleaner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   module Rails
     # BacktraceCleaner is a wrapper around Rails.backtrace_cleaner.

--- a/lib/airbrake/rails/curb.rb
+++ b/lib/airbrake/rails/curb.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Curl
   # Monkey-patch to measure request timing.
   class Easy

--- a/lib/airbrake/rails/event.rb
+++ b/lib/airbrake/rails/event.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   module Rails
     # Event is a wrapper around ActiveSupport::Notifications::Event.

--- a/lib/airbrake/rails/excon_subscriber.rb
+++ b/lib/airbrake/rails/excon_subscriber.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'airbrake/rails/event'
 
 module Airbrake

--- a/lib/airbrake/rails/http.rb
+++ b/lib/airbrake/rails/http.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HTTP
   # Monkey-patch to measure request timing.
   class Client

--- a/lib/airbrake/rails/http_client.rb
+++ b/lib/airbrake/rails/http_client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Monkey-patch to measure request timing.
 class HTTPClient
   alias do_get_without_airbrake do_get_block

--- a/lib/airbrake/rails/net_http.rb
+++ b/lib/airbrake/rails/net_http.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Monkey-patch Net::HTTP to benchmark it.
 Net::HTTP.class_eval do
   alias_method :request_without_airbrake, :request

--- a/lib/airbrake/rails/railtie.rb
+++ b/lib/airbrake/rails/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   module Rails
     # This railtie works for any Rails application that supports railties (Rails

--- a/lib/airbrake/rails/typhoeus.rb
+++ b/lib/airbrake/rails/typhoeus.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   # Monkey-patch to measure request timing.
   class Request

--- a/lib/airbrake/rake.rb
+++ b/lib/airbrake/rake.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This is not bulletproof, but if this file is executed before a task
 # definition, we can grab tasks descriptions and locations.
 # See: https://goo.gl/ksn6PE

--- a/lib/airbrake/rake/tasks.rb
+++ b/lib/airbrake/rake/tasks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'airbrake-ruby'
 
 namespace :airbrake do
@@ -97,14 +99,14 @@ namespace :airbrake do
       end
     end
 
-    url = "https://airbrake.io/api/v3/projects/#{id}/heroku-deploys?key=#{key}"
+    url = ["https://airbrake.io/api/v3/projects/#{id}/heroku-deploys?key=#{key}"]
     url << "&environment=#{env}"
     url << "&repository=#{repo}" unless repo.empty?
 
-    command = %(heroku addons:create deployhooks:http --url="#{url}")
+    command = [%(heroku addons:create deployhooks:http --url="#{url.join}")]
     command << " --app #{app}" if app
 
-    puts "$ #{command}"
+    puts "$ #{command.join}"
     Bundler.with_clean_env { puts `#{command}` }
   end
 end

--- a/lib/airbrake/resque.rb
+++ b/lib/airbrake/resque.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Resque
   module Failure
     # Provides Resque integration with Airbrake.

--- a/lib/airbrake/shoryuken.rb
+++ b/lib/airbrake/shoryuken.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   module Shoryuken
     # Provides integration with Shoryuken.

--- a/lib/airbrake/sidekiq.rb
+++ b/lib/airbrake/sidekiq.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'airbrake/sidekiq/retryable_jobs_filter'
 
 module Airbrake

--- a/lib/airbrake/sidekiq/retryable_jobs_filter.rb
+++ b/lib/airbrake/sidekiq/retryable_jobs_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   module Sidekiq
     # Filter that can ignore notices from jobs that failed but will be retried

--- a/lib/airbrake/sneakers.rb
+++ b/lib/airbrake/sneakers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Airbrake
   module Sneakers
     # Provides integration with Sneakers.

--- a/lib/airbrake/version.rb
+++ b/lib/airbrake/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # We use Semantic Versioning v2.0.0
 # More information: http://semver.org/
 module Airbrake

--- a/lib/generators/airbrake_generator.rb
+++ b/lib/generators/airbrake_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Creates the Airbrake initializer file for Rails apps.
 #
 # @example Invokation from terminal

--- a/lib/generators/airbrake_initializer.rb.erb
+++ b/lib/generators/airbrake_initializer.rb.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Airbrake is an online tool that provides robust exception tracking in your Rails
 # applications. In doing so, it allows you to easily review errors, tie an error
 # to an individual piece of code, and trace the cause back to recent

--- a/spec/apps/rack/dummy_app.rb
+++ b/spec/apps/rack/dummy_app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 DummyApp = Rack::Builder.new do
   use Rack::ShowExceptions
   use Airbrake::Rack::Middleware

--- a/spec/apps/rails/dummy_app.rb
+++ b/spec/apps/rails/dummy_app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'curb' unless Airbrake::JRUBY
 require 'excon'
 

--- a/spec/apps/rails/dummy_task.rake
+++ b/spec/apps/rails/dummy_task.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Keep this before any task definitions to collect extra info about tasks.
 # Without this line the tests will fail.
 Rake::TaskManager.record_task_metadata = true

--- a/spec/apps/sinatra/sinatra_test_app.rb
+++ b/spec/apps/sinatra/sinatra_test_app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SinatraTestApp < Sinatra::Base
   use Airbrake::Rack::Middleware
   use Warden::Manager

--- a/spec/integration/rack/rack_spec.rb
+++ b/spec/integration/rack/rack_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'integration/shared_examples/rack_examples'
 
 RSpec.describe "Rack integration specs" do

--- a/spec/integration/rails/rails_spec.rb
+++ b/spec/integration/rails/rails_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'integration/shared_examples/rack_examples'
 
 RSpec.describe "Rails integration specs" do

--- a/spec/integration/rails/rake_spec.rb
+++ b/spec/integration/rails/rake_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe "Rake integration" do
   let(:task) { Rake::Task['bingo:bango'] }
 

--- a/spec/integration/shared_examples/rack_examples.rb
+++ b/spec/integration/shared_examples/rack_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples 'rack examples' do
   include Warden::Test::Helpers
 

--- a/spec/integration/sinatra/sinatra_spec.rb
+++ b/spec/integration/sinatra/sinatra_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'sinatra'
 
 require 'apps/sinatra/sinatra_test_app'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Gems from the gemspec.
 require 'webmock'
 require 'webmock/rspec'

--- a/spec/support/matchers/a_notice_with.rb
+++ b/spec/support/matchers/a_notice_with.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Matchers.define :a_notice_with do |access_keys, expected_val|
   match do |notice|
     payload = notice[access_keys.shift]

--- a/spec/unit/logger_spec.rb
+++ b/spec/unit/logger_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Airbrake::AirbrakeLogger do
   let(:project_id) { 113743 }
   let(:project_key) { 'fd04e13d806a90f96614ad8e529b2822' }

--- a/spec/unit/rack/context_filter_spec.rb
+++ b/spec/unit/rack/context_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Airbrake::Rack::ContextFilter do
   def env_for(url, opts = {})
     Rack::MockRequest.env_for(url, opts)

--- a/spec/unit/rack/http_headers_filter_spec.rb
+++ b/spec/unit/rack/http_headers_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Airbrake::Rack::HttpHeadersFilter do
   def env_for(url, opts = {})
     Rack::MockRequest.env_for(url, opts)

--- a/spec/unit/rack/http_params_filter_spec.rb
+++ b/spec/unit/rack/http_params_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Airbrake::Rack::HttpParamsFilter do
   def env_for(url, opts = {})
     Rack::MockRequest.env_for(url, opts)

--- a/spec/unit/rack/instrumentable_spec.rb
+++ b/spec/unit/rack/instrumentable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Airbrake::Rack::Instrumentable do
   after { Airbrake::Rack::RequestStore.clear }
 

--- a/spec/unit/rack/middleware_spec.rb
+++ b/spec/unit/rack/middleware_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Airbrake::Rack::Middleware do
   # The list of Rack filters that read Rack request information and append it to
   # notices.

--- a/spec/unit/rack/rack_spec.rb
+++ b/spec/unit/rack/rack_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Airbrake::Rack do
   after { Airbrake::Rack::RequestStore.clear }
 

--- a/spec/unit/rack/request_body_filter_spec.rb
+++ b/spec/unit/rack/request_body_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Airbrake::Rack::RequestBodyFilter do
   def env_for(url, opts = {})
     Rack::MockRequest.env_for(url, opts)

--- a/spec/unit/rack/request_store_spec.rb
+++ b/spec/unit/rack/request_store_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Airbrake::Rack::RequestStore do
   after { described_class.clear }
 

--- a/spec/unit/rack/route_filter_spec.rb
+++ b/spec/unit/rack/route_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Airbrake::Rack::RouteFilter do
   context "when there's no request object available" do
     it "doesn't add context/route" do

--- a/spec/unit/rack/session_filter_spec.rb
+++ b/spec/unit/rack/session_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Airbrake::Rack::SessionFilter do
   def env_for(url, opts = {})
     Rack::MockRequest.env_for(url, opts)

--- a/spec/unit/rack/user_filter_spec.rb
+++ b/spec/unit/rack/user_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Airbrake::Rack::UserFilter do
   def env_for(url, opts = {})
     Rack::MockRequest.env_for(url, opts)

--- a/spec/unit/rack/user_spec.rb
+++ b/spec/unit/rack/user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Airbrake::Rack::User do
   let(:endpoint) { 'https://api.airbrake.io/api/v3/projects/113743/notices' }
 

--- a/spec/unit/rails/action_cable/notify_callback_spec.rb
+++ b/spec/unit/rails/action_cable/notify_callback_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'airbrake/rails/action_cable/notify_callback'
 
 RSpec.describe Airbrake::Rails::ActionCable::NotifyCallback do

--- a/spec/unit/rails/action_controller_notify_subscriber_spec.rb
+++ b/spec/unit/rails/action_controller_notify_subscriber_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'airbrake/rails/action_controller_notify_subscriber'
 
 RSpec.describe Airbrake::Rails::ActionControllerNotifySubscriber do

--- a/spec/unit/rails/action_controller_performance_breakdown_subscriber_spec.rb
+++ b/spec/unit/rails/action_controller_performance_breakdown_subscriber_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'airbrake/rails/action_controller_performance_breakdown_subscriber'
 
 RSpec.describe Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber do

--- a/spec/unit/rails/action_controller_route_subscriber_spec.rb
+++ b/spec/unit/rails/action_controller_route_subscriber_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ostruct'
 require 'airbrake/rails/action_controller_route_subscriber'
 

--- a/spec/unit/rails/active_record_subscriber_spec.rb
+++ b/spec/unit/rails/active_record_subscriber_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'airbrake/rails/active_record_subscriber'
 
 RSpec.describe Airbrake::Rails::ActiveRecordSubscriber do

--- a/spec/unit/rails/excon_spec.rb
+++ b/spec/unit/rails/excon_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'airbrake/rails/excon_subscriber'
 
 RSpec.describe Airbrake::Rails::Excon do

--- a/spec/unit/rake/tasks_spec.rb
+++ b/spec/unit/rake/tasks_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe "airbrake/rake/tasks" do
   let(:endpoint) do
     'https://api.airbrake.io/api/v4/projects/113743/deploys'

--- a/spec/unit/shoryuken_spec.rb
+++ b/spec/unit/shoryuken_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'airbrake/shoryuken'
 
 RSpec.describe Airbrake::Shoryuken::ErrorHandler do

--- a/spec/unit/sidekiq/retryable_jobs_filter_spec.rb
+++ b/spec/unit/sidekiq/retryable_jobs_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
   require 'sidekiq'
   require 'sidekiq/cli'

--- a/spec/unit/sidekiq_spec.rb
+++ b/spec/unit/sidekiq_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
   require 'sidekiq'
   require 'sidekiq/cli'

--- a/spec/unit/sneakers_spec.rb
+++ b/spec/unit/sneakers_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'sneakers'
 require 'airbrake/sneakers'
 


### PR DESCRIPTION
Turns out that they were added in Ruby 2.3, not 3.0.