### PR TITLE
rails/http: monkey-patch with prepend instead of method chaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Airbrake Changelog
 
 ### master
 
+* Fixed `HTTP::Client` performance breakdown when 3rd party code monkey-patches
+   `HTTP::Client#perform`
+   ([#1162](https://github.com/airbrake/airbrake/issues/1162))
+
+
 ### [v11.0.1][v11.0.1] (October 20, 2020)
 
 * Fixed `rake airbrake::deploy` crashing with ``NoMethodError: undefined method

--- a/lib/airbrake/rails/http.rb
+++ b/lib/airbrake/rails/http.rb
@@ -1,14 +1,18 @@
 # frozen_string_literal: true
 
-module HTTP
-  # Monkey-patch to measure request timing.
-  class Client
-    alias perform_without_airbrake perform
-
-    def perform(request, options)
-      Airbrake::Rack.capture_timing(:http) do
-        perform_without_airbrake(request, options)
+module Airbrake
+  module Rails
+    # Monkey-patch to measure request timing.
+    # @api private
+    # @since v11.0.2
+    module HTTP
+      def perform(request, options)
+        Airbrake::Rack.capture_timing(:http) do
+          super(request, options)
+        end
       end
     end
   end
 end
+
+HTTP::Client.prepend(Airbrake::Rails::HTTP)


### PR DESCRIPTION
Fixes #1161 (missing prepend instrumentation leads to stack level too deep
error)

Since we don't care about Ruby 1.9 support,  we can safely rely on `prepend` to
monkey-patch methods safely. This is more robust because nobody will overwrite
our implementation (unless they forget to call `super`) and we will also respect
other libraries that monkey-patch `HTTP::Client#perform`.