### PR TITLE
Separate lint and test workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Update package list
+        run: sudo apt-get update
+
+      - name: Install cURL Headers
+        run: sudo apt-get install libcurl4 libcurl4-openssl-dev
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,6 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
-      - name: Rubocop lint
-        run: bundle exec rubocop
-
       - name: Install Bundler dependencies
         run: bundle install
 
@@ -62,3 +59,17 @@ jobs:
 
       - name: Test Rack
         run: bundle exec appraisal rack rake spec:integration:rack
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3
+          bundler-cache: true
+
+      - name: Rubocop lint
+        run: bundle exec rubocop


### PR DESCRIPTION
The Lint workflow does not need to be run on various versions of Ruby.
Numerous offences were detected but not fixed in this PR.

```
Inspecting 89 files
...C.....CC.........C.....C.........C.........W.C.C........C.........W................C..

...(truncated)

89 files inspected, 31 offenses detected, 11 offenses autocorrectable
```