### PR TITLE
rails/backtrace_cleaner: silence own frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Changelog
 
 ### master
 
+* Rails APM: fixed wrong file/line/function for SQL queries if a query is
+  executed by a Rails engine
+  ([#1082](https://github.com/airbrake/airbrake/issues/1082))
+
 ### [v10.0.2][v10.0.2] (March 31, 2020)
 
 * ActiveJob: fix error reporting

--- a/lib/airbrake/rails/backtrace_cleaner.rb
+++ b/lib/airbrake/rails/backtrace_cleaner.rb
@@ -4,9 +4,20 @@ module Airbrake
   module Rails
     # BacktraceCleaner is a wrapper around Rails.backtrace_cleaner.
     class BacktraceCleaner
+      # @return [Regexp]
+      AIRBRAKE_FRAME_PATTERN = %r{/airbrake/lib/airbrake/}
+
       def self.clean(backtrace)
         ::Rails.backtrace_cleaner.clean(backtrace).first(1)
       end
     end
+  end
+end
+
+if defined?(Rails)
+  # Silence own frames to let the cleaner proceed to the next line (and probably
+  # find the correct call-site coming from the app code rather this library).
+  Rails.backtrace_cleaner.add_silencer do |line|
+    line =~ Airbrake::Rails::BacktraceCleaner::AIRBRAKE_FRAME_PATTERN
   end
 end


### PR DESCRIPTION
Since we rely on Rails' BacktraceCleaner to find function/file/line of the
executed SQL, sometimes the backtrace to clean can contain frames coming from
this library.

Namely, `active_record_subscriber.rb` will be returned if an SQL request is
coming from a Rails engine. In order to avoid that, we silence ourselves, so
that the cleaner can proceed to the next line and find the correct call-site
down the stack.