### PR TITLE
gemspec: bump stale dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,7 +651,7 @@ Then, invoke it like shown in the example for Rails.
 Supported Rubies
 ----------------
 
-* CRuby >= 2.3.0
+* CRuby >= 2.5.0
 * JRuby >= 9k
 
 Contact

--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -39,12 +39,12 @@ DESC
   s.add_development_dependency 'rack', '~> 2'
   s.add_development_dependency 'webmock', '~> 3'
   s.add_development_dependency 'amq-protocol'
-  s.add_development_dependency 'rack-test', '= 0.6.3'
+  s.add_development_dependency 'rack-test', '~> 1.1'
   s.add_development_dependency 'redis', '= 4.1.4'
-  s.add_development_dependency 'sidekiq', '~> 5'
+  s.add_development_dependency 'sidekiq', '~> 6'
   s.add_development_dependency 'curb', '~> 0.9' if RUBY_ENGINE == 'ruby'
   s.add_development_dependency 'excon', '~> 0.64'
-  s.add_development_dependency 'http', '~> 2.2'
+  s.add_development_dependency 'http', '~> 5.0'
   s.add_development_dependency 'httpclient', '~> 2.8'
   s.add_development_dependency 'typhoeus', '~> 1.3'
 
@@ -52,6 +52,5 @@ DESC
   # https://circleci.com/gh/airbrake/airbrake-ruby/889
   s.add_development_dependency 'public_suffix', '~> 4.0', '< 5.0'
 
-  # redis-namespace > 1.6.0 wants Ruby >= 2.4.
-  s.add_development_dependency 'redis-namespace', '= 1.6.0'
+  s.add_development_dependency 'redis-namespace', '~> 1.8'
 end


### PR DESCRIPTION
These dependencies couldn't be bumped before because they dropped Ruby <2.5 support. Now that our requirement is Ruby 2.5+, we can bump them as well.