### PR TITLE
Lock ffi and appraisal

### DIFF
--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -36,7 +36,10 @@ DESC
   s.add_development_dependency 'rspec-wait', '~> 0'
   s.add_development_dependency 'rake', '~> 12'
   s.add_development_dependency 'pry', '~> 0'
-  s.add_development_dependency 'appraisal', '~> 2'
+
+  # appraisal >= 2.3.0 wants Ruby >= 2.3
+  s.add_development_dependency 'appraisal', '= 2.2.0'
+
   s.add_development_dependency 'rack', '~> 1'
   s.add_development_dependency 'webmock', '~> 2'
 

--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -69,6 +69,9 @@ DESC
   # redis-namespace > 1.6.0 wants Ruby >= 2.4.
   s.add_development_dependency 'redis-namespace', '= 1.6.0'
 
+  # ffi > 1.12.2 wants Ruby >= 2.3.
+  s.add_development_dependency 'ffi', '= 1.12.2'
+
   if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
     s.add_development_dependency 'sidekiq', '~> 5'
   end


### PR DESCRIPTION
Newest version of appraisal and ffi dropped support for Ruby <= 2.2, but we still support them.