### PR TITLE
gemspec: bump airbrake-ruby to `~> 5.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@ Airbrake Changelog
 
 ### master
 
-* Fixed `rake airbrake::deploy` crashing with `NoMethodError: undefined method
-  `level' for nil:NilClass` when the `RAILS_LOG_TO_STDOUT` environment variable
+* Fixed `rake airbrake::deploy` crashing with ``NoMethodError: undefined method
+  `level' for nil:NilClass`` when the `RAILS_LOG_TO_STDOUT` environment variable
   is set ([#1129](https://github.com/airbrake/airbrake/pull/1129))
+* Bumped `airbrake-ruby` requirement to `~> 5.1`
+  ([#1068](https://github.com/airbrake/airbrake/issues/1068))
+
 
 ### [v11.0.0][v11.0.0] (August 17, 2020)
 

--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -30,7 +30,7 @@ DESC
 
   s.required_ruby_version = '>= 2.3'
 
-  s.add_dependency 'airbrake-ruby', '~> 5.0'
+  s.add_dependency 'airbrake-ruby', '~> 5.1'
 
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rspec-wait', '~> 0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,7 @@ Airbrake.configure do |c|
   c.performance_stats = true
   c.performance_stats_flush_period = 1
   c.query_stats = true
-  c.remote_config_host = nil
+  c.environment = 'test'
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
With airbrake-ruby 5.1 we can now set `environment` to `test` in our test
suite. This will disable the notifier config feature, and thus the proper way to
turn it off.