### PR TITLE
Fix #1248: use root namespace for ActiveRecord reference

### DIFF
--- a/lib/airbrake/rails/railties/active_record_tie.rb
+++ b/lib/airbrake/rails/railties/active_record_tie.rb
@@ -30,7 +30,7 @@ module Airbrake
           return unless defined?(::Rails)
           return if Gem::Version.new(::Rails.version) > Gem::Version.new('4.2')
 
-          ActiveRecord::Base.include(Airbrake::Rails::ActiveRecord)
+          ::ActiveRecord::Base.include(Airbrake::Rails::ActiveRecord)
         end
 
         def tie_activerecord_apm


### PR DESCRIPTION
Fix for https://github.com/airbrake/airbrake/issues/1248
- use root namespace for ActiveRecord reference