### PR TITLE
rails: install all performance hooks by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Airbrake Changelog
 
 * Rails APM: fixed double slash in front of a route name when mounting engines
   at `/` ([#1111](https://github.com/airbrake/airbrake/pull/1111))
+* Rails APM: made it possible to enable/disable APM at runtime
+  ([#1112](https://github.com/airbrake/airbrake/pull/1112))
+* Rails: fixed broken initialization for some apps due to the load order of
+  initializers ([#1112](https://github.com/airbrake/airbrake/pull/1112))
 
 ### [v10.1.0.rc.1][v10.1.0.rc.1] (July 14, 2020)
 

--- a/lib/airbrake/rack.rb
+++ b/lib/airbrake/rack.rb
@@ -18,6 +18,8 @@ module Airbrake
     # @since v9.2.0
     # @api public
     def self.capture_timing(label)
+      return yield unless Airbrake::Config.instance.performance_stats
+
       routes = Airbrake::Rack::RequestStore[:routes]
       if !routes || routes.none?
         result = yield

--- a/lib/airbrake/rails/action_controller_notify_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_notify_subscriber.rb
@@ -10,6 +10,8 @@ module Airbrake
     # @since v8.0.0
     class ActionControllerNotifySubscriber
       def call(*args)
+        return unless Airbrake::Config.instance.performance_stats
+
         routes = Airbrake::Rack::RequestStore[:routes]
         return if !routes || routes.none?
 

--- a/lib/airbrake/rails/action_controller_performance_breakdown_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_performance_breakdown_subscriber.rb
@@ -7,6 +7,8 @@ module Airbrake
     # @since v8.3.0
     class ActionControllerPerformanceBreakdownSubscriber
       def call(*args)
+        return unless Airbrake::Config.instance.performance_stats
+
         routes = Airbrake::Rack::RequestStore[:routes]
         return if !routes || routes.none?
 

--- a/lib/airbrake/rails/action_controller_route_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_route_subscriber.rb
@@ -11,6 +11,8 @@ module Airbrake
     # @since v8.0.0
     class ActionControllerRouteSubscriber
       def call(*args)
+        return unless Airbrake::Config.instance.performance_stats
+
         # We don't track routeless events.
         return unless (routes = Airbrake::Rack::RequestStore[:routes])
 

--- a/lib/airbrake/rails/active_record_subscriber.rb
+++ b/lib/airbrake/rails/active_record_subscriber.rb
@@ -10,6 +10,8 @@ module Airbrake
     # @since v8.1.0
     class ActiveRecordSubscriber
       def call(*args)
+        return unless Airbrake::Config.instance.query_stats
+
         routes = Airbrake::Rack::RequestStore[:routes]
         return if !routes || routes.none?
 

--- a/lib/airbrake/rails/excon_subscriber.rb
+++ b/lib/airbrake/rails/excon_subscriber.rb
@@ -8,6 +8,8 @@ module Airbrake
     # @since v9.2.0
     class Excon
       def call(*args)
+        return unless Airbrake::Config.instance.performance_stats
+
         routes = Airbrake::Rack::RequestStore[:routes]
         return if !routes || routes.none?
 

--- a/spec/integration/rails/rake_spec.rb
+++ b/spec/integration/rails/rake_spec.rb
@@ -3,7 +3,10 @@
 RSpec.describe "Rake integration" do
   let(:task) { Rake::Task['bingo:bango'] }
 
-  before { Rails.application.load_tasks }
+  before do
+    Rails.application.load_tasks
+    allow(Airbrake).to receive(:notify_sync)
+  end
 
   after do
     expect { task.invoke }.to raise_error(AirbrakeTestError)

--- a/spec/unit/rack/rack_spec.rb
+++ b/spec/unit/rack/rack_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Airbrake::Rack do
   after { Airbrake::Rack::RequestStore.clear }
 
-  describe ".timing" do
+  describe ".capture_timing" do
     let(:routes) { Airbrake::Rack::RequestStore[:routes] }
 
     context "when request store doesn't have any routes" do

--- a/spec/unit/rails/action_controller_route_subscriber_spec.rb
+++ b/spec/unit/rails/action_controller_route_subscriber_spec.rb
@@ -23,6 +23,18 @@ RSpec.describe Airbrake::Rails::ActionControllerRouteSubscriber do
       allow(Airbrake::Rails::Event).to receive(:new).and_return(event)
     end
 
+    context "when the Airbrake config disables performance stats" do
+      before do
+        allow(Airbrake::Config.instance)
+          .to receive(:performance_stats).and_return(false)
+      end
+
+      it "doesn't store any routes in the request store under :routes" do
+        subject.call(event_params)
+        expect(Airbrake::Rack::RequestStore[:routes]).to be_nil
+      end
+    end
+
     context "when request store has the :routes key" do
       before do
         allow(event).to receive(:method).and_return('HEAD')


### PR DESCRIPTION
Previously, we were installing performance hooks based on the value from the
Airbrake config. If `performance_stats` is `true`, then the hooks will be
installed during initialization, if it's `false`, the hooks would never be
installed.

Now, `airbrake-ruby` supports remote configuration, which can change the value
of `performance_stats` at runtime. In order to support this feature we must
change the approach and install the hooks in either case. The
`performance_stats` check is now performed inside the hooks, since this will
allow us to enable/disable the feature during the runtime.

A pleasant effect of this change is that we no longer need to read the config
inside our railtie. This fixes #1105, which reports an issue with our existing
code where we hook into `after: :load_config_initializers`. With this new
approach we don't need to hook into that event anymore because we don't care at
what stage the `config/initializers/airbrake.rb` is loaded.