### PR TITLE
Appraisals: lock Rack to 2.1.2 on Rails 5+

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -53,7 +53,9 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2')
   appraise 'rails-5.0' do
     gem 'rails', '~> 5.0.7'
     gem 'warden', '~> 1.2.3'
-    gem 'rack', '~> 2.0'
+
+    # Rack 2.2.0+ supports only Ruby 2.3+.
+    gem 'rack', '= 2.1.2'
 
     gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.18', platforms: :jruby
     gem 'sqlite3', '~> 1.3.11', platforms: %i[mri rbx]
@@ -76,7 +78,9 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2')
   appraise 'rails-5.1' do
     gem 'rails', '~> 5.1.4'
     gem 'warden', '~> 1.2.6'
-    gem 'rack', '~> 2.0'
+
+    # Rack 2.2.0+ supports only Ruby 2.3+.
+    gem 'rack', '= 2.1.2'
 
     gem 'activerecord-jdbcsqlite3-adapter', '~> 51.0', platforms: :jruby
     gem 'sqlite3', '~> 1.3.11', platforms: %i[mri rbx]

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "rubocop", "= 0.55", require: false
 gem "rails", "~> 5.0.7"
 gem "warden", "~> 1.2.3"
-gem "rack", "~> 2.0"
+gem "rack", "= 2.1.2"
 gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.18", platforms: :jruby
 gem "sqlite3", "~> 1.3.11", platforms: [:mri, :rbx]
 gem "resque", "~> 1.25.2"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "rubocop", "= 0.55", require: false
 gem "rails", "~> 5.1.4"
 gem "warden", "~> 1.2.6"
-gem "rack", "~> 2.0"
+gem "rack", "= 2.1.2"
 gem "activerecord-jdbcsqlite3-adapter", "~> 51.0", platforms: :jruby
 gem "sqlite3", "~> 1.3.11", platforms: [:mri, :rbx]
 gem "resque", "~> 1.26"


### PR DESCRIPTION
Rack 2.1.2+ dropped support for Ruby 2.2 and below:
https://github.com/rack/rack/commit/d81a5d3bdd20d80527164705b1fcfd0b7f4be6cd