### PR TITLE
rails/active_job: allow ActiveJob errors to be reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* ActiveJob: fix error reporting
+  ([#1074](https://github.com/airbrake/airbrake/issues/1074))
+
 ### [v10.0.1][v10.0.1] (January 29, 2020)
 
 * Bumped airbrake-ruby requirement to `~> 4.13`

--- a/lib/airbrake/rails/active_job.rb
+++ b/lib/airbrake/rails/active_job.rb
@@ -6,15 +6,7 @@ module Airbrake
     module ActiveJob
       extend ActiveSupport::Concern
 
-      # @return [Array<Regexp>] the list of known adapters
-      ADAPTERS = [/Resque/, /Sidekiq/, /DelayedJob/].freeze
-
       def self.notify_airbrake(exception, job)
-        queue_adapter = job.class.queue_adapter.to_s
-
-        # Do not notify twice if a queue_adapter is configured already.
-        raise exception if ADAPTERS.any? { |a| a =~ queue_adapter }
-
         notice = Airbrake.build_notice(exception)
         notice[:context][:component] = 'active_job'
         notice[:context][:action] = job.class.name


### PR DESCRIPTION
It appears that our ActiveJob integration refuses to report errors if it's
configured in pair with Resque, DelayedJob or Sidekiq.

This code I am removing was introduced in #789. Now, 2.5 years later when I read
it, it doesn't make any sense to me. The errors are not reportred because we
explicitly guard against it.

The code is supposed to protect against the situation when we report the same
error twice (through the integration such as DelayedJob and through
ActiveJob). However after extensive testing I couldn't confirm anymore that if
this guard is removed, we report twice. I was able to confirm that we report
only once, through the ActiveJob integration.