### PR TITLE
gemspec: stop depending public_suffix

### DIFF
--- a/airbrake.gemspec
+++ b/airbrake.gemspec
@@ -51,10 +51,5 @@ DESC
   s.add_development_dependency 'http', '~> 5.0'
   s.add_development_dependency 'httpclient', '~> 2.8'
   s.add_development_dependency 'typhoeus', '~> 1.3'
-
-  # Fixes build failure with public_suffix v3
-  # https://circleci.com/gh/airbrake/airbrake-ruby/889
-  s.add_development_dependency 'public_suffix', '~> 4.0', '< 5.0'
-
   s.add_development_dependency 'redis-namespace', '~> 1.8'
 end


### PR DESCRIPTION
We no longer need to specify it explicitly.