### PR TITLE
rails/app: ignore "catch-all" routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Changelog
 
 ### master
 
+* Rails APM: fixed support for "catch-all" routes, which grouped all matching
+  routes as one, instead of reporting those routes separately
+  ([#1092](https://github.com/airbrake/airbrake/issues/1092))
+
 ### [v10.0.3][v10.0.3] (April 22, 2020)
 
 * Rails APM: fixed wrong file/line/function for SQL queries if a query is

--- a/lib/airbrake/rails/app.rb
+++ b/lib/airbrake/rails/app.rb
@@ -26,6 +26,16 @@ module Airbrake
         #   * `Marketing::Engine` recognizes it as `marketing#/pricing` (correct)
         engines.each do |engine|
           engine.routes.router.recognize(request_copy) do |route, _params|
+            # Skip "catch-all" routes such as:
+            #   get '*path => 'pages#about'
+            #
+            # @todo The `glob?` method was added in Rails v4.2.0.beta1. We
+            # should remove the `respond_to?` check once we drop old Rails
+            # versions support.
+            #
+            # https://github.com/rails/rails/commit/5460591f0226a9d248b7b4f89186bd5553e7768f
+            next if route.respond_to?(:glob?) && route.glob?
+
             path =
               if engine == ::Rails.application
                 route.path.spec.to_s


### PR DESCRIPTION
Fixes #1091 (Performance - all routes appear as / with 10.0.3. Works fine in
9.5.5)

When using Rails' `recognize`, catch-all routes have higher precedence than real
routes. By skipping catch-all routes we can fall through to the next route,
which appears to be a real route.

One gotcha is that the API we use to check for "catch-all" routes is not
available on Rails 4.1 and lower (only Rails 4.2+).