### PR TITLE
spec/apps: fix warning about redefined constants

### DIFF
--- a/spec/apps/rack/rack_app.rb
+++ b/spec/apps/rack/rack_app.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-DummyApp = Rack::Builder.new do
+RackApp = Rack::Builder.new do
   use Rack::ShowExceptions
   use Airbrake::Rack::Middleware
   use Warden::Manager

--- a/spec/integration/rack/rack_spec.rb
+++ b/spec/integration/rack/rack_spec.rb
@@ -3,7 +3,7 @@
 require 'integration/shared_examples/rack_examples'
 
 RSpec.describe "Rack integration specs" do
-  let(:app) { DummyApp }
+  let(:app) { RackApp }
 
   include_examples 'rack examples'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -97,7 +97,7 @@ if ENV['APPRAISAL_INITIALIZED']
     # Don't load the Rack app since we want to test Sinatra if it's loaded.
     raise LoadError if defined?(Sinatra)
 
-    require 'apps/rack/dummy_app'
+    require 'apps/rack/rack_app'
   rescue LoadError
     puts '** Skipped Rack specs'
   end


### PR DESCRIPTION
DummyApp is defined by both Rack and Rails tests. Let's not shadow constants.