### PR TITLE
spec_helper: set remote_config_host to nil

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,7 @@ Airbrake.configure do |c|
   c.performance_stats = true
   c.performance_stats_flush_period = 1
   c.query_stats = true
+  c.remote_config_host = nil
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
This somehow fixes failing builds:
https://app.circleci.com/pipelines/github/airbrake/airbrake/127/workflows/d65e52ce-08da-4345-b6dc-ba568b8f85a7/jobs/9045

> Real HTTP connections are disabled. Unregistered request:
> GET https://v1-production-notifier-configs