### PR TITLE
Fix rubocop offenses

### DIFF
--- a/lib/airbrake/sidekiq/retryable_jobs_filter.rb
+++ b/lib/airbrake/sidekiq/retryable_jobs_filter.rb
@@ -6,8 +6,10 @@ module Airbrake
     # by Sidekiq
     # @since v7.3.0
     class RetryableJobsFilter
-      SIDEKIQ_GTE_5_0_0 = Gem::Version.new(::Sidekiq::VERSION) >= Gem::Version.new('5.0.0')
-      SIDEKIQ_GTE_7_0_0 = Gem::Version.new(::Sidekiq::VERSION) >= Gem::Version.new('7.0.0')
+      SIDEKIQ_GTE_5_0_0 =
+        Gem::Version.new(::Sidekiq::VERSION) >= Gem::Version.new('5.0.0')
+      SIDEKIQ_GTE_7_0_0 =
+        Gem::Version.new(::Sidekiq::VERSION) >= Gem::Version.new('7.0.0')
 
       if SIDEKIQ_GTE_5_0_0
         require 'sidekiq/job_retry'

--- a/spec/unit/sidekiq/retryable_jobs_filter_spec.rb
+++ b/spec/unit/sidekiq/retryable_jobs_filter_spec.rb
@@ -63,7 +63,8 @@ RSpec.describe Airbrake::Sidekiq::RetryableJobsFilter do
 
     context "when Sidekiq thread reused" do
       it "should not ignore a job with a higher than default retry limit" do
-        # This first job uses the global default retry limit and should memoize @max_retries
+        # This first job uses the global default retry limit
+        # and should memoize @max_retries
         notice1 = build_notice('retry' => true, 'retry_count' => 0)
         filter.call(notice1)
         expect(notice1).to be_ignored


### PR DESCRIPTION
```
Offenses:

lib/airbrake/sidekiq/retryable_jobs_filter.rb:9:91: C: Layout/LineLength: Line is too long. [91/90] (https://rubystyle.guide#max-line-length)
    SIDEKIQ_GTE_5_0_0 = Gem::Version.new(::Sidekiq::VERSION) >= Gem::Version.new('5.0.0')
lib/airbrake/sidekiq/retryable_jobs_filter.rb:10:91: C: Layout/LineLength: Line is too long. [91/90] (https://rubystyle.guide#max-line-length)
    SIDEKIQ_GTE_7_0_0 = Gem::Version.new(::Sidekiq::VERSION) >= Gem::Version.new('7.0.0')
spec/unit/sidekiq/retryable_jobs_filter_spec.rb:66:91: C: Layout/LineLength: Line is too long. [92/90] (https://rubystyle.guide#max-line-length)
    # This first job uses the global default retry limit and should memoize @max_retries
                                                                        ^^
```