### PR TITLE
rails/app: check for `Nodes::Star` instead of using `glob?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Breaking changes:
 * Dropped support for Ruby 2.5
   ([#1208](https://github.com/airbrake/airbrake/issues/1208))
 
+Bug fixes:
+
+* Fixed APM not working on Rails 7 due to ``NoMethodError (undefined method
+  `glob?' for nil:NilClass)``
+  ([#1211](https://github.com/airbrake/airbrake/issues/1211))
+
 ### [v12.0.0][v12.0.0] (September 22, 2021)
 
 Breaking changes:

--- a/lib/airbrake/rails/app.rb
+++ b/lib/airbrake/rails/app.rb
@@ -40,12 +40,12 @@ module Airbrake
             # Skip "catch-all" routes such as:
             #   get '*path => 'pages#about'
             #
-            # @todo The `glob?` method was added in Rails v4.2.0.beta1. We
-            # should remove the `respond_to?` check once we drop old Rails
-            # versions support.
+            # Ideally, we should be using `route.glob?` but in Rails 7+ this
+            # call would fail with a `NoMethodError`. This is because in
+            # Rails 7+ the AST for the route is not kept in memory anymore.
             #
-            # https://github.com/rails/rails/commit/5460591f0226a9d248b7b4f89186bd5553e7768f
-            next if route.respond_to?(:glob?) && route.glob?
+            # See: https://github.com/rails/rails/pull/43006#discussion_r783895766
+            next if route.path.spec.any?(ActionDispatch::Journey::Nodes::Star)
 
             path =
               if engine == ::Rails.application


### PR DESCRIPTION
Fixes https://github.com/airbrake/airbrake/issues/1177
(airbrake gem don't work with 7.0.0.alpha2 release)

Alternative to https://github.com/airbrake/airbrake/pull/1206

`glob?` on Rails 7+ raises error because Rails 7+ doesn't keep the route AST in
memory anymore. A Rails contributor who worked on the related code
[suggested][1] to use `Nodes::Star` instead, since that used to be the previous
implementation of the `glob?` method.

[1]: https://github.com/rails/rails/pull/43006#discussion_r783840849