### PR TITLE
rails/app: fix request.path with "//"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Changelog
 
 ### master
 
+* Rails APM: fixed double slash in front of a route name when mounting engines
+  at `/` ([#1111](https://github.com/airbrake/airbrake/pull/1111))
+
 ### [v10.1.0.rc.1][v10.1.0.rc.1] (July 14, 2020)
 
 * Fixes `Airbrake::Sidekiq::RetryableJobsFilter` erroneously reporting retry


### PR DESCRIPTION
Fixes #1072 (request.path starts with "//" after updating to v10)

This is a hack but we have no better option since `request.dup` is not able to
duplicate `script_name` properly.