### PR TITLE
rails/event: convert milliseconds into seconds for #time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Airbrake Changelog
 
 ### master
 
+* Fixed support of APM on Rails 7+, where the reported time of a performance
+  breakdowns and queries malformed, resulting in the complete rejection of the
+  performance breakdowns or queries by the backend. This improves on the fix
+  introduced in v13.0.1
+  ([#1227](https://github.com/airbrake/airbrake/issues/1227))
+
 ### [v13.0.1][v13.0.1] (May 13, 2022)
 
 * Fixed support of APM on Rails 7+, where the reported time of a route was

--- a/lib/airbrake/rails/action_controller_notify_subscriber.rb
+++ b/lib/airbrake/rails/action_controller_notify_subscriber.rb
@@ -9,10 +9,6 @@ module Airbrake
     #
     # @since v8.0.0
     class ActionControllerNotifySubscriber
-      def initialize(rails_vsn)
-        @rails_7_or_above = rails_vsn.to_i >= 7
-      end
-
       def call(*args)
         return unless Airbrake::Config.instance.performance_stats
 
@@ -27,16 +23,7 @@ module Airbrake
             route: route,
             status_code: event.status_code,
             timing: event.duration,
-
-            # On Rails 7+ `ActiveSupport::Notifications::Event#time` returns an
-            # instance of Float. It represents monotonic time in milliseconds.
-            # Airbrake Ruby expects that the provided time is in seconds. Hence,
-            # we need to convert it from milliseconds to seconds. In the
-            # versions below Rails 7, time is an instance of Time.
-            #
-            # Relevant commit:
-            # https://github.com/rails/rails/commit/81d0dc90becfe0b8e7f7f26beb66c25d84b8ec7f
-            time: @rails_7_or_above ? event.time / 1000 : event.time,
+            time: event.time,
           )
         end
       end

--- a/lib/airbrake/rails/railties/action_controller_tie.rb
+++ b/lib/airbrake/rails/railties/action_controller_tie.rb
@@ -15,9 +15,7 @@ module Airbrake
       class ActionControllerTie
         def initialize
           @route_subscriber = Airbrake::Rails::ActionControllerRouteSubscriber.new
-          @notify_subscriber = Airbrake::Rails::ActionControllerNotifySubscriber.new(
-            ::Rails.version,
-          )
+          @notify_subscriber = Airbrake::Rails::ActionControllerNotifySubscriber.new
           @performance_breakdown_subscriber =
             Airbrake::Rails::ActionControllerPerformanceBreakdownSubscriber.new
         end


### PR DESCRIPTION
Improves on 852ffd6219e3a6c3dba642c23fa8995279c06975.

While 852ffd6219e3a6c3dba642c23fa8995279c06975 was the correct fix, it was fixed
at the wrong place. Route stat reporting worked but other APM parts still
suffered from the same bug. I simply didn't notice that. I also wanted to make
the change testable.

The correct place to fix the bug is the Event class. The downside is that we
cannot write unit tests for it.