### PR TITLE
generators: do not embed creds into the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,17 +94,21 @@ Configuration
 
 #### Integration
 
-To integrate Airbrake with your Rails application, you need to know
-your [project id and project key][project-idkey]. Invoke the following command
-and replace `PROJECT_ID` and `PROJECT_KEY` with your values:
+To integrate Airbrake with your Rails application, you need to know your
+[project id and project key][project-idkey]. Set `AIRBRAKE_PROJECT_ID` &
+`AIRBRAKE_PROJECT_KEY` environment variables with your project's values and
+generate the Airbrake config:
 
 ```bash
-rails g airbrake PROJECT_ID PROJECT_KEY
+export AIRBRAKE_PROJECT_ID=<PROJECT ID>
+export AIRBRAKE_PROJECT_KEY=<PROJECT KEY>
+
+rails g airbrake
 ```
 
-[Heroku add-on][heroku-addon] users can omit specifying the key and the id and
-invoke the command without arguments (Heroku add-on's environment variables will
-be used) ([Heroku add-on docs][heroku-docs]):
+[Heroku add-on][heroku-addon] users can omit specifying the key and the
+id. Heroku add-on's environment variables will be used ([Heroku add-on
+docs][heroku-docs]):
 
 ```bash
 rails g airbrake

--- a/lib/generators/airbrake_generator.rb
+++ b/lib/generators/airbrake_generator.rb
@@ -3,22 +3,19 @@
 # Creates the Airbrake initializer file for Rails apps.
 #
 # @example Invokation from terminal
-#   rails generate airbrake PROJECT_KEY PROJECT_ID [NAME]
+#   rails generate airbrake [NAME]
 #
 class AirbrakeGenerator < Rails::Generators::Base
   # Adds current directory to source paths, so we can find the template file.
   source_root File.expand_path(__dir__)
 
-  argument :project_id, required: false
-  argument :project_key, required: false
-
   # Makes the NAME option optional, which allows to subclass from Base, so we
   # can pass arguments to the ERB template.
   #
-  # @see http://asciicasts.com/episodes/218-making-generators-in-rails-3
+  # @see https://asciicasts.com/episodes/218-making-generators-in-rails-3.html
   argument :name, type: :string, default: 'application'
 
-  desc 'Configures the Airbrake notifier with your project id and project key'
+  desc 'Configures the Airbrake notifier'
   def generate_layout
     template 'airbrake_initializer.rb.erb', 'config/initializers/airbrake.rb'
   end

--- a/lib/generators/airbrake_initializer.rb.erb
+++ b/lib/generators/airbrake_initializer.rb.erb
@@ -1,80 +1,80 @@
 # frozen_string_literal: true
 
-# Airbrake is an online tool that provides robust exception tracking in your Rails
-# applications. In doing so, it allows you to easily review errors, tie an error
-# to an individual piece of code, and trace the cause back to recent
-# changes. Airbrake enables for easy categorization, searching, and prioritization
-# of exceptions so that when errors occur, your team can quickly determine the
-# root cause.
+# Airbrake is an online tool that provides robust exception tracking in your
+# Rails applications. In doing so, it allows you to easily review errors, tie an
+# error to an individual piece of code, and trace the cause back to recent
+# changes. Airbrake enables for easy categorization, searching, and
+# prioritization of exceptions so that when errors occur, your team can quickly
+# determine the root cause.
 #
 # Configuration details:
 # https://github.com/airbrake/airbrake-ruby#configuration
-Airbrake.configure do |c|
-  # You must set both project_id & project_key. To find your project_id and
-  # project_key navigate to your project's General Settings and copy the values
-  # from the right sidebar.
-  # https://github.com/airbrake/airbrake-ruby#project_id--project_key
-<% if project_id -%>
-  c.project_id = <%= project_id %>
-<% else -%>
-  c.project_id = ENV['AIRBRAKE_PROJECT_ID']
-<% end -%>
-<% if project_key -%>
-  c.project_key = '<%= project_key %>'
-<% else -%>
-  c.project_key = ENV['AIRBRAKE_API_KEY']
-<% end -%>
+if (project_id = ENV['AIRBRAKE_PROJECT_ID']) &&
+   project_key = (ENV['AIRBRAKE_PROJECT_KEY'] || ENV['AIRBRAKE_API_KEY'])
+  Airbrake.configure do |c|
+    # You must set both project_id & project_key. To find your project_id and
+    # project_key navigate to your project's General Settings and copy the
+    # values from the right sidebar.
+    # https://github.com/airbrake/airbrake-ruby#project_id--project_key
+    c.project_id = project_id
+    c.project_key = project_key
 
-  # Configures the root directory of your project. Expects a String or a
-  # Pathname, which represents the path to your project. Providing this option
-  # helps us to filter out repetitive data from backtrace frames and link to
-  # GitHub files from our dashboard.
-  # https://github.com/airbrake/airbrake-ruby#root_directory
-  c.root_directory = Rails.root
+    # Configures the root directory of your project. Expects a String or a
+    # Pathname, which represents the path to your project. Providing this option
+    # helps us to filter out repetitive data from backtrace frames and link to
+    # GitHub files from our dashboard.
+    # https://github.com/airbrake/airbrake-ruby#root_directory
+    c.root_directory = Rails.root
 
-  # By default, Airbrake Ruby outputs to STDOUT. In Rails apps it makes sense to
-  # use the Rails' logger.
-  # https://github.com/airbrake/airbrake-ruby#logger
-  c.logger = Airbrake::Rails.logger
+    # By default, Airbrake Ruby outputs to STDOUT. In Rails apps it makes sense
+    # to use the Rails' logger.
+    # https://github.com/airbrake/airbrake-ruby#logger
+    c.logger = Airbrake::Rails.logger
 
-  # Configures the environment the application is running in. Helps the Airbrake
-  # dashboard to distinguish between exceptions occurring in different
-  # environments.
-  # NOTE: This option must be set in order to make the 'ignore_environments'
-  # option work.
-  # https://github.com/airbrake/airbrake-ruby#environment
-  c.environment = Rails.env
+    # Configures the environment the application is running in. Helps the
+    # Airbrake dashboard to distinguish between exceptions occurring in
+    # different environments.
+    # NOTE: This option must be set in order to make the 'ignore_environments'
+    # option work.
+    # https://github.com/airbrake/airbrake-ruby#environment
+    c.environment = Rails.env
 
-  # Setting this option allows Airbrake to filter exceptions occurring in
-  # unwanted environments such as :test.
-  # NOTE: This option *does not* work if you don't set the 'environment' option.
-  # https://github.com/airbrake/airbrake-ruby#ignore_environments
-  c.ignore_environments = %w[test]
+    # Setting this option allows Airbrake to filter exceptions occurring in
+    # unwanted environments such as :test.  NOTE: This option *does not* work if
+    # you don't set the 'environment' option.
+    # https://github.com/airbrake/airbrake-ruby#ignore_environments
+    c.ignore_environments = %w[test]
 
-  # A list of parameters that should be filtered out of what is sent to
-  # Airbrake. By default, all "password" attributes will have their contents
-  # replaced.
-  # https://github.com/airbrake/airbrake-ruby#blocklist_keys
-  c.blocklist_keys = [/password/i, /authorization/i]
+    # A list of parameters that should be filtered out of what is sent to
+    # Airbrake. By default, all "password" attributes will have their contents
+    # replaced.
+    # https://github.com/airbrake/airbrake-ruby#blocklist_keys
+    c.blocklist_keys = [/password/i, /authorization/i]
 
-  # Alternatively, you can integrate with Rails' filter_parameters.
-  # Read more: https://goo.gl/gqQ1xS
-  # c.blocklist_keys = Rails.application.config.filter_parameters
+    # Alternatively, you can integrate with Rails' filter_parameters.
+    # Read more: https://goo.gl/gqQ1xS
+    # c.blocklist_keys = Rails.application.config.filter_parameters
+  end
+
+  # A filter that collects request body information. Enable it if you are sure you
+  # don't send sensitive information to Airbrake in your body (such as passwords).
+  # https://github.com/airbrake/airbrake#requestbodyfilter
+  # Airbrake.add_filter(Airbrake::Rack::RequestBodyFilter.new)
+
+  # Attaches thread & fiber local variables along with general thread information.
+  # Airbrake.add_filter(Airbrake::Filters::ThreadFilter.new)
+
+  # Attaches loaded dependencies to the notice object
+  # (under context/versions/dependencies).
+  # Airbrake.add_filter(Airbrake::Filters::DependencyFilter.new)
+
+  # If you want to convert your log messages to Airbrake errors, we offer an
+  # integration with the Logger class from stdlib.
+  # https://github.com/airbrake/airbrake#logger
+  # Rails.logger = Airbrake::AirbrakeLogger.new(Rails.logger)
+else
+  Rails.logger.warn(
+    "#{__FILE__}: Airbrake project id or project key is not set. " \
+    "Skipping Airbrake configuration"
+  )
 end
-
-# A filter that collects request body information. Enable it if you are sure you
-# don't send sensitive information to Airbrake in your body (such as passwords).
-# https://github.com/airbrake/airbrake#requestbodyfilter
-# Airbrake.add_filter(Airbrake::Rack::RequestBodyFilter.new)
-
-# Attaches thread & fiber local variables along with general thread information.
-# Airbrake.add_filter(Airbrake::Filters::ThreadFilter.new)
-
-# Attaches loaded dependencies to the notice object
-# (under context/versions/dependencies).
-# Airbrake.add_filter(Airbrake::Filters::DependencyFilter.new)
-
-# If you want to convert your log messages to Airbrake errors, we offer an
-# integration with the Logger class from stdlib.
-# https://github.com/airbrake/airbrake#logger
-# Rails.logger = Airbrake::AirbrakeLogger.new(Rails.logger)


### PR DESCRIPTION
This is bad engineering practice as it violates [the twelve-factor app
principles](https://12factor.net) (factor 3).