### PR TITLE
Separate var when overriding max retries before notify in Sidekiq jobs

### DIFF
--- a/lib/airbrake/sidekiq/retryable_jobs_filter.rb
+++ b/lib/airbrake/sidekiq/retryable_jobs_filter.rb
@@ -16,7 +16,7 @@ module Airbrake
       end
 
       def initialize(max_retries: nil)
-        @max_retries = max_retries
+        @retries_before_notify = max_retries
       end
 
       def call(notice)
@@ -36,8 +36,8 @@ module Airbrake
       end
 
       def max_attempts_for(job)
-        if @max_retries
-          @max_retries
+        if @retries_before_notify
+          @retries_before_notify
         elsif job['retry'].is_a?(Integer)
           job['retry']
         else


### PR DESCRIPTION
Previously, the @max_retries var was being used for both the global default retry limit as well as when a developer indicates they want error notifications before retries have been exhausted for a Sidekiq job. This results in an undesirable side effect for apps that:

* Do not pass max_retries as an arg to the RetryableJobsFilter initializer to indicate they want early notifications for errors when there are retries remaining

* Explicitly set a higher retry count than the global default for some jobs

Since Sidekiq may reuse worker threads, this will result in a situation where a thread may first execute a job with no retry limit explicitly set, which will load the global default into @max_retries. Later that same thread will be used to execute a job that has an explicit retry limit set, but RetryableJobsFilter will mistakenly use the previously set value for @max_retries instead of first checking for the presence of the explicity retry limit on the job hash itself.

Fix this behavior by using a separate variable (@retries_before_notify) when a developer wants to enable early notifications when there are still retries remaining so it doesn't confuse

Hopefully fixes https://github.com/airbrake/airbrake/issues/1239