### PR TITLE
Improve logic when Rails class/module is defined but Rails (rails gem) is not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Changelog
 
 ### master
 
+### [][] ()
+
+* Added Def class to improve on recognising Rails gem presence vs Rails class.
+
 ### [v13.0.3][v13.0.3] (September 20, 2022)
 
 * Fixed `tie_rails_4_or_below_with_active_record': uninitialized constant

--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -8,12 +8,13 @@ require 'English'
 require 'airbrake-ruby'
 
 require 'airbrake/version'
+require 'airbrake/def'
 
 # Automatically load needed files for the environment the library is running in.
 if defined?(Rack)
   require 'airbrake/rack'
 
-  require 'airbrake/rails' if defined?(Rails)
+  require 'airbrake/rails' if Airbrake::Def.rails?
 end
 
 require 'airbrake/rake' if defined?(Rake::Task)

--- a/lib/airbrake/def.rb
+++ b/lib/airbrake/def.rb
@@ -1,0 +1,7 @@
+module Airbrake
+  class Def
+    def self.rails?
+      defined?(Rails) && defined?(Rails.version)
+    end
+  end
+end

--- a/lib/airbrake/rails/backtrace_cleaner.rb
+++ b/lib/airbrake/rails/backtrace_cleaner.rb
@@ -14,7 +14,7 @@ module Airbrake
   end
 end
 
-if defined?(Rails)
+if Airbrake::Def.rails?
   # Silence own frames to let the cleaner proceed to the next line (and probably
   # find the correct call-site coming from the app code rather this library).
   Rails.backtrace_cleaner.add_silencer do |line|

--- a/lib/airbrake/rake/tasks.rb
+++ b/lib/airbrake/rake/tasks.rb
@@ -4,7 +4,7 @@ require 'airbrake-ruby'
 
 namespace :airbrake do
   desc 'Verify your gem installation by sending a test exception'
-  task test: (:environment if defined?(Rails)) do
+  task test: (:environment if Airbrake::Def.rails?) do
     raise Airbrake::Error, 'airbrake-ruby is not configured' unless Airbrake.configured?
 
     require 'pp'
@@ -38,7 +38,7 @@ namespace :airbrake do
 
   desc 'Notify Airbrake of a new deploy'
   task :deploy do
-    if defined?(Rails)
+    if Airbrake::Def.rails?
       initializer = Rails.root.join('config', 'initializers', 'airbrake.rb')
 
       # Avoid loading the environment to speed up the deploy task and try guess


### PR DESCRIPTION
This PR is a suggested solution to issue: https://github.com/airbrake/airbrake/issues/1255
where any definition of Rails module/class without actual use of framework causes issues with airbrake gem.