### PR TITLE
spec/integration/rails: skip Typhoeus test on JRuby

### DIFF
--- a/spec/integration/rails/rails_spec.rb
+++ b/spec/integration/rails/rails_spec.rb
@@ -478,6 +478,13 @@ RSpec.describe "Rails integration specs" do
         stub_request(:get, 'http://example.com').to_return(body: '')
       end
 
+      before do
+        # On JRuby 9.2.19.0 this fails with a SIGSEGV in JVM:
+        # https://bit.ly/3Everoa
+        # This is somehow related to libcurl.so.
+        skip('SIGSEGV on JRuby 9.2.19.0') if Airbrake::JRUBY
+      end
+
       it "includes the http breakdown" do
         expect(Airbrake).to receive(:notify_performance_breakdown).with(
           hash_including(groups: { http: be > 0 }),


### PR DESCRIPTION
This spec segfaults on latest JRuby 9.2.19.0 in JVM.
https://app.circleci.com/pipelines/github/airbrake/airbrake/227/workflows/3db05cae-87d8-4599-9da2-a37c4c76bf4f/jobs/9670

During an extensive debugging session I haven't been able to identify the root
cause.

I found an identical report from 2012 but it had no resolution:
https://github.com/typhoeus/typhoeus/issues/202

I also found related links:
* https://github.com/jruby/jruby/issues/231
* https://github.com/jruby/jruby/issues/752