### PR TITLE
Fix rubocop warnings about missing `rubygems_mfa_required` and usage of OpenStruct

### DIFF
--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -29,6 +29,10 @@ DESC
 
   s.required_ruby_version = '>= 2.5'
 
+  s.metadata = {
+    'rubygems_mfa_required' => 'true',
+  }
+
   s.add_dependency 'airbrake-ruby', '~> 6.0'
 
   s.add_development_dependency 'rspec', '~> 3'

--- a/spec/integration/rails/rails_spec.rb
+++ b/spec/integration/rails/rails_spec.rb
@@ -64,11 +64,8 @@ RSpec.describe "Rails integration specs" do
 
   shared_examples "context payload content" do |route|
     let(:user) do
-      OpenStruct.new(
-        id: 1,
-        email: 'qa@example.com',
-        username: 'qa-dept',
-      )
+      stub_const('User', Struct.new(:id, :email, :username))
+      User.new(1, 'qa@example.com', 'qa-dept')
     end
 
     before do
@@ -223,11 +220,8 @@ RSpec.describe "Rails integration specs" do
   describe "user extraction" do
     context "when Warden is not available but 'current_user' is defined" do
       let(:user) do
-        OpenStruct.new(
-          id: 1,
-          email: 'qa@example.com',
-          username: 'qa-dept',
-        )
+        stub_const('User', Struct.new(:id, :email, :username))
+        User.new(1, 'qa@example.com', 'qa-dept')
       end
 
       before do
@@ -497,7 +491,8 @@ RSpec.describe "Rails integration specs" do
 
     context "when current user is logged in" do
       let(:user) do
-        OpenStruct.new(id: 1, email: 'qa@example.com', username: 'qa-dept')
+        stub_const('User', Struct.new(:id, :email, :username))
+        User.new(1, 'qa@example.com', 'qa-dept')
       end
 
       before do

--- a/spec/integration/shared_examples/rack_examples.rb
+++ b/spec/integration/shared_examples/rack_examples.rb
@@ -40,13 +40,8 @@ RSpec.shared_examples 'rack examples' do
 
   describe "user payload" do
     let(:user) do
-      OpenStruct.new(
-        id: 1,
-        email: 'qa@example.com',
-        username: 'qa-dept',
-        first_name: 'John',
-        last_name: 'Doe',
-      )
+      stub_const('User', Struct.new(:id, :email, :username, :first_name, :last_name))
+      User.new(1, 'qa@example.com', 'qa-dept', 'John', 'Doe')
     end
 
     before { login_as(user) }

--- a/spec/unit/rack/user_spec.rb
+++ b/spec/unit/rack/user_spec.rb
@@ -4,13 +4,8 @@ RSpec.describe Airbrake::Rack::User do
   let(:endpoint) { 'https://api.airbrake.io/api/v3/projects/113743/notices' }
 
   let(:user) do
-    OpenStruct.new(
-      id: 1,
-      email: 'qa@example.com',
-      username: 'qa-dept',
-      first_name: 'Bingo',
-      last_name: 'Bongo',
-    )
+    stub_const('User', Struct.new(:id, :email, :username, :first_name, :last_name))
+    User.new(1, 'qa@example.com', 'qa-dept', 'Bingo', 'Bongo')
   end
 
   def env_for(url, opts = {})
@@ -190,7 +185,7 @@ RSpec.describe Airbrake::Rack::User do
     end
 
     context "when Rack user doesn't contain any of the expect fields" do
-      let(:user_data) { described_class.new(OpenStruct.new).as_json }
+      let(:user_data) { described_class.new({}).as_json }
 
       it "is empty" do
         expect(user_data).to be_empty

--- a/spec/unit/rails/action_controller_route_subscriber_spec.rb
+++ b/spec/unit/rails/action_controller_route_subscriber_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ostruct'
 require 'airbrake/rails/action_controller_route_subscriber'
 
 RSpec.describe Airbrake::Rails::ActionControllerRouteSubscriber do


### PR DESCRIPTION
This should fix the build on `master`.