### PR TITLE
delayed_job: send execution stats asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Airbrake Changelog
 * Rails APM: fixed wrong file/line/function for SQL queries if a query is
   executed by a Rails engine
   ([#1082](https://github.com/airbrake/airbrake/issues/1082))
+* Fixed performance degradation of Delayed Job jobs
+  ([#1084](https://github.com/airbrake/airbrake/issues/1084))
 
 ### [v10.0.2][v10.0.2] (March 31, 2020)
 

--- a/lib/airbrake/delayed_job.rb
+++ b/lib/airbrake/delayed_job.rb
@@ -28,7 +28,7 @@ module Delayed
               notice[:context][:action] = action
             end
 
-            ::Airbrake.notify_queue_sync(
+            ::Airbrake.notify_queue(
               queue: action,
               error_count: 1,
               timing: 0.01,
@@ -36,7 +36,7 @@ module Delayed
 
             raise exception
           else
-            ::Airbrake.notify_queue_sync(
+            ::Airbrake.notify_queue(
               queue: job_class || job.payload_object.class.name,
               error_count: 0,
               timing: timing,

--- a/lib/airbrake/rails/active_job.rb
+++ b/lib/airbrake/rails/active_job.rb
@@ -22,14 +22,14 @@ module Airbrake
           block.call
         end
       rescue StandardError => exception
-        Airbrake.notify_queue_sync(
+        Airbrake.notify_queue(
           queue: job.class.name,
           error_count: 1,
           timing: 0.01,
         )
         raise exception
       else
-        Airbrake.notify_queue_sync(
+        Airbrake.notify_queue(
           queue: job.class.name,
           error_count: 0,
           timing: timing,


### PR DESCRIPTION
Fixes #1081 (delayed_job performance issues with Airbrake version 10.0.1)

There's no good reason to use synchronous delivery. I tested DJ on a sample app
with this change and stat reporting still works, while job execution time is
1000% faster.