### PR TITLE
Appraisals: bump sqlite3 to `~> 1.4`

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -6,7 +6,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7.0') && RUBY_ENGINE != 
     gem 'warden', '~> 1.2.3'
 
     gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.18', platforms: :jruby
-    gem 'sqlite3', '~> 1.3.11', platforms: %i[mri rbx]
+    gem 'sqlite3', '~> 1.4', platforms: %i[mri rbx]
 
     gem 'resque', '~> 1.25.2'
     gem 'resque_spec', github: 'airbrake/resque_spec'
@@ -23,7 +23,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7.0') && RUBY_ENGINE != 
     gem 'warden', '~> 1.2.3'
 
     gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.18', platforms: :jruby
-    gem 'sqlite3', '~> 1.3.11', platforms: %i[mri rbx]
+    gem 'sqlite3', '~> 1.4', platforms: %i[mri rbx]
 
     gem 'resque', '~> 1.25.2'
     gem 'resque_spec', github: 'airbrake/resque_spec'
@@ -41,7 +41,7 @@ appraise 'rails-5.0' do
   gem 'warden', '~> 1.2.3'
 
   gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.18', platforms: :jruby
-  gem 'sqlite3', '~> 1.3.11', platforms: %i[mri rbx]
+  gem 'sqlite3', '~> 1.4', platforms: %i[mri rbx]
 
   gem 'resque', '~> 1.25.2'
   gem 'resque_spec', github: 'airbrake/resque_spec'
@@ -57,7 +57,7 @@ appraise 'rails-5.1' do
   gem 'warden', '~> 1.2.6'
 
   gem 'activerecord-jdbcsqlite3-adapter', '~> 51.0', platforms: :jruby
-  gem 'sqlite3', '~> 1.3.11', platforms: %i[mri rbx]
+  gem 'sqlite3', '~> 1.4', platforms: %i[mri rbx]
 
   gem 'resque', '~> 1.26'
   gem 'resque_spec', github: 'airbrake/resque_spec'
@@ -75,7 +75,7 @@ appraise 'rails-5.2' do
   gem 'rack', '~> 2.0'
 
   gem 'activerecord-jdbcsqlite3-adapter', '~> 52.0', platforms: :jruby
-  gem 'sqlite3', '~> 1.3.11', platforms: %i[mri rbx]
+  gem 'sqlite3', '~> 1.4', platforms: %i[mri rbx]
 
   gem 'resque', '~> 1.26'
   gem 'resque_spec', github: 'airbrake/resque_spec'

--- a/Appraisals
+++ b/Appraisals
@@ -6,7 +6,6 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7.0') && RUBY_ENGINE != 
     gem 'warden', '~> 1.2.3'
 
     gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.18', platforms: :jruby
-    gem 'sqlite3', '~> 1.4', platforms: %i[mri rbx]
 
     gem 'resque', '~> 1.25.2'
     gem 'resque_spec', github: 'airbrake/resque_spec'
@@ -41,7 +40,6 @@ appraise 'rails-5.0' do
   gem 'warden', '~> 1.2.3'
 
   gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.18', platforms: :jruby
-  gem 'sqlite3', '~> 1.4', platforms: %i[mri rbx]
 
   gem 'resque', '~> 1.25.2'
   gem 'resque_spec', github: 'airbrake/resque_spec'
@@ -57,7 +55,6 @@ appraise 'rails-5.1' do
   gem 'warden', '~> 1.2.6'
 
   gem 'activerecord-jdbcsqlite3-adapter', '~> 51.0', platforms: :jruby
-  gem 'sqlite3', '~> 1.4', platforms: %i[mri rbx]
 
   gem 'resque', '~> 1.26'
   gem 'resque_spec', github: 'airbrake/resque_spec'
@@ -75,7 +72,6 @@ appraise 'rails-5.2' do
   gem 'rack', '~> 2.0'
 
   gem 'activerecord-jdbcsqlite3-adapter', '~> 52.0', platforms: :jruby
-  gem 'sqlite3', '~> 1.4', platforms: %i[mri rbx]
 
   gem 'resque', '~> 1.26'
   gem 'resque_spec', github: 'airbrake/resque_spec'
