### PR TITLE
action_controller_notify_subscriber: use seconds as time on Rails 7+

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,9 @@ Style/FrozenStringLiteralComment:
 Metrics/BlockLength:
   CountComments: false
   Max: 25
+  IgnoredMethods:
+    - describe
+    - context
   Exclude:
     - 'Rakefile'
     - '**/*.rake'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Changelog
 
 ### master
 
+* Fixed support of APM on Rails 7+, where the reported time of a route was
+  malformed, resulting in the complete rejection of the route stats by the
+  backend ([#1223](https://github.com/airbrake/airbrake/issues/1223))
+
 ### [v13.0.0][v13.0.0] (January 18, 2022)
 
 Breaking changes:

--- a/lib/airbrake/rails/action_controller_notify_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_notify_subscriber.rb
@@ -9,6 +9,10 @@ module Airbrake
     #
     # @since v8.0.0
     class ActionControllerNotifySubscriber
+      def initialize(rails_vsn)
+        @rails_7_or_above = rails_vsn.to_i >= 7
+      end
+
       def call(*args)
         return unless Airbrake::Config.instance.performance_stats
 
@@ -23,7 +27,16 @@ module Airbrake
             route: route,
             status_code: event.status_code,
             timing: event.duration,
-            time: event.time,
+
+            # On Rails 7+ `ActiveSupport::Notifications::Event#time` returns an
+            # instance of Float. It represents monotonic time in milliseconds.
+            # Airbrake Ruby expects that the provided time is in seconds. Hence,
+            # we need to convert it from milliseconds to seconds. In the
+            # versions below Rails 7, time is an instance of Time.
+            #
+            # Relevant commit:
+            # https://github.com/rails/rails/commit/81d0dc90becfe0b8e7f7f26beb66c25d84b8ec7f
+            time: @rails_7_or_above ? event.time / 1000 : event.time,
           )
         end
       end

--- a/lib/airbrake/rails/railtie.rb
+++ b/lib/airbrake/rails/railtie.rb
@@ -64,7 +64,7 @@ module Airbrake
           require 'airbrake/rails/action_controller_notify_subscriber'
           ActiveSupport::Notifications.subscribe(
             'process_action.action_controller',
-            Airbrake::Rails::ActionControllerNotifySubscriber.new,
+            Airbrake::Rails::ActionControllerNotifySubscriber.new(::Rails.version),
           )
 
           # Send performance breakdown: where a request spends its time.

--- a/spec/unit/rails/action_controller_notify_subscriber_spec.rb
+++ b/spec/unit/rails/action_controller_notify_subscriber_spec.rb
@@ -10,12 +10,13 @@ RSpec.describe Airbrake::Rails::ActionControllerNotifySubscriber do
 
     before do
       allow(Airbrake::Rails::Event).to receive(:new).and_return(event)
+      allow(Airbrake).to receive(:notify_request)
     end
 
     context "when there are no routes in the request store" do
       it "doesn't notify requests" do
-        expect(Airbrake).not_to receive(:notify_request)
         subject.call([])
+        expect(Airbrake).not_to have_received(:notify_request)
       end
     end
 
@@ -38,8 +39,8 @@ RSpec.describe Airbrake::Rails::ActionControllerNotifySubscriber do
         end
 
         it "doesn't notify requests" do
-          expect(Airbrake).not_to receive(:notify_request)
           subject.call([])
+          expect(Airbrake).not_to have_received(:notify_request)
         end
       end
 
@@ -47,22 +48,27 @@ RSpec.describe Airbrake::Rails::ActionControllerNotifySubscriber do
         before do
           allow(Airbrake::Config.instance)
             .to receive(:performance_stats).and_return(true)
+
+          allow(event).to receive(:method).and_return('GET')
+          allow(event).to receive(:status_code).and_return(200)
+          allow(event).to receive(:time).and_return(Time.now)
+          allow(event).to receive(:duration).and_return(1.234)
         end
 
         it "sends request info to Airbrake" do
-          expect(Airbrake).to receive(:notify_request).with(
+          subject.call([])
+
+          expect(Airbrake).to have_received(:notify_request).with(
             hash_including(
               method: 'GET',
               route: '/test-route',
               status_code: 200,
             ),
           )
-          expect(event).to receive(:method).and_return('GET')
-          expect(event).to receive(:status_code).and_return(200)
-          expect(event).to receive(:time).and_return(Time.now)
-          expect(event).to receive(:duration).and_return(1.234)
-
-          subject.call([])
+          expect(event).to have_received(:method)
+          expect(event).to have_received(:status_code)
+          expect(event).to have_received(:time)
+          expect(event).to have_received(:duration)
         end
       end
     end


### PR DESCRIPTION
Fixes bugged route stat reporting on Rails 7+ due to the fact that `@event.time`
returns milliseconds (but we want seconds). Therefore the time that we pass is
ahead by centuries, and our backend rejects such routes.