### PR TITLE
sidekiq: specify that params are 'job' params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Changelog
 
 ### master
 
+* Fixes `Airbrake::Sidekiq::RetryableJobsFilter` erroneously reporting retry
+  attempts when it shouldn't
+  ([#1103](https://github.com/airbrake/airbrake/pull/1103))
+
 ### [v10.0.5][v10.0.5] (June 17, 2020)
 
 * Fixed deprecation warning about "connection_config" on Rails 6.1+

--- a/lib/airbrake/sidekiq.rb
+++ b/lib/airbrake/sidekiq.rb
@@ -29,7 +29,7 @@ module Airbrake
       private
 
       def notify_airbrake(exception, context)
-        Airbrake.notify(exception, context) do |notice|
+        Airbrake.notify(exception, job: context) do |notice|
           notice[:context][:component] = 'sidekiq'
           notice[:context][:action] = action(context)
         end

--- a/spec/unit/sidekiq_spec.rb
+++ b/spec/unit/sidekiq_spec.rb
@@ -40,8 +40,10 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
       it "sends error" do
         expect(Airbrake).to receive(:notify).with(
           exception,
-          'args' => %w[bango bongo],
-          'class' => 'HardSidekiqWorker',
+          job: {
+            'args' => %w[bango bongo],
+            'class' => 'HardSidekiqWorker',
+          },
         )
         call_handler
       end


### PR DESCRIPTION
Fixes #1102
(Airbrake::Sidekiq::RetryableJobsFilter not working)

`Airbrake::Sidekiq::RetryableJobsFilter` checks for `notice[:params][:job]` and
then reads job-specific keys. However our Sidekiq integration places
job-specific keys to `notice[:params]`. Therefore, the filter's code always
thinks that the job is not retryable and never ignores the notice.