@@ -94,7 +90,6 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5')
     gem 'rack', '~> 2.0'
 
     gem 'activerecord-jdbcsqlite3-adapter', '~> 60.1', platforms: :jruby
-    gem 'sqlite3', '~> 1.4', platforms: %i[mri rbx]
 
     gem 'resque', '~> 1.26'
     gem 'resque_spec', github: 'airbrake/resque_spec'

--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -49,6 +49,7 @@ DESC
   s.add_development_dependency 'http', '~> 2.2'
   s.add_development_dependency 'httpclient', '~> 2.8'
   s.add_development_dependency 'typhoeus', '~> 1.3'
+  s.add_development_dependency 'sqlite3', '~> 1.4' if RUBY_ENGINE == 'ruby'
 
   # Fixes build failure with public_suffix v3
   # https://circleci.com/gh/airbrake/airbrake-ruby/889

--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -6,7 +6,7 @@ gem "rubocop", "= 0.51", require: false
 gem "rails", "~> 4.0.13"
 gem "warden", "~> 1.2.3"
 gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.18", platforms: :jruby
-gem "sqlite3", "~> 1.3.11", platforms: [:mri, :rbx]
+gem "sqlite3", "~> 1.4", platforms: [:mri, :rbx]
 gem "resque", "~> 1.25.2"
 gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job_active_record", "~> 4.1.0"

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -6,7 +6,7 @@ gem "rubocop", "= 0.55", require: false
 gem "rails", "~> 4.1.16"
 gem "warden", "~> 1.2.3"
 gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.18", platforms: :jruby
-gem "sqlite3", "~> 1.3.11", platforms: [:mri, :rbx]
+gem "sqlite3", "~> 1.4", platforms: [:mri, :rbx]
 gem "resque", "~> 1.25.2"
 gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job_active_record", "~> 4.1.0"

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -6,7 +6,7 @@ gem "rubocop", "= 0.55", require: false
 gem "rails", "~> 4.2.10"
 gem "warden", "~> 1.2.3"
 gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.18", platforms: :jruby
-gem "sqlite3", "~> 1.3.11", platforms: [:mri, :rbx]
+gem "sqlite3", "~> 1.4", platforms: [:mri, :rbx]
 gem "resque", "~> 1.25.2"
 gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job_active_record", "~> 4.1.0"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -6,7 +6,7 @@ gem "rubocop", "= 0.55", require: false
 gem "rails", "~> 5.0.7"
 gem "warden", "~> 1.2.3"
 gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.18", platforms: :jruby
-gem "sqlite3", "~> 1.3.11", platforms: [:mri, :rbx]
+gem "sqlite3", "~> 1.4", platforms: [:mri, :rbx]
 gem "resque", "~> 1.25.2"
 gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job_active_record", "~> 4.1.0"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -6,7 +6,7 @@ gem "rubocop", "= 0.55", require: false
 gem "rails", "~> 5.1.4"
 gem "warden", "~> 1.2.6"
 gem "activerecord-jdbcsqlite3-adapter", "~> 51.0", platforms: :jruby
-gem "sqlite3", "~> 1.3.11", platforms: [:mri, :rbx]
+gem "sqlite3", "~> 1.4", platforms: [:mri, :rbx]
 gem "resque", "~> 1.26"
 gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job", github: "collectiveidea/delayed_job"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -7,7 +7,7 @@ gem "rails", "~> 5.2.0"
 gem "warden", "~> 1.2.6"
 gem "rack", "~> 2.0"
 gem "activerecord-jdbcsqlite3-adapter", "~> 52.0", platforms: :jruby
-gem "sqlite3", "~> 1.3.11", platforms: [:mri, :rbx]
+gem "sqlite3", "~> 1.4", platforms: [:mri, :rbx]
 gem "resque", "~> 1.26"
 gem "resque_spec", github: "airbrake/resque_spec"
 gem "delayed_job", github: "collectiveidea/delayed_job"


### PR DESCRIPTION
This will fix the following warning on Ruby 2.7:

> rb_tainted_str_new is deprecated and will be removed in Ruby 3.2