### PR TITLE
circleci: fix typo in rails60 directive

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ references:
     run:
       name: Test Rails 5.2
       command: bundle exec appraisal rails-5.2 rake spec:integration:rails
-  rails52: &rails60
+  rails60: &rails60
     run:
       name: Test Rails 6.0
       command: bundle exec appraisal rails-6.0 rake spec:integration:rails


### PR DESCRIPTION
Kindly reported by
https://app.circleci.com/pipelines/github/airbrake/airbrake/1/workflows/368850c2-3062-4634-afe4-890fbebd088c/jobs/8116

```
   #!/bin/sh -eo pipefail
   # Unable to parse YAML
   # while constructing a mapping
   #  in 'string', line 3, column 3:
   #       repo_restore_cache: &repo_restor ...
   #       ^
   # found duplicate key rails52
   #  in 'string', line 48, column 3:
   #       rails52: &rails60
   #       ^
```