### PR TITLE
Dropped support for Ruby 2.3 & 2.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,43 +72,6 @@ jobs:
           name: Verify all @since tag versions start with letter 'v'
           command: |
             ! egrep -r "# @since [0-9]" lib
-  "ruby-2.3":
-    docker:
-      - image: circleci/ruby:2.3
-        auth:
-          username: $DOCKERHUB_USER
-          password: $DOCKERHUB_PASSWORD
-    working_directory: ~/airbrake
-    steps:
-      - <<: *repo_restore_cache
-      - <<: *bundle_install
-      - <<: *appraisal_install
-      - <<: *unit
-      - <<: *rails41
-      - <<: *rails42
-      - <<: *rails50
-      - <<: *rails51
-      - <<: *rails52
-      - <<: *sinatra
-      - <<: *rack
-  "ruby-2.4":
-    docker:
-      - image: circleci/ruby:2.4
-        auth:
-          username: $DOCKERHUB_USER
-          password: $DOCKERHUB_PASSWORD
-    working_directory: ~/airbrake
-    steps:
-      - <<: *repo_restore_cache
-      - <<: *bundle_install
-      - <<: *appraisal_install
-      - <<: *unit
-      - <<: *rails42
-      - <<: *rails50
-      - <<: *rails51
-      - <<: *rails52
-      - <<: *sinatra
-      - <<: *rack
   "ruby-2.5":
     docker:
       - image: circleci/ruby:2.5
@@ -187,12 +150,6 @@ workflows:
   build:
     jobs:
       - lint
-      - "ruby-2.3":
-          requires:
-            - lint
-      - "ruby-2.4":
-          requires:
-            - lint
       - "ruby-2.5":
           requires:
             - lint

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 # Explanations of all possible options:
 #   https://github.com/bbatsov/rubocop/blob/master/config/default.yml
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
   DisplayCopNames: true
   DisplayStyleGuide: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ Airbrake Changelog
 
 ### master
 
+Breaking changes:
+
+* Dropped support for Ruby 2.3
+  ([#1180](https://github.com/airbrake/airbrake/issues/1180))
+* Dropped support for Ruby 2.4
+  ([#1180](https://github.com/airbrake/airbrake/issues/1180))
+
 ### [v11.0.3][v11.0.3] (May 13, 2021)
 
 * Fixed `Sneakers` integration when 3rd party code monkey-patches

--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -28,7 +28,7 @@ DESC
   s.require_path = 'lib'
   s.files        = ['lib/airbrake.rb', *Dir.glob('lib/**/*')]
 
-  s.required_ruby_version = '>= 2.3'
+  s.required_ruby_version = '>= 2.5'
 
   s.add_dependency 'airbrake-ruby', '~> 5.1'
 

--- a/lib/airbrake/sneakers.rb
+++ b/lib/airbrake/sneakers.rb
@@ -48,24 +48,22 @@ module Airbrake
       define_method(
         ::Sneakers::Worker.method_defined?(:process_work) ? :process_work : :do_work,
       ) do |delivery_info, metadata, msg, handler|
-        begin
-          timing = Airbrake::Benchmark.measure do
-            super(delivery_info, metadata, msg, handler)
-          end
-        rescue Exception => exception # rubocop:disable Lint/RescueException
-          Airbrake.notify_queue(
-            queue: self.class.to_s,
-            error_count: 1,
-            timing: 0.01,
-          )
-          raise exception
-        else
-          Airbrake.notify_queue(
-            queue: self.class.to_s,
-            error_count: 0,
-            timing: timing,
-          )
+        timing = Airbrake::Benchmark.measure do
+          super(delivery_info, metadata, msg, handler)
         end
+      rescue Exception => exception # rubocop:disable Lint/RescueException
+        Airbrake.notify_queue(
+          queue: self.class.to_s,
+          error_count: 1,
+          timing: 0.01,
+        )
+        raise exception
+      else
+        Airbrake.notify_queue(
+          queue: self.class.to_s,
+          error_count: 0,
+          timing: timing,
+        )
       end
     end
   end

--- a/spec/support/matchers/a_notice_with.rb
+++ b/spec/support/matchers/a_notice_with.rb
@@ -5,28 +5,12 @@ RSpec::Matchers.define :a_notice_with do |access_keys, expected_val|
     payload = notice[access_keys.shift]
     break(false) unless payload
 
-    actual_val =
-      if payload.respond_to?(:dig)
-        payload.dig(*access_keys)
-      else
-        dig_pre_23(payload, *access_keys)
-      end
+    actual_val = payload.dig(*access_keys)
 
     if expected_val.is_a?(Regexp)
       actual_val =~ expected_val
     else
       actual_val == expected_val
     end
-  end
-
-  # TODO: Use the normal "dig" version once we support Ruby 2.3 and above.
-  def dig_pre_23(hash, *keys)
-    v = hash[keys.shift]
-    while keys.any?
-      return unless v.is_a?(Hash)
-
-      v = v[keys.shift]
-    end
-    v
   end
 end


### PR DESCRIPTION
Airbrake Ruby no longer supports these versions as of
https://github.com/airbrake/airbrake-ruby/pull/663.