### PR TITLE
Fix crash when airbrake:deploy used with RAILS_LOG_TO_STDOUT

### DIFF
--- a/lib/airbrake/rails.rb
+++ b/lib/airbrake/rails.rb
@@ -6,16 +6,14 @@ module Airbrake
   # Rails namespace holds all Rails-related functionality.
   module Rails
     def self.logger
-      if ENV['RAILS_LOG_TO_STDOUT'].present?
-        Logger.new(STDOUT, level: ::Rails.logger.level)
-      else
-        Logger.new(
-          ::Rails.root.join('log', 'airbrake.log'),
+      # Rails.logger is not set in some Rake tasks such as
+      # 'airbrake:deploy'. In this case we use a sensible fallback.
+      level = (::Rails.logger ? ::Rails.logger.level : Logger::ERROR)
 
-          # Rails.logger is not set in some Rake tasks such as
-          # 'airbrake:deploy'. In this case we use a sensible fallback.
-          level: (::Rails.logger ? ::Rails.logger.level : Logger::ERROR),
-        )
+      if ENV['RAILS_LOG_TO_STDOUT'].present?
+        Logger.new(STDOUT, level: level)
+      else
+        Logger.new(::Rails.root.join('log', 'airbrake.log'), level: level)
       end
     end
   end


### PR DESCRIPTION
rake airbrake:deploy crashes when environment variable RAILS_LOG_TO_STDOUT is present:

```
NoMethodError: undefined method `level' for nil:NilClass
	/usr/local/bundle/ruby/2.5.0/gems/airbrake-11.0.0/lib/airbrake/rails.rb:10:in `logger'
	/service/config/initializers/airbrake.rb:30:in `block in <top (required)>'
	/usr/local/bundle/ruby/2.5.0/gems/airbrake-ruby-5.0.2/lib/airbrake-ruby.rb:122:in `configure'
	/service/config/initializers/airbrake.rb:12:in `<top (required)>'
```

This problem has already been fixed before but only for the case when RAILS_LOG_TO_STDOUT is not present.

My fix moves the earlier fix for level: out of its else-branch. It's now effective independend of RAILS_LOG_TO_STDOUT. A ::Rails.logger is nil in rake airbrake::deploy and this doesn't dependend on RAILS_LOG_TO_STDOUT.

Please pull my fix. Cheers!

