### PR TITLE
Fix middleware load order for Rails 4.x without ActiveRecord

### DIFF
--- a/lib/airbrake/rails/railties/middleware_tie.rb
+++ b/lib/airbrake/rails/railties/middleware_tie.rb
@@ -25,7 +25,7 @@ module Airbrake
             return tie_rails_4_or_below_with_active_record
           end
 
-          tie_rails_4_or_below_with_active_record
+          tie_rails_4_or_below_without_active_record
         end
 
         private


### PR DESCRIPTION
This just seems like a typo to me.  Both branches call `tie_rails_4_or_below_with_active_record`

```
$ be rails c
/Users/nickd/.rvm/gems/ruby-2.7.6@benchprep/gems/activesupport-4.2.11.1/lib/active_support/core_ext/object/duplicable.rb:111: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
Traceback (most recent call last):
	24: from bin/rails:4:in `<main>'
	23: from bin/rails:4:in `require'
	22: from /Users/nickd/.rvm/gems/ruby-2.7.6@benchprep/gems/railties-4.2.11.1/lib/rails/commands.rb:17:in `<top (required)>'
	21: from /Users/nickd/.rvm/gems/ruby-2.7.6@benchprep/gems/railties-4.2.11.1/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
	20: from /Users/nickd/.rvm/gems/ruby-2.7.6@benchprep/gems/railties-4.2.11.1/lib/rails/commands/commands_tasks.rb:67:in `console'
	19: from /Users/nickd/.rvm/gems/ruby-2.7.6@benchprep/gems/railties-4.2.11.1/lib/rails/commands/commands_tasks.rb:142:in `require_application_and_environment!'
	18: from /Users/nickd/.rvm/gems/ruby-2.7.6@benchprep/gems/railties-4.2.11.1/lib/rails/application.rb:328:in `require_environment!'
	17: from /Users/nickd/projects/tenant-dashboard/config/environment.rb:5:in `<top (required)>'
	16: from /Users/nickd/.rvm/gems/ruby-2.7.6@benchprep/gems/railties-4.2.11.1/lib/rails/application.rb:352:in `initialize!'
	15: from /Users/nickd/.rvm/gems/ruby-2.7.6@benchprep/gems/railties-4.2.11.1/lib/rails/initializable.rb:54:in `run_initializers'
	14: from /Users/nickd/.rvm/rubies/ruby-2.7.6/lib/ruby/2.7.0/tsort.rb:205:in `tsort_each'
	13: from /Users/nickd/.rvm/rubies/ruby-2.7.6/lib/ruby/2.7.0/tsort.rb:226:in `tsort_each'
	12: from /Users/nickd/.rvm/rubies/ruby-2.7.6/lib/ruby/2.7.0/tsort.rb:347:in `each_strongly_connected_component'
	11: from /Users/nickd/.rvm/rubies/ruby-2.7.6/lib/ruby/2.7.0/tsort.rb:347:in `call'
	10: from /Users/nickd/.rvm/rubies/ruby-2.7.6/lib/ruby/2.7.0/tsort.rb:347:in `each'
	 9: from /Users/nickd/.rvm/rubies/ruby-2.7.6/lib/ruby/2.7.0/tsort.rb:349:in `block in each_strongly_connected_component'
	 8: from /Users/nickd/.rvm/rubies/ruby-2.7.6/lib/ruby/2.7.0/tsort.rb:431:in `each_strongly_connected_component_from'
	 7: from /Users/nickd/.rvm/rubies/ruby-2.7.6/lib/ruby/2.7.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	 6: from /Users/nickd/.rvm/rubies/ruby-2.7.6/lib/ruby/2.7.0/tsort.rb:228:in `block in tsort_each'
	 5: from /Users/nickd/.rvm/gems/ruby-2.7.6@benchprep/gems/railties-4.2.11.1/lib/rails/initializable.rb:55:in `block in run_initializers'
	 4: from /Users/nickd/.rvm/gems/ruby-2.7.6@benchprep/gems/railties-4.2.11.1/lib/rails/initializable.rb:30:in `run'
	 3: from /Users/nickd/.rvm/gems/ruby-2.7.6@benchprep/gems/railties-4.2.11.1/lib/rails/initializable.rb:30:in `instance_exec'
	 2: from /Users/nickd/.rvm/gems/ruby-2.7.6@benchprep/gems/airbrake-13.0.2/lib/airbrake/rails/railtie.rb:11:in `block in <class:Railtie>'
	 1: from /Users/nickd/.rvm/gems/ruby-2.7.6@benchprep/gems/airbrake-13.0.2/lib/airbrake/rails/railties/middleware_tie.rb:28:in `call'
/Users/nickd/.rvm/gems/ruby-2.7.6@benchprep/gems/airbrake-13.0.2/lib/airbrake/rails/railties/middleware_tie.rb:47:in `tie_rails_4_or_below_with_active_record': uninitialized constant ActiveRecord (NameError)
```