### PR TITLE
rake: monkey-patch with prepend instead of method chaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Airbrake Changelog
 * Fixed `Resque` integration when 3rd party code monkey-patches
    `Resque::Job#perform`
    ([#1166](https://github.com/airbrake/airbrake/issues/1166))
+* Fixed `Rake` integration when 3rd party code monkey-patches
+   `Rake::Task#execute`
+   ([#1167](https://github.com/airbrake/airbrake/issues/1167))
 
 ### [v11.0.2][v11.0.2] (May 12, 2021)
 

--- a/lib/airbrake/rake.rb
+++ b/lib/airbrake/rake.rb
@@ -5,61 +5,62 @@
 # See: https://goo.gl/ksn6PE
 Rake::TaskManager.record_task_metadata = true
 
-module Rake
-  # Redefine +Rake::Task#execute+, so it can report errors to Airbrake.
-  class Task
-    # Store the original method to use it later.
-    alias execute_without_airbrake execute
+module Airbrake
+  module Rake
+    # Redefine +Rake::Task#execute+, so it can report errors to Airbrake.
+    module Task
+      # A wrapper around the original +#execute+, that catches all errors and
+      # notifies Airbrake.
+      #
+      # rubocop:disable Lint/RescueException
+      def execute(args = nil)
+        super(args)
+      rescue Exception => ex
+        notify_airbrake(ex, args)
+        raise ex
+      end
+      # rubocop:enable Lint/RescueException
 
-    # A wrapper around the original +#execute+, that catches all errors and
-    # notifies Airbrake.
-    #
-    # rubocop:disable Lint/RescueException
-    def execute(args = nil)
-      execute_without_airbrake(args)
-    rescue Exception => ex
-      notify_airbrake(ex, args)
-      raise ex
-    end
-    # rubocop:enable Lint/RescueException
+      private
 
-    private
+      def notify_airbrake(exception, args)
+        notice = Airbrake.build_notice(exception)
+        notice[:context][:component] = 'rake'
+        notice[:context][:action] = name
+        notice[:params].merge!(
+          rake_task: task_info,
+          execute_args: args,
+          argv: ARGV.join(' '),
+        )
 
-    def notify_airbrake(exception, args)
-      notice = Airbrake.build_notice(exception)
-      notice[:context][:component] = 'rake'
-      notice[:context][:action] = name
-      notice[:params].merge!(
-        rake_task: task_info,
-        execute_args: args,
-        argv: ARGV.join(' '),
-      )
-
-      Airbrake.notify_sync(notice)
-    end
-
-    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize
-    def task_info
-      info = {}
-
-      info[:name] = name
-      info[:timestamp] = timestamp.to_s
-      info[:investigation] = investigation
-
-      info[:full_comment] = full_comment if full_comment
-      info[:arg_names] = arg_names if arg_names.any?
-      info[:arg_description] = arg_description if arg_description
-      info[:locations] = locations if locations.any?
-      info[:sources] = sources if sources.any?
-
-      if prerequisite_tasks.any?
-        info[:prerequisite_tasks] = prerequisite_tasks.map do |p|
-          p.__send__(:task_info)
-        end
+        Airbrake.notify_sync(notice)
       end
 
-      info
+      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize
+      def task_info
+        info = {}
+
+        info[:name] = name
+        info[:timestamp] = timestamp.to_s
+        info[:investigation] = investigation
+
+        info[:full_comment] = full_comment if full_comment
+        info[:arg_names] = arg_names if arg_names.any?
+        info[:arg_description] = arg_description if arg_description
+        info[:locations] = locations if locations.any?
+        info[:sources] = sources if sources.any?
+
+        if prerequisite_tasks.any?
+          info[:prerequisite_tasks] = prerequisite_tasks.map do |p|
+            p.__send__(:task_info)
+          end
+        end
+
+        info
+      end
+      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize
     end
-    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize
   end
 end
+
+Rake::Task.prepend(Airbrake::Rake::Task)


### PR DESCRIPTION
Since we don't care about Ruby 1.9 support, we can safely rely on `prepend` to
monkey-patch methods safely. This is more robust because nobody will overwrite
our implementation (unless they forget to call super) and we will also respect
other libraries that monkey-patch `Rake::Task#execute`.