### PR TITLE
Drop support for Ruby 2.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.5, 2.6, 2.7, '3.0', jruby]
+        ruby: [2.6, 2.7, 3.0, jruby]
 
     runs-on: ${{ matrix.os }}
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 # Explanations of all possible options:
 #   https://github.com/bbatsov/rubocop/blob/master/config/default.yml
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   DisplayCopNames: true
   DisplayStyleGuide: true
   NewCops: enable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Airbrake Changelog
 Breaking changes:
 
 * Dropped support for Ruby 2.5
-  ([#1180](https://github.com/airbrake/airbrake/issues/1180))
+  ([#1208](https://github.com/airbrake/airbrake/issues/1208))
 
 ### [v12.0.0][v12.0.0] (September 22, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Airbrake Changelog
 
 ### master
 
+Breaking changes:
+
+* Dropped support for Ruby 2.5
+  ([#1180](https://github.com/airbrake/airbrake/issues/1180))
+
 ### [v12.0.0][v12.0.0] (September 22, 2021)
 
 Breaking changes:

--- a/README.md
+++ b/README.md
@@ -651,7 +651,7 @@ Then, invoke it like shown in the example for Rails.
 Supported Rubies
 ----------------
 
-* CRuby >= 2.5.0
+* CRuby >= 2.6.0
 * JRuby >= 9k
 
 Contact

--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -27,7 +27,7 @@ DESC
   s.require_path = 'lib'
   s.files        = ['lib/airbrake.rb', *Dir.glob('lib/**/*')]
 
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 2.6'
 
   s.metadata = {
     'rubygems_mfa_required' => 'true',

--- a/spec/integration/rails/rails_spec.rb
+++ b/spec/integration/rails/rails_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "Rails integration specs" do
     end
 
     it "includes params" do
-      action = route[1..-1]
+      action = route[1..]
       body = /"context":{.*"params":{.*"controller":"dummy","action":"#{action}".*}/
       expect(a_request(:post, endpoint).with(body: body)).to have_been_made
     end


### PR DESCRIPTION
Some of our test dependencies start requiring Ruby 2.6+.
Ruby 2.5 was EOL on 31 Mar 2021, so it should be safe to move on.