### PR TITLE
rails/railtie: read adapter info without requiring an active DB conn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Airbrake Changelog
 * Fixed support of APM on Rails 7+, where the reported time of a route was
   malformed, resulting in the complete rejection of the route stats by the
   backend ([#1223](https://github.com/airbrake/airbrake/issues/1223))
+* Fixed bug where Rails 6+ apps that don't require ActiveRecord crash when
+  Airbrake is installed
+  ([#1224](https://github.com/airbrake/airbrake/pull/1224))
 
 ### [v13.0.0][v13.0.0] (January 18, 2022)
 


### PR DESCRIPTION
Fixes https://github.com/airbrake/airbrake/issues/1222
(Airbrake Gem Attempts to Connect to Database in Databaseless App in Rails 6)

Good article:
https://www.bigbinary.com/blog/rails-6-changed-activerecord-base-configurations-result-to-an-object

We also add a guard that makes sure there's an ActiveRecord configuration
present (it can be that ActiveRecord is required but not configured; why? I have
no idea but it did happen to our customer and he's got no clue either).