### PR TITLE
action_cable: monkey-patch with prepend instead of method chaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Airbrake Changelog
 * Fixed `Sneakers` integration when 3rd party code monkey-patches
    `Sneakers::Worker#process_work`
    ([#1164](https://github.com/airbrake/airbrake/issues/1164))
+* Fixed `ActionCable` integration when 3rd party code monkey-patches
+   `ActionCable::Channel::Base#perform_action`
+   ([#1165](https://github.com/airbrake/airbrake/issues/1165))
 
 ### [v11.0.2][v11.0.2] (May 12, 2021)
 


### PR DESCRIPTION
Since we don't care about Ruby 1.9 support, we can safely rely on `prepend` to
monkey-patch methods safely. This is more robust because nobody will overwrite
our implementation (unless they forget to call super) and we will also respect
other libraries that monkey-patch `ActionCable::Channel::Base#perform_action`.