### PR TITLE
resque: monkey-patch with prepend instead of method chaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Airbrake Changelog
 * Fixed `ActionCable` integration when 3rd party code monkey-patches
    `ActionCable::Channel::Base#perform_action`
    ([#1165](https://github.com/airbrake/airbrake/issues/1165))
+* Fixed `Resque` integration when 3rd party code monkey-patches
+   `Resque::Job#perform`
+   ([#1166](https://github.com/airbrake/airbrake/issues/1166))
 
 ### [v11.0.2][v11.0.2] (May 12, 2021)
 


### PR DESCRIPTION
Since we don't care about Ruby 1.9 support, we can safely rely on `prepend` to
monkey-patch methods safely. This is more robust because nobody will overwrite
our implementation (unless they forget to call super) and we will also respect
other libraries that monkey-patch `Resque::Job#perform`.