### PR TITLE
Release v13.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Airbrake Changelog
 
 ### master
 
+### [v13.0.4][v13.0.4] (November 27, 2023)
+
+* Add support for sidekiq 7 ([#1245](https://github.com/airbrake/airbrake/pull/1245))
+* Separate var when overriding max retries before notify in Sidekiq jobs ([#1244](https://github.com/airbrake/airbrake/pull/1244))
+
 ### [v13.0.3][v13.0.3] (September 20, 2022)
 
 * Fixed `tie_rails_4_or_below_with_active_record': uninitialized constant
@@ -1023,3 +1028,4 @@ Features:
 [v13.0.1]: https://github.com/airbrake/airbrake/releases/tag/v13.0.1
 [v13.0.2]: https://github.com/airbrake/airbrake/releases/tag/v13.0.2
 [v13.0.3]: https://github.com/airbrake/airbrake/releases/tag/v13.0.3
+[v13.0.4]: https://github.com/airbrake/airbrake/releases/tag/v13.0.4

--- a/lib/airbrake/version.rb
+++ b/lib/airbrake/version.rb
@@ -3,5 +3,5 @@
 # We use Semantic Versioning v2.0.0
 # More information: http://semver.org/
 module Airbrake
-  AIRBRAKE_VERSION = '13.0.3'
+  AIRBRAKE_VERSION = '13.0.4'
 end


### PR DESCRIPTION
* Add support for sidekiq 7 ([#1245](https://github.com/airbrake/airbrake/pull/1245))
* Separate var when overriding max retries before notify in Sidekiq jobs ([#1244](https://github.com/airbrake/airbrake/pull/1244))