### PR TITLE
rails/net_http: monkey-patch with prepend instead of method chaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Airbrake Changelog
 
 * ActiveJob: fix error reporting
   ([#1074](https://github.com/airbrake/airbrake/issues/1074))
+* Fixed `Net::HTTP` performance breakdown when 3rd party code monkey-patches
+  `Net::HTTP#request` ([#1078](https://github.com/airbrake/airbrake/issues/1078))
 
 ### [v10.0.1][v10.0.1] (January 29, 2020)
 

--- a/lib/airbrake/rails/net_http.rb
+++ b/lib/airbrake/rails/net_http.rb
@@ -1,12 +1,18 @@
 # frozen_string_literal: true
 
-# Monkey-patch Net::HTTP to benchmark it.
-Net::HTTP.class_eval do
-  alias_method :request_without_airbrake, :request
-
-  def request(request, *args, &block)
-    Airbrake::Rack.capture_timing(:http) do
-      request_without_airbrake(request, *args, &block)
+module Airbrake
+  module Rails
+    # Monkey-patch Net::HTTP to benchmark it.
+    # @api private
+    # @since v10.0.2
+    module NetHttp
+      def request(request, *args, &block)
+        Airbrake::Rack.capture_timing(:http) do
+          super(request, *args, &block)
+        end
+      end
     end
   end
 end
+
+Net::HTTP.prepend(Airbrake::Rails::NetHttp)


### PR DESCRIPTION
Fixes #1077 (Airbrake's new Performance metrics instrumentation leads to
infinite loop with Datadog)

Since we don't care about Ruby 1.9 support, we can safely rely on `prepend` to
monkey-patch methods safely. This is more robust because nobody will overwrite
our implementation (unless they forget to call `super`) and we will also respect
other libraries that monkey-patch `Net::HTTP#request`.